### PR TITLE
Mention default version

### DIFF
--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -5,7 +5,7 @@ description: 'Build separate versions for your documentation'
 
 ## Setup
 
-Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array. The first version in the array is used as the default version.
+Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array. The first version from the array serves as the default version.
 
 <Tip>
   The versions dropdown will show your versions in the order you include them in

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -5,7 +5,7 @@ description: 'Build separate versions for your documentation'
 
 ## Setup
 
-Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array.
+Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array. The first version in the array is used as the default version.
 
 <Tip>
   The versions dropdown will show your versions in the order you include them in


### PR DESCRIPTION
was

> Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array.

now

> Add `"versions": ["v2", "v1"]` to your `mint.json` file where "v1" and "v2" are the names of your versions. You can put any number of versions in this array. The first version from the array serves as the default version.

as discussed in https://mintlify.slack.com/archives/C04HXQV9KQC/p1708034543656889?thread_ts=1708034236.336299&cid=C04HXQV9KQC