### PR TITLE
Add pnpm install and run scripts to Development doc

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -18,9 +18,13 @@ Follow these steps to install and run Mintlify on your operating system:
   npm i -g mintlify
   ```
 
-```bash yarn
-yarn global add mintlify
-```
+  ```bash yarn
+  yarn global add mintlify
+  ```
+
+  ```bash pnpm
+  pnpm add -g mintlify
+  ```
 
 </CodeGroup>
 
@@ -29,6 +33,27 @@ yarn global add mintlify
 ```bash
 mintlify dev
 ```
+
+Alternatively, if you do not want to install Mintlify globally you can use a run script available:
+
+<CodeGroup>
+  ```bash npm
+  npx mintlify dev
+  ```
+
+  ```bash yarn
+  yarn dlx mintlify dev
+  ```
+
+  ```bash pnpm
+  pnpm dlx mintlify dev
+  ```
+
+</CodeGroup>
+
+<Warning>
+  Yarn's "dlx" run script requires yarn version >2. See [here](https://yarnpkg.com/cli/dlx) for more information.
+</Warning>
 
 A local preview of your documentation will be available at `http://localhost:3000`.
 
@@ -55,9 +80,13 @@ Please note that each CLI release is associated with a specific version of Mintl
   npm i -g mintlify@latest
   ```
 
-```bash yarn
-yarn global upgrade mintlify
-```
+  ```bash yarn
+  yarn global upgrade mintlify
+  ```
+
+  ```bash pnpm
+  pnpm up --global
+  ```
 
 </CodeGroup>
 


### PR DESCRIPTION
Add pnpm install instructions to the development documentation. As well as alternative instructions for using run scripts instead of installing the Mintlify package globally.