### PR TITLE
correct `frontchat` integration key

### DIFF
--- a/integrations/support/front.mdx
+++ b/integrations/support/front.mdx
@@ -8,13 +8,13 @@ Add the following to your `mint.json` file to add an [Front Chat](https://front.
 
 ```json Integration options in mint.json
 "integrations": {
-    "front": "CHAT_ID"
+    "frontchat": "CHAT_ID"
 }
 ```
 
 ```json Example
 "integrations": {
-    "front": "1365d046d7c023e9b030ce90d02d093a"
+    "frontchat": "1365d046d7c023e9b030ce90d02d093a"
 }
 ```
 


### PR DESCRIPTION
seems like the actual key is `frontchat` not `front`. this works for me and it matches whats in the schema.json file, but I suppose I don't know which is "correct". 