### PR TITLE
Remove custom Inter font

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,14 +11,6 @@
   "icons": {
     "library": "lucide"
   },
-  "fonts": {
-    "body": {
-      "family": "inter-variable"
-    },
-    "heading": {
-      "family": "inter-variable"
-    }
-  },
   "navigation": {
     "dropdowns": [
       {
@@ -28,12 +20,7 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": [
-              "index",
-              "quickstart",
-              "installation",
-              "editor"
-            ]
+            "pages": ["index", "quickstart", "installation", "editor"]
           },
           {
             "group": "Core Concepts",
@@ -134,9 +121,7 @@
           },
           {
             "group": "Guides",
-            "pages": [
-              "guides/migration"
-            ]
+            "pages": ["guides/migration"]
           },
           {
             "group": "Deep Dive",
@@ -239,10 +224,7 @@
               {
                 "group": "Model Context Protocol",
                 "icon": "audio-waveform",
-                "pages": [
-                  "advanced/mcp/quickstart",
-                  "advanced/mcp/generate"
-                ]
+                "pages": ["advanced/mcp/quickstart", "advanced/mcp/generate"]
               }
             ]
           }
@@ -255,9 +237,7 @@
         "groups": [
           {
             "group": "API Reference",
-            "pages": [
-              "api-reference/introduction"
-            ]
+            "pages": ["api-reference/introduction"]
           },
           {
             "group": "Updates",
@@ -282,9 +262,7 @@
         "groups": [
           {
             "group": "Changelog",
-            "pages": [
-              "changelog"
-            ]
+            "pages": ["changelog"]
           }
         ]
       }
@@ -397,11 +375,6 @@
     }
   },
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude"]
   }
 }


### PR DESCRIPTION
Removes custom `inter-variable` font from being used, since `Inter` is the default font in Mintlify docs. Corresponds with a separate PR in Mintlify's core client that allows for variable-weight Inter to be used by default.