### PR TITLE
added localization setup details to versioning page

### DIFF
--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -313,7 +313,7 @@ Japanese, and Portuguese.
 </Info>
 
 For more information, please refer to our
-[versioning documentation](/settings/versioning).
+[versioning & localization documentation](/settings/versioning).
 
 Example:
 

--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -308,8 +308,8 @@ locale. We currently support localization in English, Chinese, Spanish, French,
 Japanese, and Portuguese.
 
 <Info>
-  Localization applies to the UI and fixed assets in the docs, such as "was this
-  page helpful".
+  Localization auto-translates the UI and fixed assets in the docs, such as "Was
+  this page helpful?". You must translate the content of the pages yourself.
 </Info>
 
 For more information, please refer to our

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -167,7 +167,7 @@ We currently support localization in English (`en`), Chinese (`cn`), Spanish (`e
 
 <Tip>
   The versions dropdown will show your localizations in the order you include
-  them in `mint.json`.
+  them in the `mint.json`.
 </Tip>
 
 Once setup, the rest of localization is handled by the versioning setup described above.

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -138,7 +138,7 @@ Common errors and how to fix them
 
 `"versions"` in your `mint.json` can be leveraged to create different language versions. The first localization from the array serves as the default localization.
 
-We currently support localization in English, Chinese, Spanish, French, Japanese, and Portuguese.
+We currently support localization in English (`en`), Chinese, Spanish (`es`), French (`fr`), Japanese, and Portuguese.
 
 Set your localization in your `mint.json` file like this:
 

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Versioning & Localization'
-description: 'Build separate versions or localizations'
-icon: 'square-chevron-down'
+title: "Versioning & Localization"
+description: "Build separate versions or localizations"
+icon: "square-chevron-down"
 ---
 
 Mintlify supports versioning or localization. You can use one or the other, not both.
@@ -49,14 +49,17 @@ You can also specify the version of a single page in the page metadata. Versions
 
 ```yaml Pages (quickstart.mdx)
 ---
-title: 'Quickstart'
-version: 'v2'
+title: "Quickstart"
+version: "v2"
 ---
 ```
+
 </CodeGroup>
 
 <Warning>
-  While it is possible to nest versioned groups within versioned groups, it is not recommended. If you do take this approach, the more deeply-nested version takes precedence.
+  While it is possible to nest versioned groups within versioned groups, it is
+  not recommended. If you do take this approach, the more deeply-nested version
+  takes precedence.
 </Warning>
 
 #### Versioning Tabs and Anchors
@@ -104,6 +107,7 @@ In `mint.json`, simply add `version` to your tab or anchor. Tabs and anchors wit
   },
 ],
 ```
+
 </CodeGroup>
 
 #### Sharing Between Versions
@@ -111,7 +115,10 @@ In `mint.json`, simply add `version` to your tab or anchor. Tabs and anchors wit
 Not _all_ content has to be hidden though! Any content without a specified version appears in every version so you don't have to duplicate content!
 
 <Tip>
-  When using localization with versioning, each version can have its own set of translations. This means you can have different language versions for different API versions, giving you full flexibility in managing both versioned and localized content.
+  When using localization with versioning, each version can have its own set of
+  translations. This means you can have different language versions for
+  different API versions, giving you full flexibility in managing both versioned
+  and localized content.
 </Tip>
 
 ### Troubleshooting
@@ -123,6 +130,7 @@ Common errors and how to fix them
     You likely nested a version inside of another. For example, your group had version "v1" but your page had version "v2".
 
     We do not recommend nesting versions inside of each other because it's hard to maintain your docs later.
+
   </Accordion>
 
   <Accordion title="Missing Pages" icon="circle-exclamation">
@@ -136,13 +144,11 @@ Common errors and how to fix them
 
 ### Setup
 
-`"versions"` in your `mint.json` can be leveraged to create different language versions. The first localization from the array serves as the default localization.
+`"versions"` in your `mint.json` can be leveraged to create different language versions by adding a `locale` value to the version. The first localization from the array serves as the default localization.
 
-We currently support localization in English (`en`), Chinese, Spanish (`es`), French (`fr`), Japanese, and Portuguese.
+We currently support localization in English (`en`), Chinese (`cn`), Spanish (`es`), French (`fr`), Japanese (`jp`), Portuguese (`pt`), and German (`de`).
 
-Set your localization in your `mint.json` file like this:
-
-```json
+```json mint.json example
 "versions": [
   {
     "name": "English",
@@ -160,8 +166,8 @@ Set your localization in your `mint.json` file like this:
 ```
 
 <Tip>
-  The versions dropdown will show your localizations in the order you include them in
-  `mint.json`.
+  The versions dropdown will show your localizations in the order you include
+  them in `mint.json`.
 </Tip>
 
 Once setup, the rest of localization is handled by the versioning setup described above.

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -1,12 +1,16 @@
 ---
-title: 'Versioning'
-description: 'Build separate versions'
+title: 'Versioning & Localization'
+description: 'Build separate versions or localizations'
 icon: 'square-chevron-down'
 ---
 
+Mintlify supports versioning or localization. You can use one or the other, not both.
+
 These guides will assume `v1` pages are in a folder named `v1`, `v2` pages are in a folder named `v2`, and so on. While this method of structuring your files isn't strictly necessary, it's a great way to keep your files organized.
 
-## Setup
+## Versioning
+
+### Setup
 
 Add `"versions": ["v2", "v1"]` to your `mint.json` file where `v1` and `v2` are the names of your versions. You can put any number of versions in this array. The first version from the array serves as the default version.
 
@@ -26,7 +30,7 @@ If you would like to specify a default version, you can do so like this:
   `mint.json`.
 </Tip>
 
-## Versioning Groups and Pages
+### Versioning Groups and Pages
 
 The best way to specify page versions is by adding a version value to a group in the navigation. When you specify the version of a group, that version is applied to all pages within that group.
 
@@ -55,7 +59,7 @@ version: 'v2'
   While it is possible to nest versioned groups within versioned groups, it is not recommended. If you do take this approach, the more deeply-nested version takes precedence.
 </Warning>
 
-### Versioning Tabs and Anchors
+#### Versioning Tabs and Anchors
 
 You can hide a tab or anchor based on a version. This is useful if you have links that are only relevant in one version. Importantly, this does **not** apply the version to the pages within that anchor.
 
@@ -102,7 +106,7 @@ In `mint.json`, simply add `version` to your tab or anchor. Tabs and anchors wit
 ```
 </CodeGroup>
 
-### Sharing Between Versions
+#### Sharing Between Versions
 
 Not _all_ content has to be hidden though! Any content without a specified version appears in every version so you don't have to duplicate content!
 
@@ -110,7 +114,7 @@ Not _all_ content has to be hidden though! Any content without a specified versi
   When using localization with versioning, each version can have its own set of translations. This means you can have different language versions for different API versions, giving you full flexibility in managing both versioned and localized content.
 </Tip>
 
-## Troubleshooting
+### Troubleshooting
 
 Common errors and how to fix them
 
@@ -127,3 +131,37 @@ Common errors and how to fix them
     array in `mint.json`.
   </Accordion>
 </AccordionGroup>
+
+## Localization
+
+### Setup
+
+Using `"versions"` in your `mint.json` file where `en`, `fr`, and `es` are the names of your localizations. The first localization from the array serves as the default localization.
+
+We currently support localization in English, Chinese, Spanish, French, Japanese, and Portuguese.
+
+Set your localization in your `mint.json` file like this:
+
+```json
+"versions": [
+  {
+    "name": "English",
+    "locale": "en",
+  },
+  {
+    "name": "French",
+    "locale": "fr",
+  },
+  {
+    "name": "Spanish",
+    "locale": "es"
+  }
+]
+```
+
+<Tip>
+  The versions dropdown will show your localizations in the order you include them in
+  `mint.json`.
+</Tip>
+
+Once setup, the rest of localization is handled by the versioning setup described above.

--- a/settings/versioning.mdx
+++ b/settings/versioning.mdx
@@ -136,7 +136,7 @@ Common errors and how to fix them
 
 ### Setup
 
-Using `"versions"` in your `mint.json` file where `en`, `fr`, and `es` are the names of your localizations. The first localization from the array serves as the default localization.
+`"versions"` in your `mint.json` can be leveraged to create different language versions. The first localization from the array serves as the default localization.
 
 We currently support localization in English, Chinese, Spanish, French, Japanese, and Portuguese.
 


### PR DESCRIPTION
# Feedback requested
I added only the Setup info for localizations to make it easier for customers to get going. Then referenced that the rest of the versions documentation is how you implement it.

Should I actually continue to "duplicate" the version content though and give full examples of using localization across:
Versioning Groups and Pages, Versioning Tabs and Anchors, Sharing Between Versions, Troubleshooting ?