### PR TITLE
docs(settings): fix reference to subpath domain setting

### DIFF
--- a/settings/custom-domain.mdx
+++ b/settings/custom-domain.mdx
@@ -7,7 +7,7 @@ To set up your documentation on a custom subdomain, you'll need to set your desi
 
 <Info>
   Looking to set up a custom subdirectory domain like mintlify.com/docs? Find
-  instructions [here](/integrations/subdirectory/cloudflare).
+  instructions [here](/integrations/subpath/cloudflare).
 </Info>
 
 ## Dashboard Settings


### PR DESCRIPTION
Hi there :wave: 
I've been confused navigating the documentation to set subpath deployment, since clicking on the link suggested at the top of this [page](https://mintlify.com/docs/integrations/subpath/cloudflare) takes me somewhere that isn't relevant.

This PR simply fixes the reference on the custom domain page to set up subpath deployment.

Any feedback is welcome!