### PR TITLE
Fix typo and invalid code group link

### DIFF
--- a/content/components/sticky-examples.mdx
+++ b/content/components/sticky-examples.mdx
@@ -4,13 +4,13 @@ description: "Display code blocks at the top-right of the page on desktop device
 icon: "sidebar-flip"
 ---
 
-The `<RequestExample>` and `<ResponseExample>` to stick code blocks to the top-right of a page even as you scroll. The components work on all pages even if you don't use an API playground.
+The `<RequestExample>` and `<ResponseExample>` stick code blocks to the top-right of a page even as you scroll. The components work on all pages even if you don't use an API playground.
 
 `<RequestExample>` and `<ResponseExample>` show up like regular code blocks on mobile.
 
 ## Request Example
 
-The `<RequestExample>` component works similar to [CodeGroup](/content/code#code-group), but displays the request content on the right sidebar. Thus, you can put multiple code blocks inside `<RequestExample>`.
+The `<RequestExample>` component works similar to [CodeGroup](/content/components/code-groups), but displays the request content on the right sidebar. Thus, you can put multiple code blocks inside `<RequestExample>`.
 
 Please set a name on every code block you put inside RequestExample.
 


### PR DESCRIPTION
This PR fixes a broken link and a typo found in the Sidebar Code doc.