### PR TITLE
Fix Wrong Syntax and Add Warning about video attributes in camelCase

### DIFF
--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -130,8 +130,8 @@ To autoplay the video, use:
 ```
 
 <Warning>
-Since Mintlify needs to adhere to JSX syntax, these tags need to be in camelCase, which means double word attributes will need to 
-be in camelCase: autoPlay, playsInline.
+Since Mintlify needs to adhere to the JSX syntax, double word attributes will need to 
+be written in camelCase: autoPlay, playsInline.
 </Warning>
 
 ## iFrames

--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -130,7 +130,7 @@ To autoplay the video, use:
 ```
 
 <Warning>
-Since mintlify needs to adhere to JSX syntax, these tags need to be in camelCase, which means double word attributes will need to 
+Since Mintlify needs to adhere to JSX syntax, these tags need to be in camelCase, which means double word attributes will need to 
 be in camelCase: autoPlay, playsInline.
 </Warning>
 

--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -120,14 +120,19 @@ To autoplay the video, use:
 
 ```html
 <video
-  autoplay
+  autoPlay
   muted
   loop
-  playsinline
+  playsInline
   className="w-full aspect-video"
   src="link-to-your-video.com"
 ></video>
 ```
+
+<Warning>
+Since mintlify needs to adhere to JSX syntax, these tags need to be in camelCase, which means double word attributes will need to 
+be in camelCase: autoPlay, playsInline.
+</Warning>
 
 ## iFrames
 


### PR DESCRIPTION
As per a conversation with the team, mintlify needs to use camelCase syntax for HTML attributes, such as className, but also in cases like playsInline or autoPlay, for video tags.

Docs were showing the wrong syntax.

This PR fixes that and also adds a warning to create more awareness about this super subtle topic, which are usually the hardest to debug and find out.