### PR TITLE
Redirect to mintlify dashboard

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -33,7 +33,7 @@ integrate your docs with your code, and make source control effortless.
 
     To create your docs repo without logging into Github, follow these instructions:
     1. Clone our [starter template](https://github.com/mintlify/starter) into a new public repo. You can make the repo private later.
-    2. [Get in touch](mailto:support@mintlify.com) with our team to deploy your repo.
+    2. Onboard onto the [Mintlify Dashboard](https://dashboard.mintlify.com)
 
     ![Starter Template](https://mintlify.s3-us-west-1.amazonaws.com/mintlify/images/starter-template.png)
 


### PR DESCRIPTION
Our quickstart tells people to reach out to us, but we should just lead them to the dashboard