### PR TITLE
Fix small typo in component-library.mdx

### DIFF
--- a/component-library.mdx
+++ b/component-library.mdx
@@ -3,7 +3,7 @@ title: 'Components'
 description: 'Enhance your docs with our pre-built components '
 ---
 
-Mintlify provides a library of build-in-components to make your docs beautiful without formatting things yourself. They can be added **directly within your files**. Some components are rendered from [Markdown syntax](https://www.markdownguide.org/basic-syntax/), while other components work the same way as [React components](https://reactjs.org/docs/components-and-props.html).
+Mintlify provides a library of built-in-components to make your docs beautiful without formatting things yourself. They can be added **directly within your files**. Some components are rendered from [Markdown syntax](https://www.markdownguide.org/basic-syntax/), while other components work the same way as [React components](https://reactjs.org/docs/components-and-props.html).
 
 <Info>
   Customize the style of components with [Tailwind


### PR DESCRIPTION
This tiny PR changes `build-in-component` to `built-in-component`