### PR TITLE
docs: EdDSA -> ES256 for personalization handshake

### DIFF
--- a/settings/authentication-personalization/personalization-setup/jwt.mdx
+++ b/settings/authentication-personalization/personalization-setup/jwt.mdx
@@ -20,7 +20,7 @@ If you don’t have a dashboard, or if you want to keep your dashboard and docs 
     Create a login flow that does the following:
     - Authenticate the user
     - Create a JWT containing the authenticated user's info in the [User](../sending-data) format
-    - Sign the JWT with the secret key, using the EdDSA algorithm
+    - Sign the JWT with the secret key, using the ES256 algorithm
     - Create a redirect URL back to your docs, including the JWT as the hash
   </Step>
   <Step title="Configure your Personalization settings">
@@ -51,7 +51,7 @@ import { Request, Response } from 'express';
 
 const TWO_WEEKS_IN_MS = 1000 * 60 * 60 * 24 * 7 * 2;
 
-const signingKey = await jose.importPKCS8(process.env.MINTLIFY_PRIVATE_KEY, 'EdDSA');
+const signingKey = await jose.importPKCS8(process.env.MINTLIFY_PRIVATE_KEY, 'ES256');
 
 export async function handleRequest(req: Request, res: Response) {
   const user = {
@@ -64,7 +64,7 @@ export async function handleRequest(req: Request, res: Response) {
   };
 
   const jwt = await new jose.SignJWT(user)
-    .setProtectedHeader({ alg: 'EdDSA' })
+    .setProtectedHeader({ alg: 'ES256' })
     .setExpirationTime('10 s')
     .sign(signingKey);
 


### PR DESCRIPTION
We switched to issuing Ed25519 key pairs recently because the algorithm sidesteps a lot of issues with EC key pairs, but it's not stable in almost all browsers. Hence, for now, we have to switch back.