### PR TITLE
feat: add keywords frontmatter

### DIFF
--- a/page.mdx
+++ b/page.mdx
@@ -177,7 +177,19 @@ them into your page's metadata. Meta tags with colons need to be wrapped in
 quotes.
 
 ```md
+---
 "twitter:image": "/images/your-photo.jpg"
+---
 ```
 
 See [our SEO page](/settings/seo) for all supported meta tags.
+
+You can also improve a specific page's discoverability in Mintlify's built-in search by
+providing `keywords` in your frontmatter. These keywords won't appear as part of the page
+content, but users that search for them will be shown the page as a result.
+
+```md
+---
+keywords: ['search', 'indexing']
+---
+```

--- a/page.mdx
+++ b/page.mdx
@@ -185,8 +185,8 @@ quotes.
 See [our SEO page](/settings/seo) for all supported meta tags.
 
 You can also enhance a specific page's discoverability in the built-in search by
-providing `keywords` in your frontmatter. These keywords won't appear as part of the page
-content, but users that search for them will be shown the page as a result.
+providing `keywords` in your metadata. These keywords won't appear as part of the page
+content or in search results, but users that search for them will be shown the page as a result.
 
 ```md
 ---

--- a/page.mdx
+++ b/page.mdx
@@ -184,6 +184,8 @@ quotes.
 
 See [our SEO page](/settings/seo) for all supported meta tags.
 
+## Internal Search Optimization
+
 You can also enhance a specific page's discoverability in the built-in search by
 providing `keywords` in your metadata. These keywords won't appear as part of the page
 content or in search results, but users that search for them will be shown the page as a result.

--- a/page.mdx
+++ b/page.mdx
@@ -184,7 +184,7 @@ quotes.
 
 See [our SEO page](/settings/seo) for all supported meta tags.
 
-You can also improve a specific page's discoverability in Mintlify's built-in search by
+You can also enhance a specific page's discoverability in the built-in search by
 providing `keywords` in your frontmatter. These keywords won't appear as part of the page
 content, but users that search for them will be shown the page as a result.
 


### PR DESCRIPTION
Users can now add arbitrary keywords to improve indexing of pages in the full-text index.