### PR TITLE
Quickstart: guide through the GitHub setup

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -33,7 +33,7 @@ This URL is instantly available and will update whenever you make changes to you
 
 ### Install the GitHub App
 
-Mintlify provides a GitHub App that automates the deployment process when you push changes to your repository. If you don't already have a GitHub account, you will need to [sign up for GitHub](https://github.com/signup).
+Mintlify provides a GitHub App that automates the deployment process when you push changes to your repository.
 
 You can install the GitHub App by following the instructions from the onboarding checklist or from your dashboard.
 
@@ -61,7 +61,7 @@ You can install the GitHub App by following the instructions from the onboarding
   You may need an admin for your GitHub organization to authorize your account depending on your organization's settings.
 </Info>
 
-## Mintlify Workflows
+## Editing Workflows
 
 Mintlify offers two different workflows for creating and maintaining your documentation.
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -31,6 +31,36 @@ You can find your URL from the Overview page of the dashboard.
 
 This URL is instantly available and will update whenever you make changes to your documentation. It's perfect for testing and sharing with your team during development.
 
+### Install the GitHub App
+
+Mintlify provides a GitHub App that automates the deployment process when you push changes to your repository. If you don't already have a GitHub account, you will need to [sign up for GitHub](https://github.com/signup).
+
+You can install the GitHub App by following the instructions from the onboarding checklist or from your dashboard.
+
+1. Navigate to **Settings** in your Mintlify dashboard.
+2. Select **GitHub App** from the sidebar.
+3. Select **Install GitHub App**. This will open a new tab to the GitHub App installation page.
+4. Select the organization or user account where you want to install the app. Then select the repositories that you want t oconnect.
+
+<Frame>
+  <img src="/images/quickstart/github-app-installation-light.png" alt="GitHub App Installation" className="block dark:hidden" />
+  <img src="/images/quickstart/github-app-installation-dark.png" alt="GitHub App Installation" className="hidden dark:block" />
+</Frame>
+
+<Info>
+  Remember to update the GitHub App permissions if you move the documentation to a different repository.
+</Info>
+
+### Authorize your GitHub Account
+
+1. Navigate to **Settings** in your Mintlify dashboard.
+2. Select **My Profile** from the sidebar.
+3. Select **Authorize GitHub account**. This will open a new tab to the GitHub authorization page.
+
+<Info>
+  You may need an admin for your GitHub organization to authorize your account depending on your organization's settings.
+</Info>
+
 ## Development Workflows
 
 Mintlify offers two different workflows for creating and maintaining your documentation.
@@ -71,23 +101,6 @@ pnpm add -g mint
 
 <Info>
   You need Node.js version 19 or higher installed on your machine. If you encounter installation issues, check the troubleshooting guide.
-</Info>
-
-### Install the GitHub App
-
-Mintlify provides a GitHub App that automates the deployment process when you push changes to your repository.
-
-You can install the GitHub App by following the instructions from the onboarding checklist or by navigating to `Settings` > `Organization` > `GitHub`.
-
-Click `Install GitHub App`. Select the repositories you want to connect.
-
-<Frame>
-  <img src="/images/quickstart/github-app-installation-light.png" alt="GitHub App Installation" className="block dark:hidden" />
-  <img src="/images/quickstart/github-app-installation-dark.png" alt="GitHub App Installation" className="hidden dark:block" />
-</Frame>
-
-<Info>
-  Remember to update the GitHub App permissions if you move the documentation to a different repository.
 </Info>
 
 ### Edit the Documentation
@@ -141,19 +154,20 @@ Once the deployment is complete, your last update will be available at `<your-pr
 
 ## Web Editor Workflow
 
-The web editor workflow provides a WYSIWYG interface for creating and editing documentation without requiring local development tools. It's ideal for non-technical team members or for making quick updates.
+The web editor workflow provides a what-you-see-is-what-you-get (WYSIWYG) interface for creating and editing documentation. It's ideal for people who want to work in their web browser without additional local development tools.
 
 ### Access the Web Editor
 
-Log in to your Mintlify Dashboard and select your project. Navigate to `Editor` on the left sidebar to open the web editor.
+1. Log in to your [Mintlify Dashboard](https://dashboard.mintlify.com).
+2. Select **Editor** on the left sidebar.
 
 <Info>
   If you haven't installed the GitHub App, you will be prompted to do so upon opening the web editor.
 </Info>
 
 <Frame>
-  <img alt="Web Editor" src="/images/quickstart/web-editor-light.png" className="block dark:hidden" />
-  <img alt="Web Editor" src="/images/quickstart/web-editor-dark.png" className="hidden dark:block" />
+  <img alt="The Mintlify web editor in the visual editor mode" src="/images/quickstart/web-editor-light.png" className="block dark:hidden" />
+  <img alt="The Mintlify web editor in the visual editor mode" src="/images/quickstart/web-editor-dark.png" className="hidden dark:block" />
 </Frame>
 
 ### Edit the Documentation

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -61,7 +61,7 @@ You can install the GitHub App by following the instructions from the onboarding
   You may need an admin for your GitHub organization to authorize your account depending on your organization's settings.
 </Info>
 
-## Development Workflows
+## Mintlify Workflows
 
 Mintlify offers two different workflows for creating and maintaining your documentation.
 


### PR DESCRIPTION
This PR updates https://mintlify.com/docs/quickstart

Summary of changes:
* Move info on installing the GitHub App to Getting Started section since its relevant to both workflows
* Add section on authorizing your GitHub account, including that you may need an admin to approve
* Change `Development Workflows` to `Mintlify Workflows` since it seems more meaningful to more users