### PR TITLE
Explain logo settings and mention custom scripts

### DIFF
--- a/integrations/custom/css.mdx
+++ b/integrations/custom/css.mdx
@@ -28,7 +28,7 @@ footer {
 
 Mintlify has a set of common identifiers to help you tag important elements of the UI. Some, but not all are listed in the following:
 
-`#topbar-cta-button` `#navbar` `#sidebar` `#content-area` `table-of-contents`
+`#topbar-cta-button` `#navbar` `#sidebar` `#content-area` `#table-of-contents`
 
 <Tip>
   Use inspect element to find references to elements you're looking to

--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -16,7 +16,8 @@ settings. Learn more about the [properties](#properties) or from an
 </ResponseField>
 
 <ResponseField name="logo" type="string or object">
-  Path to logo image or object with path to "light" and "dark" mode logo images
+  Path to logo image or object with path to "light" and "dark" mode logo images, and where the logo links to.
+  SVG format is recommended. It does not pixelate and the file size is generally smaller.
   <Expandable title="Logo">
     <ResponseField name="light" type="string">
       Path to the logo in light mode. For example: `/path/to/logo.svg`
@@ -506,3 +507,7 @@ Click on the following dropdown to view a sample configuration file
 ```
 
 </Accordion>
+
+## More Customization
+
+Learn more about how to further customize your docs with custom CSS and JS in [Custom Scripts](https://mintlify.com/docs/integrations/custom/).

--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -16,8 +16,7 @@ settings. Learn more about the [properties](#properties) or from an
 </ResponseField>
 
 <ResponseField name="logo" type="string or object">
-  Path to logo image or object with path to "light" and "dark" mode logo images, and where the logo links to.
-  SVG format is recommended. It does not pixelate and the file size is generally smaller.
+  Path to logo image or object with path to "light" and "dark" mode logo images, and where the logo links to. SVG format is recommended. It does not pixelate and the file size is generally smaller.
   <Expandable title="Logo">
     <ResponseField name="light" type="string">
       Path to the logo in light mode. For example: `/path/to/logo.svg`


### PR DESCRIPTION
Docs & Donuts work

- make logo href setting more obvious: https://linear.app/mintlify/issue/CUS-35/changing-the-logo-redirect
- explain logo format choice: https://linear.app/mintlify/issue/CUS-34/choosing-the-right-image-type-for-logos
- add link to custom css/js option in global settings
- fix `#table-of-contents` missing `#`