### PR TITLE
feat(snippets): Add client-side content section

### DIFF
--- a/reusable-snippets.mdx
+++ b/reusable-snippets.mdx
@@ -25,7 +25,7 @@ should consider creating a custom snippet to keep your content in sync.
    locations. Optionally, you can add variables that can be filled in via props
    when you import the snippet.
 
-```mdx snippets/my-snippet.mdx
+```typescript snippets/my-snippet.mdx
 Hello world! This is my content I want to reuse across pages. My keyword of the
 day is {word}.
 ```
@@ -37,7 +37,7 @@ day is {word}.
 
 2. Import the snippet into your destination file.
 
-```mdx destination-file.mdx
+```typescript destination-file.mdx
 ---
 title: My title
 description: My Description
@@ -56,7 +56,7 @@ Lorem impsum dolor sit amet.
 
 1. Export a variable from your snippet file:
 
-```mdx snippets/path/to/custom-variables.mdx
+```typescript snippets/path/to/custom-variables.mdx
 export const myName = 'my name';
 
 export const myObject = { fruit: 'strawberries' };
@@ -64,7 +64,7 @@ export const myObject = { fruit: 'strawberries' };
 
 2. Import the snippet from your destination file and use the variable:
 
-```mdx destination-file.mdx
+```typescript destination-file.mdx
 ---
 title: My title
 description: My Description
@@ -80,7 +80,7 @@ Hello, my name is {myName} and I like {myObject.fruit}.
 1. Inside your snippet file, create a component that takes in props by exporting
    your component in the form of an arrow function.
 
-```mdx snippets/custom-component.mdx
+```typescript snippets/custom-component.mdx
 export const MyComponent = ({ title }) => (
   <div>
     <h1>{title}</h1>
@@ -96,7 +96,7 @@ export const MyComponent = ({ title }) => (
 
 2. Import the snippet into your destination file and pass in the props
 
-```mdx destination-file.mdx
+```typescript destination-file.mdx
 ---
 title: My title
 description: My Description
@@ -107,4 +107,28 @@ import { MyComponent } from '/snippets/custom-component.mdx';
 Lorem ipsum dolor sit amet.
 
 <MyComponent title={'Custom title'} />
+```
+
+### Client-Side Content
+
+By default, Mintlify employs server-side rendering, generating content
+at build time. For client-side content loading, ensure to verify the
+`document` object's availability before initiating the rendering process.
+
+```typescript snippets/client-component.mdx
+{/* `setTimeout` simulates a React.useEffect, which is called after the component is mounted. */}
+export const ClientComponent = () => {
+  if (typeof document === "undefined") {
+    return null;
+  } else {
+    setTimeout(() => {
+      const clientComponent = document.getElementById("client-component");
+      if (clientComponent) {
+        clientComponent.innerHTML = "Hello, client-side component!";
+      }
+    }, 1);
+
+    return <div id="client-component"></div>
+  }
+}
 ```


### PR DESCRIPTION
**What?**
* Add Client-side rendering content section to snippets docs
* Update snippets code blocks to use `typescript` to apply code highlighting

**Why?**
* It was not clear how to use client-side rendering within snippets. Client-side rendering is useful when it is necessary to directly interact with the DOM on the client side
* The snippets code blocks were not syntax highlighted

**Screenshots**
<img width="754" alt="image" src="https://github.com/mintlify/docs/assets/32132657/6da495f3-0111-4147-a35a-b419d5b63499">
