### PR TITLE
add docs for codeblock line highlight

### DIFF
--- a/content/components/code.mdx
+++ b/content/components/code.mdx
@@ -66,10 +66,36 @@ const hello = "world";
 ```
 ````
 
+## Line Highlighting
+
+You can highlight specific lines in your code blocks by adding a special comment after the language identifier. Use curly braces `{}` and specify line numbers or ranges separated by commas.
+
+```javascript Line Highlighting Example {1,3-5}
+const greeting = "Hello, World!";
+function sayHello() {
+  console.log(greeting);
+}
+sayHello();
+```
+
+````md
+```javascript Line Highlighting Example {1,3-5}
+const greeting = "Hello, World!";
+function sayHello() {
+  console.log(greeting);
+}
+sayHello();
+```
+````
+
 ## Code Groups
 
 Want to display multiple code examples in one code box? Check out the Code Group docs:
 
-<Card title="Code Group" href="/content/components/code-groups" icon="columns-3">
+<Card
+  title="Code Group"
+  href="/content/components/code-groups"
+  icon="columns-3"
+>
   Read the reference for the Code Group component
 </Card>


### PR DESCRIPTION
<img width="1485" alt="Screenshot 2024-10-22 at 9 42 48 PM" src="https://github.com/user-attachments/assets/9bd4fd3e-c552-4591-b9c5-8c55e8be09f5">
