### PR TITLE
fix: remove unused glass param

### DIFF
--- a/content/components/frames.mdx
+++ b/content/components/frames.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Frames'
-description: 'Use the Frame component to wrap images or other components in a container.'
-icon: 'frame'
+title: "Frames"
+description: "Use the Frame component to wrap images or other components in a container."
+icon: "frame"
 ---
 
 Frames are very helpful if you want to center an image.
@@ -34,12 +34,6 @@ You can add additional context to an image using the optional `caption` prop.
 
 ```jsx Frame with Captions
 <Frame caption="Caption Text">
-  <img src="/path/image.jpg" />
-</Frame>
-```
-
-```jsx Glass Frame
-<Frame type="glass">
   <img src="/path/image.jpg" />
 </Frame>
 ```


### PR DESCRIPTION
The `type` param has no effect