### PR TITLE
Information architecture update

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -28,17 +28,14 @@
             ]
           },
           {
-            "group": "Customization",
+            "group": "Core configuration",
             "pages": [
               "settings",
               "pages",
               "navigation",
               "themes",
               "settings/custom-domain",
-              "react-components",
-              "settings/custom-scripts",
-              "ai-ingestion",
-              "translations"
+              "ai-ingestion"
             ]
           },
           {
@@ -135,6 +132,9 @@
             "pages": [
               "guides/migration",
               "mcp",
+              "translations",
+              "react-components",
+              "settings/custom-scripts",
               "settings/seo",
               "settings/broken-links",
               {

--- a/docs.json
+++ b/docs.json
@@ -28,7 +28,7 @@
             ]
           },
           {
-            "group": "Customizing your docs",
+            "group": "Customization",
             "pages": [
               "settings",
               "pages",
@@ -68,7 +68,7 @@
             ]
           },
           {
-            "group": "API Pages",
+            "group": "API pages",
             "pages": [
               "api-playground/overview",
               {

--- a/docs.json
+++ b/docs.json
@@ -19,7 +19,7 @@
         "description": "Set up your documentation",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Getting started",
             "pages": [
               "index",
               "quickstart",
@@ -28,14 +28,17 @@
             ]
           },
           {
-            "group": "Core Concepts",
+            "group": "Customizing your docs",
             "pages": [
               "settings",
               "pages",
               "navigation",
               "themes",
+              "settings/custom-domain",
               "react-components",
-              "ai-ingestion"
+              "settings/custom-scripts",
+              "ai-ingestion",
+              "translations"
             ]
           },
           {
@@ -96,73 +99,42 @@
               "api-playground/troubleshooting"
             ]
           },
-          {
-            "group": "Guides",
+          { 
+            "group": "Authentication and personalization",
             "pages": [
-              "guides/migration"
+              "settings/authentication-personalization/authentication",
+              "settings/authentication-personalization/partial-authentication",
+              "settings/authentication-personalization/personalization",
+              "settings/authentication-personalization/authentication-vs-personalization",
+              {
+                "group": "Authentication Setup",
+                "pages": [
+                  "settings/authentication-personalization/authentication-setup/choosing-a-handshake",
+                  "settings/authentication-personalization/authentication-setup/password",
+                  "settings/authentication-personalization/authentication-setup/jwt",
+                  "settings/authentication-personalization/authentication-setup/oauth",
+                  "settings/authentication-personalization/authentication-setup/mintlify"
+                ]
+              },
+              {
+                "group": "Personalization Setup",
+                "pages": [
+                  "settings/authentication-personalization/personalization-setup/choosing-a-handshake",
+                  "settings/authentication-personalization/personalization-setup/shared-session",
+                  "settings/authentication-personalization/personalization-setup/jwt",
+                  "settings/authentication-personalization/personalization-setup/oauth"
+                ]
+              },
+              "settings/authentication-personalization/sending-data"
             ]
           },
           {
-            "group": "Deep Dive",
+            "group": "Guides",
             "pages": [
-              "settings/custom-domain",
+              "guides/migration",
+              "mcp",
               "settings/seo",
               "settings/broken-links",
-              "settings/github",
-              "settings/gitlab",
-              "settings/ci",
-              "settings/preview-deployments",
-              "settings/custom-scripts",
-              "mcp",
-              "translations",
-              {
-                "group": "Integrations",
-                "icon": "blocks",
-                "pages": [
-                  {
-                    "group": "Analytics",
-                    "pages": [
-                      "integrations/analytics/overview",
-                      "integrations/analytics/amplitude",
-                      "integrations/analytics/clearbit",
-                      "integrations/analytics/fathom",
-                      "integrations/analytics/google-analytics",
-                      "integrations/analytics/google-tag-manager",
-                      "integrations/analytics/heap",
-                      "integrations/analytics/hotjar",
-                      "integrations/analytics/koala",
-                      "integrations/analytics/logrocket",
-                      "integrations/analytics/mixpanel",
-                      "integrations/analytics/pirsch",
-                      "integrations/analytics/plausible",
-                      "integrations/analytics/posthog",
-                      "integrations/analytics/segment"
-                    ]
-                  },
-                  {
-                    "group": "SDKs",
-                    "pages": [
-                      "integrations/sdks/speakeasy",
-                      "integrations/sdks/stainless"
-                    ]
-                  },
-                  {
-                    "group": "Support",
-                    "pages": [
-                      "integrations/support/overview",
-                      "integrations/support/intercom",
-                      "integrations/support/front"
-                    ]
-                  },
-                  {
-                    "group": "Privacy",
-                    "pages": [
-                      "integrations/privacy/overview",
-                      "integrations/privacy/osano"
-                    ]
-                  }
-                ]
-              },
               {
                 "group": "Custom Subdirectory",
                 "icon": "folder",
@@ -170,36 +142,6 @@
                   "advanced/subpath/cloudflare",
                   "advanced/subpath/route53-cloudfront",
                   "advanced/subpath/vercel"
-                ]
-              },
-              {
-                "group": "Auth & Personalization",
-                "icon": "user",
-                "pages": [
-                  "settings/authentication-personalization/authentication",
-                  "settings/authentication-personalization/partial-authentication",
-                  "settings/authentication-personalization/personalization",
-                  "settings/authentication-personalization/authentication-vs-personalization",
-                  {
-                    "group": "Authentication Setup",
-                    "pages": [
-                      "settings/authentication-personalization/authentication-setup/choosing-a-handshake",
-                      "settings/authentication-personalization/authentication-setup/password",
-                      "settings/authentication-personalization/authentication-setup/jwt",
-                      "settings/authentication-personalization/authentication-setup/oauth",
-                      "settings/authentication-personalization/authentication-setup/mintlify"
-                    ]
-                  },
-                  {
-                    "group": "Personalization Setup",
-                    "pages": [
-                      "settings/authentication-personalization/personalization-setup/choosing-a-handshake",
-                      "settings/authentication-personalization/personalization-setup/shared-session",
-                      "settings/authentication-personalization/personalization-setup/jwt",
-                      "settings/authentication-personalization/personalization-setup/oauth"
-                    ]
-                  },
-                  "settings/authentication-personalization/sending-data"
                 ]
               },
               {
@@ -212,6 +154,62 @@
 
                 ]
               }
+            ]
+          },
+          {
+            "group": "Integrations",
+            "pages": [
+              {
+                "group": "Analytics",
+                "pages": [
+                  "integrations/analytics/overview",
+                  "integrations/analytics/amplitude",
+                  "integrations/analytics/clearbit",
+                  "integrations/analytics/fathom",
+                  "integrations/analytics/google-analytics",
+                  "integrations/analytics/google-tag-manager",
+                  "integrations/analytics/heap",
+                  "integrations/analytics/hotjar",
+                  "integrations/analytics/koala",
+                  "integrations/analytics/logrocket",
+                  "integrations/analytics/mixpanel",
+                  "integrations/analytics/pirsch",
+                  "integrations/analytics/plausible",
+                  "integrations/analytics/posthog",
+                  "integrations/analytics/segment"
+                ]
+              },
+              {
+                "group": "SDKs",
+                "pages": [
+                  "integrations/sdks/speakeasy",
+                  "integrations/sdks/stainless"
+                ]
+              },
+              {
+                "group": "Support",
+                "pages": [
+                  "integrations/support/overview",
+                  "integrations/support/intercom",
+                  "integrations/support/front"
+                ]
+              },
+              {
+                "group": "Privacy",
+                "pages": [
+                  "integrations/privacy/overview",
+                  "integrations/privacy/osano"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Version control & CI/CD",
+            "pages": [
+            "settings/github",
+              "settings/gitlab",
+              "settings/ci",
+              "settings/preview-deployments"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -19,7 +19,7 @@
         "description": "Set up your documentation",
         "groups": [
           {
-            "group": "Getting started",
+            "group": "Getting Started",
             "pages": [
               "index",
               "quickstart",
@@ -28,7 +28,7 @@
             ]
           },
           {
-            "group": "Core configuration",
+            "group": "Core Configuration",
             "pages": [
               "settings",
               "pages",
@@ -65,7 +65,7 @@
             ]
           },
           {
-            "group": "API pages",
+            "group": "API Pages",
             "pages": [
               "api-playground/overview",
               {
@@ -97,7 +97,7 @@
             ]
           },
           { 
-            "group": "Authentication and personalization",
+            "group": "Authentication and Personalization",
             "pages": [
               "settings/authentication-personalization/authentication",
               "settings/authentication-personalization/partial-authentication",
@@ -210,7 +210,7 @@
             ]
           },
           {
-            "group": "Version control & CI/CD",
+            "group": "Version Control and CI/CD",
             "pages": [
             "settings/github",
               "settings/gitlab",

--- a/docs.json
+++ b/docs.json
@@ -108,6 +108,7 @@
               "settings/authentication-personalization/authentication-vs-personalization",
               {
                 "group": "Authentication Setup",
+                "icon": "file-cog",
                 "pages": [
                   "settings/authentication-personalization/authentication-setup/choosing-a-handshake",
                   "settings/authentication-personalization/authentication-setup/password",
@@ -118,6 +119,7 @@
               },
               {
                 "group": "Personalization Setup",
+                "icon": "user-cog",
                 "pages": [
                   "settings/authentication-personalization/personalization-setup/choosing-a-handshake",
                   "settings/authentication-personalization/personalization-setup/shared-session",
@@ -161,6 +163,7 @@
             "pages": [
               {
                 "group": "Analytics",
+                "icon": "chart-no-axes-combined",
                 "pages": [
                   "integrations/analytics/overview",
                   "integrations/analytics/amplitude",
@@ -181,6 +184,7 @@
               },
               {
                 "group": "SDKs",
+                "icon": "folder-code",
                 "pages": [
                   "integrations/sdks/speakeasy",
                   "integrations/sdks/stainless"
@@ -188,6 +192,7 @@
               },
               {
                 "group": "Support",
+                "icon": "messages-square",
                 "pages": [
                   "integrations/support/overview",
                   "integrations/support/intercom",
@@ -196,6 +201,7 @@
               },
               {
                 "group": "Privacy",
+                "icon": "folder-lock",
                 "pages": [
                   "integrations/privacy/overview",
                   "integrations/privacy/osano"

--- a/settings/authentication-personalization/authentication-vs-personalization.mdx
+++ b/settings/authentication-personalization/authentication-vs-personalization.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Auth vs Personalization'
-description: 'How to determine which product is best for you'
+title: "Auth vs Personalization"
+description: "How to determine which product is best for you"
+icon: "arrow-right-left"
 ---
 
 Mintlify offers both Authentication and Personalization. For the most part, Authentication is

--- a/settings/authentication-personalization/authentication.mdx
+++ b/settings/authentication-personalization/authentication.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Authentication"
 description: "Guarantee privacy of your docs by authenticating users"
+icon: "file-lock"
 ---
 
 <Info>

--- a/settings/authentication-personalization/partial-authentication.mdx
+++ b/settings/authentication-personalization/partial-authentication.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Partial Authentication"
 description: "Authenticate users to view only certain pages"
+icon: "file-lock-2"
 ---
 
 Partial Authentication allows you to authenticate users to view only certain pages.

--- a/settings/authentication-personalization/personalization.mdx
+++ b/settings/authentication-personalization/personalization.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Personalization"
 description: "A list of features unlocked with Personalization"
+icon: "user-pen"
 ---
 
 Personalization refers to a suite of features that allow you to customize your

--- a/settings/authentication-personalization/sending-data.mdx
+++ b/settings/authentication-personalization/sending-data.mdx
@@ -1,6 +1,7 @@
 ---
-title: 'Sending Data'
-description: 'The shape of user data you can use to personalize your docs'
+title: "Sending Data"
+description: "The shape of user data you can use to personalize your docs"
+icon: "send"
 ---
 
 Depending on your Handshake method, your API will respond with either a raw JSON object or a signed JWT. The shape of the data is the same for both:


### PR DESCRIPTION
This PR updates the labels and grouping of content in `docs.json`.

Goal is to group content with meaningful labels and reduce the layers of nesting (for example, integrations go from navigating three levels deep to two levels).

Summary of changes:
* "Core Concepts" -> "Core Configuration": make it more task-based. People need to configure these aspects of their docs, not just learn concepts
* Add more pages to "Guides": content that are discrete tasks people may or may not need to do. Compared to core configurations which we'd expect everyone to do no matter their circumstances
* Make "Integrations", "Authentication and Personalization", and "Version Control and CI/CD" their own groups
* Add icons for pages and groups that didn't have them

I'd originally changed group titles to sentence case, but since this should be site-wide I'm saving it for a future PR. That way it can all be done at once and we don't have a mix of some sentence case and some title case.