### PR TITLE
Versioning tabs

### DIFF
--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -43,6 +43,30 @@ In `mint.json`, simply add `version` to your anchor. Anchors without a version v
 
 You don't need to add `v1/` or `v2/` to the start of your URLs, but some customers do it to keep their doc files organized.
 
+### Tabs
+
+Similarly, you can version with tabs. In the `mint.json`, add `version` to the tab. Tabs without a version value are shown in every version. 
+
+```json
+  "tabs": [
+    {
+      "name": "API Reference V1",
+      "url": "v1/api-reference",
+      "version": "v1"
+    },
+    {
+      "name": "API Reference V2",
+      "url": "v2/api-reference",
+      "version": "v2"
+    },
+        {
+        "name": "Tabs Without a Version",
+        "url": "example-tab"
+    }
+  ],
+  ```
+
+
 ### Groups
 
 You can version specific groups. This is useful when a few pages changed but everything else stayed the same.

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -59,11 +59,11 @@ Similarly, you can version with tabs. In the `mint.json`, add `version` to the t
       "url": "v2/api-reference",
       "version": "v2"
     },
-        {
-        "name": "Tabs Without a Version",
-        "url": "example-tab"
+    {
+      "name": "Tabs Without a Version",
+      "url": "example-tab"
     }
-  ],
+  ]
   ```
 
 


### PR DESCRIPTION
This PR adds documentation on how to version with tabs. 
<img width="776" alt="CleanShot 2024-01-30 at 13 34 02@2x" src="https://github.com/mintlify/docs/assets/123998500/8a0e15bd-8a62-4946-a0ea-48b3f93dc4e5">
