### PR TITLE
Fixes content URL

### DIFF
--- a/content/code.mdx
+++ b/content/code.mdx
@@ -35,4 +35,4 @@ class HelloWorld {
 ```
 ````
 
-Visit the [Code Block page](content/components/code) for more detailed docs.
+Visit the [Code Block page](/content/components/code) for more detailed docs.


### PR DESCRIPTION
This PR fixes the content URL for the "Code Block page" on [this page](https://mintlify.com/docs/content/code).

|Screenshot|
|-|
|<img width="998" alt="Screenshot 2023-06-20 at 7 59 02 PM" src="https://github.com/mintlify/docs/assets/6391763/773f4635-973b-43a7-a9db-5b1bc831d26b">|