### PR TITLE
Add internal url to props table

### DIFF
--- a/integrations/widget/chat.mdx
+++ b/integrations/widget/chat.mdx
@@ -62,6 +62,7 @@ In the first script tag or the React component props, you can customize the appe
 | Prop     | Type     | Description                                                 |
 | -------- | -------- | ----------------------------------------------------------- |
 | `apiKey` | `string` | Widget API key generated from Mintlify dashboard. Required. |
+| `url?` | `string` | Used for internal testing only |
 
 ### MintlifyWidgetDisplayProps
 


### PR DESCRIPTION
This adds `url` to the props table with a description of `Used for internal testing only`