### PR TITLE
Updating update.mdx

### DIFF
--- a/content/components/update.mdx
+++ b/content/components/update.mdx
@@ -6,7 +6,7 @@ icon: "rectangle-history"
 
 The `Update` component is used to keep track of changes and updates.
 
-<Update label="2024-10-12" description="v0.1.1">
+<Update label="2024-10-12" description="v0.1.1" tags={["Filter 1"]}>
   <Frame>
     <img
       className="block"
@@ -23,14 +23,14 @@ The `Update` component is used to keep track of changes and updates.
   - Sticky section for each changelog
 </Update>
 
-<Update label="2024-10-11" description="v0.1.0">
+<Update label="2024-10-11" description="v0.1.0" tags={["Filter 2"]}>
   ### How to use 
   ```md
-  <Update label="2024-10-12" description="v0.1.1">
+  <Update label="2024-10-12" description="v0.1.1" tags={["Filter 1"]}>
     This is how you use a changelog with a label 
     and a description.
   </Update>
-  <Update label="2024-10-11" description="v0.1.0">
+  <Update label="2024-10-11" description="v0.1.0" tags={["Filter 2"]}>
     This is how you use a changelog with a label 
     and a description.
   </Update>
@@ -46,14 +46,16 @@ The `Update` component is used to keep track of changes and updates.
 ## Props
 
 <ResponseField name="label" type="string" required>
-  Label in the changelog, on the sticky left side.
-</ResponseField>
-
-<ResponseField name="description" type="string">
-  Description below the label in the Changelog preview.
+  The label give to the update, appears as sticky text to the left of the changelog.
 </ResponseField>
 
 <ResponseField name="tags" type="string[]">
-  Tags for the changelog, will be show as filters in the right side panel
+  Tags for the changelog, will be shown as filters in the right side panel.
 </ResponseField>
+
+<ResponseField name="description" type="string">
+  Description of the update, appears below the label and tag.
+</ResponseField>
+
+
 


### PR DESCRIPTION
Correcting for clarity and adding in filters

Sam and I determined it would be better to demo the filters instead of the TOC (you can only show one or the other)

Major nit: the Prism highlighting disappears when you add the tag (see image)

![CleanShot 2025-04-09 at 12 15 51](https://github.com/user-attachments/assets/67c77297-b1c3-4402-8814-d482b5c7e2da)
