### PR TITLE
chore: remove outdated troubleshooting steps

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -5,7 +5,7 @@ description: 'Preview changes locally to update your docs'
 
 <Info>
 
-**Prerequisite**: Please install Node.js (version 19.00.0 or higher) before proceeding.
+**Prerequisite**: Please install Node.js (version 19 or higher) before proceeding.
 
 </Info>
 
@@ -55,10 +55,9 @@ Please note that each CLI release is associated with a specific version of Mintl
   npm i -g mintlify@latest
   ```
 
-```bash yarn
-yarn global upgrade mintlify
-```
-
+  ```bash yarn
+  yarn global upgrade mintlify
+  ```
 </CodeGroup>
 
 ## Validating Links
@@ -87,8 +86,11 @@ We suggest using appropriate extensions on your IDE to recognize and format MDX.
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Issue: Mintlify is not loading">
-    Solution: Update to Node v19. Try `mintlify install` and attempt loading again.
+  <Accordion title='Error: Could not load the "sharp" module using the darwin-arm64 runtime'>
+    This may be due to an outdated version of node. Try the following:
+    1. Remove the currently-installed version of mintlify: `npm remove -g mintlify`
+    2. Upgrade to Node v19 or higher.
+    3. Reinstall mintlify: `npm install -g mintlify`
   </Accordion>
 
   <Accordion title="Issue: Encountering an unknown error">


### PR DESCRIPTION
`mintlify install` is no longer a command, so we shouldn't recommend it to users