### PR TITLE
added all changes from 2024 as far as I could tell from twitter

### DIFF
--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -284,3 +284,63 @@ mode: "wide"
   into easy-to-digest reports with AI-powered suggestions on how to improve your
   product.
 </Update>
+
+<Update label="June 2024">
+
+## Launch Week Highlights
+* Themes: Customize your styling with pre-configured themes. Just add the theme Quill, Prism, or Venus to your `mint.json` file and it'll update your docs styling.
+* Search V2: directly query OpenAPI endpoint descriptions and titles to reach API Reference pages, remove hidden pages from search, and enjoy our updated searchbar UI.
+* Web Editor branching: create branches in our web editor without an IDE.
+* User Personalization: authenticate users with Shared Session or JWT so that you can show them customized content, such as pre-filling API keys or showing specific content for customers.
+* OepenAPI Automation Upgrades: to auto-populate API Playground pages, you can add an `openapi` field to an object in tabs or anchors arrays in the mint.json. 
+
+</Update>
+
+<Update label="May 2024">
+
+## Okta SSO 
+We now support sign-on via Okta SAML and OIDC.
+
+## Mintlify REST API
+Programmatically rigger updates to your documentation. 
+
+</Update>
+
+<Update label="April 2024">
+
+## Custom mode
+Add a configuration to the metadata to remove all elements except for the top bar.
+Example use cases:
+* Create a custom global landing page setup with custom components
+* Add full-screen videos or image galleries
+* Embed custom iFrame demo elements to add intractability to your docs
+
+Check out our [Custom Mode docs](/page#custom-mode).
+</Update>
+
+
+<Update label="March 2024">
+## Mintlify MDX for VSCode
+Call snippets of our pre-built components an dcallouts without leaving VSCode. [Install the extension here](https://marketplace.visualstudio.com/items?itemName=mintlify.mintlify-snippets). 
+
+</Update>
+
+<Update label="February 2024">
+
+## Quality Improvements
+* Dashboard upgrades: view update logs to see what's changed and status of an update, toggle between Mintlify projects to manage deployments
+* Versioning with tabs fully supported
+* Wildcard redirects now supported
+* CLI Error Detection: we now show the position of invalid frontmatter when there are parsing issues during local development
+
+</Update>
+
+<Update label="January 2024">
+
+## Launch Week Highlights
+* Preview Deployments: When you create a pull request, we'll generate a unique link that shows a live preview of what your docs look like in prod. You can share this link with teammates.
+* Snippets V2: We now support fully reusable components and variables for snippets.
+* Open-source MDX Engine: We've exposed two APIs—getCompiledMdx and MDXComponent—so you can access Mintlify markdown and code syntax highlighting. [Contributions to the project](https://github.com/mintlify/mdx) are welcome. 
+* AI Chat Insights: Segment chat history by date and increase AI Chat quota from the dashboard, and see how often a specific query appears.
+
+</Update>


### PR DESCRIPTION
David mentioned it'd be nice to point to all our changes from 2024. I can't list them all in a blog, but I can point the blog to our changelog and have it be a very long list that dates back the whole year.

I know these aren't incredible descriptions and I'm missing context, open to changing any, but basically want to make it a fairly exhaustive list

eventually we can apply some type of style guideline to our changelog and run it through AI Assistant to make it more consistent