### PR TITLE
Fix prop type

### DIFF
--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -120,7 +120,7 @@ To autoplay the video, use:
 
 ```html
 <video
-  autoplay
+  autoPlay
   muted
   loop
   playsInline

--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -123,7 +123,7 @@ To autoplay the video, use:
   autoplay
   muted
   loop
-  playsinline
+  playsInline
   className="w-full aspect-video"
   src="link-to-your-video.com"
 ></video>


### PR DESCRIPTION
When using `playsinline` and `autoplay` props, the following warning is returned:

```
Warning: Invalid DOM property `autoplay`. Did you mean `autoPlay`
Warning: Invalid DOM property `playsinline`. Did you mean `playsInline`
```

This PR replaces the faulty props with their correct counterparts.