### PR TITLE
Add workflow file to index docs into Plain

### DIFF
--- a/.github/workflows/index-sitemap.yml
+++ b/.github/workflows/index-sitemap.yml
@@ -1,0 +1,24 @@
+name: Index docs
+
+on:
+  schedule:
+    - cron: "0 */3 * * *"  
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install CLI
+        run: npm install -g @team-plain/cli@latest
+        
+      - name: Index Docs
+        run: plain index-sitemap https://mintlify.com/docs/sitemap.xml
+        env:
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}


### PR DESCRIPTION
This workflow will run every 3h and index your documentation into Plain, and improve the answers and accuracy of [AI-generated replies](https://www.plain.com/docs/plain-ai/smart-ai-replies).

To make this work, after merging this PR, you will have to:
- Create an API key in Plain **Settings** → **Machine Users** with the following permission: `indexedDocument:create`
- Add it your documentation repo as an environment variable called `PLAIN_API_KEY`



