### PR TITLE
Fix broken link in image-embeds.mdx

### DIFF
--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -67,7 +67,7 @@ For more information, we recommend the following sections:
 <Card
   title="Frame Component Reference"
   icon="frame"
-  href="/content/components/frame"
+  href="/content/components/frames"
 >
   Read the reference for the Frame component
 </Card>


### PR DESCRIPTION
Link was broken, for a single 's'!