### PR TITLE
Added image path tip

### DIFF
--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -23,7 +23,9 @@ The [markdown syntax](https://www.markdownguide.org/basic-syntax/#images) lets y
 ```md
 ![title](/path/image.jpg)
 ```
-
+<Tip>
+To make sure images are displayed correctly in production, we recommend adding a forward slash to the relative image path (e.g. `/path/image.jpg`).
+</Tip>
 Note that the image file size must be less than 5MB. Otherwise, we recommend hosting on a service like [Cloudinary](https://cloudinary.com/) or [S3](https://aws.amazon.com/s3/). You can then use that URL and embed.
 
 ### Using Embeds


### PR DESCRIPTION
Images need to have `/` to work in prod. They work locally without it but not in prod so we should let users know to add this forward slash. 