### PR TITLE
Include Lucide in icon options

### DIFF
--- a/content/components/accordions.mdx
+++ b/content/components/accordions.mdx
@@ -35,7 +35,7 @@ icon: "square-caret-down"
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/icons), or SVG code
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/content/components/accordions.mdx
+++ b/content/components/accordions.mdx
@@ -35,7 +35,7 @@ icon: "square-caret-down"
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons) or SVG code
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/content/components/cards.mdx
+++ b/content/components/cards.mdx
@@ -49,7 +49,7 @@ Add an `img` property to a card to display an image on the top of the card.
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons) or SVG code in `icon={}`
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code in `icon={}`
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/content/components/cards.mdx
+++ b/content/components/cards.mdx
@@ -49,7 +49,7 @@ Add an `img` property to a card to display an image on the top of the card.
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code in `icon={}`
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/icons), or SVG code in `icon={}`
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/content/components/icons.mdx
+++ b/content/components/icons.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Icons"
-description: "Use [Font Awesome](https://fontawesome.com/icons) icons anywhere in the doc"
+description: "Use [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/) icons anywhere in the doc"
 icon: "icons"
 ---
 

--- a/content/components/icons.mdx
+++ b/content/components/icons.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Icons"
-description: "Use [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/) icons anywhere in the doc"
+description: "Use [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/icons) icons anywhere in the doc"
 icon: "icons"
 ---
 

--- a/content/components/steps.mdx
+++ b/content/components/steps.mdx
@@ -53,7 +53,7 @@ Steps are the best way to display a series of actions of events to your users. Y
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons) or SVG code in `icon={}`
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code in `icon={}`
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/content/components/steps.mdx
+++ b/content/components/steps.mdx
@@ -53,7 +53,7 @@ Steps are the best way to display a series of actions of events to your users. Y
 </ResponseField>
 
 <ResponseField name="icon" type="string or svg">
-  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/), or SVG code in `icon={}`
+  A [Font Awesome icon](https://fontawesome.com/icons), [Lucide icon](https://lucide.dev/icons), or SVG code in `icon={}`
 </ResponseField>
 
 <ResponseField name="iconType" type="string">

--- a/navigation/divisions.mdx
+++ b/navigation/divisions.mdx
@@ -51,7 +51,7 @@ Anchors are another way to section your content. They show up on top of your sid
 </Frame>
 
 The configuration is very similar to the tab configuration. We highly recommend that you set an `icon` field as well.
-The icon values are [fontawesome icons](https://fontawesome.com/search)
+Valid icon values include all named [Font Awesome](https://fontawesome.com/search) and [Lucide](https://lucide.dev/) icons.
 
 ```json docs.json
 "navigation": {
@@ -91,7 +91,7 @@ The icon values are [fontawesome icons](https://fontawesome.com/search)
 </Frame>
 
 Dropdowns show up in the same place as anchors, but are consolidated into a single dropdown.
-We also recommend that you set an icon for each dropdown item ([options](https://fontawesome.com/search)).
+We also recommend that you set an icon for each dropdown item (from [Font Awesome](https://fontawesome.com/search) or [Lucide](https://lucide.dev/)).
 ```json docs.json
 "navigation": {
   "dropdowns": [

--- a/navigation/divisions.mdx
+++ b/navigation/divisions.mdx
@@ -51,7 +51,7 @@ Anchors are another way to section your content. They show up on top of your sid
 </Frame>
 
 The configuration is very similar to the tab configuration. We highly recommend that you set an `icon` field as well.
-Valid icon values include all named [Font Awesome](https://fontawesome.com/search) and [Lucide](https://lucide.dev/) icons.
+Valid icon values include all named [Font Awesome](https://fontawesome.com/icons) and [Lucide](https://lucide.dev/icons) icons.
 
 ```json docs.json
 "navigation": {
@@ -91,7 +91,7 @@ Valid icon values include all named [Font Awesome](https://fontawesome.com/searc
 </Frame>
 
 Dropdowns show up in the same place as anchors, but are consolidated into a single dropdown.
-We also recommend that you set an icon for each dropdown item (from [Font Awesome](https://fontawesome.com/search) or [Lucide](https://lucide.dev/)).
+We also recommend that you set an icon for each dropdown item (from [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/icons)).
 ```json docs.json
 "navigation": {
   "dropdowns": [

--- a/page.mdx
+++ b/page.mdx
@@ -67,7 +67,7 @@ sidebarTitle: "Short title"
 
 Want an icon for your sidebar item like the ones in
 [components](/content/components/accordions)? You can set an `icon` attribute in
-the metadata! All icons from [Font Awesome](https://fontawesome.com/icons) and [Lucide](https://lucide.dev/) are
+the metadata! All icons from [Font Awesome](https://fontawesome.com/icons) and [Lucide](https://lucide.dev/icons) are
 available for us. You can also set an icon type for Font Awesome icons (optional). If not set, the icon
 type will be regular.
 

--- a/page.mdx
+++ b/page.mdx
@@ -67,8 +67,8 @@ sidebarTitle: "Short title"
 
 Want an icon for your sidebar item like the ones in
 [components](/content/components/accordions)? You can set an `icon` attribute in
-the metadata! All icons from [Font Awesome](https://fontawesome.com/icons) are
-available for us. You can also set an icon type (optional). If not set, the icon
+the metadata! All icons from [Font Awesome](https://fontawesome.com/icons) and [Lucide](https://lucide.dev/) are
+available for us. You can also set an icon type for Font Awesome icons (optional). If not set, the icon
 type will be regular.
 
 ```md

--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -968,11 +968,11 @@ Example:
       </ResponseField>
 
       <ResponseField name="icon" type="string">
-        The [Fontawesome](https://fontawesome.com/icons) icon for the group. Note: this only applies to sub-folders.
+        The [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/) icon for the group. Note: this only applies to sub-folders.
       </ResponseField>
 
       <ResponseField name="iconType" type="string">
-        The type of [Fontawesome](https://fontawesome.com/icons) icon. Must be one of: brands, duotone, light, sharp-solid, solid, thin
+        The type of icon (only for [Font Awesome](https://fontawesome.com/icons) icons). Must be one of: brands, duotone, light, sharp-solid, solid, thin
       </ResponseField>
 
     </Expandable>
@@ -1111,7 +1111,7 @@ Example:
       </ResponseField>
 
       <ResponseField name="icon" type="string">
-        The [Font Awesome](https://fontawesome.com/search?q=heart) icon used to feature the anchor.
+        The [Font Awesome](https://fontawesome.com/search?q=heart) or [Lucide](https://lucide.dev/) icon used to feature the anchor.
 
         Example: `comments`
       </ResponseField>

--- a/settings/global.mdx
+++ b/settings/global.mdx
@@ -968,7 +968,7 @@ Example:
       </ResponseField>
 
       <ResponseField name="icon" type="string">
-        The [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/) icon for the group. Note: this only applies to sub-folders.
+        The [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/icons) icon for the group. Note: this only applies to sub-folders.
       </ResponseField>
 
       <ResponseField name="iconType" type="string">
@@ -1111,7 +1111,7 @@ Example:
       </ResponseField>
 
       <ResponseField name="icon" type="string">
-        The [Font Awesome](https://fontawesome.com/search?q=heart) or [Lucide](https://lucide.dev/) icon used to feature the anchor.
+        The [Font Awesome](https://fontawesome.com/icons) or [Lucide](https://lucide.dev/icons) icon used to feature the anchor.
 
         Example: `comments`
       </ResponseField>


### PR DESCRIPTION
With https://github.com/mintlify/mint/pull/2460 we added Lucide as an icon library option. This PR updates all mentions in the docs where we point to Font Awesome to also mention Lucide. 