### PR TITLE
nit: mention the new label prop available for widget

### DIFF
--- a/advanced/widget/chat.mdx
+++ b/advanced/widget/chat.mdx
@@ -75,11 +75,12 @@ In the first script tag or the React component props, you can customize the appe
 
 #### MintlifyWidgetDisplayTriggerProps
 
-| Prop          | Type                                 | Description                                                                            |
-| ------------- | ------------------------------------ | -------------------------------------------------------------------------------------- |
-| `type?`       | `'button'` \| `'input'`                | Type of the trigger to display. Defaults to `button`.                                  |
-| `buttonIcon?` | `'chat'` \| `'sparkles'` \| `'mintlify'` | Icon used in the trigger. Only available for the `button` trigger. Defaults to `chat`. |
-| `iconOnly?`   | `boolean`                            | Only show icon in the trigger or not. Defaults to `false`.                             |
+| Prop          | Type                                 | Description                                                                                                                |
+| ------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `type?`       | `'button'`\|`'input'`                | Type of the trigger to display. Defaults to `button`.                                                                      |
+| `label?`      | `string`                             | Label displayed in the trigger. Defaults to `Get help` for the button trigger and `Ask anything...` for the input trigger. |
+| `buttonIcon?` | `'chat'`\|`'sparkles'`\|`'mintlify'` | Icon used in the trigger. Only available for the `button` trigger. Defaults to `chat`.                                     |
+| `iconOnly?`   | `boolean`                            | Only show icon in the trigger or not. Defaults to `false`.                                                                 |
 
 Here is an overview of what the trigger looks like with different configurations.
 


### PR DESCRIPTION
we added [customizable cta text](https://github.com/mintlify/mint/pull/1614) to widget triggers, this pr mentions it in the public doc


![image](https://github.com/user-attachments/assets/80504e28-71de-481f-96e3-777d582b4ee3)

identical change was made to npm readme: https://github.com/mintlify/mint/pull/1614/files#diff-0e14e2a514242459eb4b9d8930b074d1de0b6a665c63a145f58affc2bb82ee1e


