### PR TITLE
quick fix to improve the OpenAPI pages

### DIFF
--- a/api-playground/openapi/setup.mdx
+++ b/api-playground/openapi/setup.mdx
@@ -79,6 +79,8 @@ and the API playground will be automatically generated from the OpenAPI document
 If you have multiple OpenAPI files, include the path to the OpenAPI file to ensure Mintlify finds the correct OpenAPI document. This is not required if you have
 only one OpenAPI file - it will automatically detect your OpenAPI file.
 
+If you want to reference an external OpenAPI file using this method, provide the file’s URL in the docs.json. See [here](https://mintlify.com/docs/settings/global#param-source-4) for the correct format.
+
 <CodeGroup>
   ```md Example
   ---
@@ -94,8 +96,6 @@ only one OpenAPI file - it will automatically detect your OpenAPI file.
   ---
   ```
 </CodeGroup>
-
-<br />
 
 <Note>
   In most cases, the method and path must match the method and path specified

--- a/api-playground/openapi/setup.mdx
+++ b/api-playground/openapi/setup.mdx
@@ -49,6 +49,8 @@ The fastest way to get started with OpenAPI is to add an `openapi` field to a ta
 }
 ```
 
+<Note>The directory field is optional. If not specified, the files will be placed in the **api-reference** folder of the docs repo.</Note>
+
 When using this option, the metadata for the generated pages will have the following default values:
 
 * `title`: The `summary` field from the OpenAPI operation, if present. Otherwise a title generated from the HTTP method and endpoint.

--- a/api-playground/troubleshooting.mdx
+++ b/api-playground/troubleshooting.mdx
@@ -16,7 +16,7 @@ Here's a list of common issues we've seen customers run into:
 
     To verify your OpenAPI document will pass validation:
 
-    1. Visit [this validator](https://apitools.dev/swagger-parser/online/)
+    1. Visit [this validator](https://editor.swagger.io/)
     2. Switch to the "Validate text" tab
     3. Paste in your OpenAPI document
     4. Click "Validate it!"


### PR DESCRIPTION
I added the tip to the OpenAPI page to explain what directory does

I updated the OpenAPI validator to this link: https://editor.swagger.io/