### PR TITLE
Update API playground docs

### DIFF
--- a/api-playground/mdx/configuration.mdx
+++ b/api-playground/mdx/configuration.mdx
@@ -56,6 +56,15 @@ Mintlify allows you to define your API endpoints using a combination of `docs.js
     If you have `server` configured in [docs.json](/settings/global), you can use relative paths like `/v1/endpoint`.
 
     </Note>
+
+    You can also override the globally-defined display mode for the API playground on specific pages by adding `playground` at the top of the MDX file:
+
+    ```md
+    ---
+    title: 'Create new user'
+    api: 'POST https://api.mintlify.com/user'
+    playground: 'none'
+    ``` 
   </Step>
 
   <Step title="Add your endpoints to your docs">

--- a/api-playground/mdx/configuration.mdx
+++ b/api-playground/mdx/configuration.mdx
@@ -57,14 +57,15 @@ Mintlify allows you to define your API endpoints using a combination of `docs.js
 
     </Note>
 
-    You can also override the globally-defined display mode for the API playground on specific pages by adding `playground` at the top of the MDX file:
+    You can also override the globally-defined display mode for the API playground per page by adding `playground` at the top of the MDX file:
 
     ```md
     ---
     title: 'Create new user'
     api: 'POST https://api.mintlify.com/user'
     playground: 'none'
-    ``` 
+    ```
+    
   </Step>
 
   <Step title="Add your endpoints to your docs">


### PR DESCRIPTION
Follow-up to https://linear.app/mintlify/issue/ENG-3266/allow-setting-api-playground-mode-on-the-page-level

With [this PR](https://github.com/mintlify/mint/pull/2308) we enabled the ability for customers to change the API playground display mode per page. Adding this to the docs about customizing MDX pages under API Playground.

Preview: https://mintlify-kathryn-update-api-playground-mdx-frontmatter-docs.mintlify.app/api-playground/mdx/configuration