### PR TITLE
Fixing mcp npm package url

### DIFF
--- a/advanced/mcp/quickstart.mdx
+++ b/advanced/mcp/quickstart.mdx
@@ -5,7 +5,7 @@ description: "Generate an MCP server to help connect your product to AI apps"
 
 ## Introduction
 
-Mintlify's MCP Generator is a CLI tool that generates an MCP server based on your company's documentation & OpenAPI specification (if available). The MCP Generator is delivered via [npm package](https://www.npmjs.com/package/mcp).
+Mintlify's MCP Generator is a CLI tool that generates an MCP server based on your company's documentation & OpenAPI specification (if available). The MCP Generator is delivered via [npm package](https://www.npmjs.com/package/@mintlify/mcp).
 
 Your MCP server can then be used with any MCP client for these key scenarios:
 


### PR DESCRIPTION
Fixing the url from our old mcp url to the new one @mintlify/mcp 