### PR TITLE
fix link styling in Panel page

### DIFF
--- a/components/panel.mdx
+++ b/components/panel.mdx
@@ -6,7 +6,7 @@ icon: 'panel-right'
 
 You can use the `<Panel>` component to customize the right side panel of a page with any components that you want.
 
-If a page has a `<Panel>` component, any [`<RequestExample>`](/components/examples#request-example) and [`<ResponseExample>`](/components/examples#response-example) components must be inside `<Panel>`.
+If a page has a `<Panel>` component, any [RequestExample](/components/examples#request-example) and [ResponseExample](/components/examples#response-example) components must be inside `<Panel>`.
 
 The components in a `<Panel>` will replace a page's table of contents.
 


### PR DESCRIPTION
This PR updates the link styling in https://mintlify.com/docs/components/panel