### PR TITLE
Fix invalid link for code group

### DIFF
--- a/content/components/code.mdx
+++ b/content/components/code.mdx
@@ -70,6 +70,6 @@ const hello = "world";
 
 Want to display multiple code examples in one code box? Check out the Code Group docs:
 
-<Card title="Code Group" href="/content/components/code-group" icon="columns-3">
+<Card title="Code Group" href="/content/components/code-groups" icon="columns-3">
   Read the reference for the Code Group component
 </Card>


### PR DESCRIPTION
The card to the code group page was missing a `s` so the card is falling back to homepage

here: https://mintlify.com/docs/content/components/code