### PR TITLE
Update docs for what happens when port is in use

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -40,10 +40,10 @@ By default, Mintlify uses port 3000. You can customize the port Mintlify runs on
 mintlify dev --port 3333
 ```
 
-If you attempt to run Mintlify on a port that's already in use, you will see an error message:
+If you attempt to run Mintlify on a port that's already in use, it will offer an alternative port:
 
 ```md
-Error: listen EADDRINUSE: address already in use :::3000
+Port 3000 is already in use. Use port 3001 instead? [Y/n]
 ```
 
 ## Mintlify Versions


### PR DESCRIPTION
Presumably it used to show the error that was in the docs, but `mintlify dev` now offers to use an alternative port if the default is in use.