### PR TITLE
Change `source` to `Markdown` in web editor page

### DIFF
--- a/editor.mdx
+++ b/editor.mdx
@@ -86,19 +86,19 @@ You can add content blocks and other components to your documentation in visual 
   />
 </Frame>
 
-### Source Mode
+### Markdown Mode
 
-Source mode provides direct access to the underlying MDX code of your documentation. This mode is preferable when you need precise control over component properties or when you prefer to write in Markdown/MDX syntax.
+Markdown mode provides direct access to the underlying MDX code of your documentation. This mode is preferable when you need precise control over component properties or when you prefer to write in Markdown/MDX syntax.
 
 <Frame>
   <img 
     src="/images/editor/markdown-mode-light.png" 
-    alt="Source mode in the Mintlify web editor" 
+    alt="Markdown mode in the Mintlify web editor" 
     className="block dark:hidden"
   />
   <img 
     src="/images/editor/markdown-mode-dark.png" 
-    alt="Source mode in the Mintlify Web Editor" 
+    alt="Markdown mode in the Mintlify Web Editor" 
     className="hidden dark:block"
   />
 </Frame>
@@ -107,7 +107,7 @@ Source mode provides direct access to the underlying MDX code of your documentat
 
 1. **Browse files**: Use the sidebar file explorer to navigate through your documentation.
 2. **Open a file**: Click on the file that you want to edit to open it in the editor.
-3. **Make changes**: Edit the content using visual or source mode. Changes are automatically saved as drafts.
+3. **Make changes**: Edit the content using visual or Markdown mode. Changes are automatically saved as drafts.
 4. **Preview changes**: See how your changes will appear in visual mode.
 
 ## Publishing


### PR DESCRIPTION
This PR is a follow up to https://github.com/mintlify/mint/pull/2889. Updates https://mintlify.com/docs/editor.

Summary of changes:
* Change `source editor` to `Markdown editor` to reflect UI update