### PR TITLE
Improvement: columns & cards

### DIFF
--- a/components/cards.mdx
+++ b/components/cards.mdx
@@ -25,15 +25,15 @@ icon: 'square-mouse-pointer'
 
 </RequestExample>
 
-### Horizontal Card
+## Horizontal card
 
-Add a `horizontal` property to make it horizontally displayed.
+Add a `horizontal` property to display cards horizontally.
 
 <Card title="Horizontal Card" icon="text" horizontal>
   Here is an example of a horizontal card
 </Card>
 
-### Image Card
+## Image card
 
 Add an `img` property to display an image on the top of the card.
 
@@ -41,7 +41,7 @@ Add an `img` property to display an image on the top of the card.
   Here is an example of a card with an image
 </Card>
 
-### Link Card
+## Link card
 
 You can customize the CTA and whether or not to display the arrow on the card. By default, the arrow will only show for external links.
 
@@ -71,7 +71,20 @@ You can customize the CTA and whether or not to display the arrow on the card. B
   ```
 </RequestExample>
 
-### Props
+## Grouping cards
+
+You can group cards in [columns](/components/columns).
+
+<Columns cols={2}>
+  <Card title="First Card" icon="panel-left-close">
+    This is the first card.
+  </Card>
+  <Card title="Second Card" icon="panel-right-close">
+    This is the second card.
+  </Card>
+</Columns>
+
+## Props
 
 <ResponseField name="title" type="string" required>
   The title of the card

--- a/components/columns.mdx
+++ b/components/columns.mdx
@@ -2,6 +2,7 @@
 title: 'Columns'
 description: 'Show cards side by side in a grid format'
 icon: 'columns-2'
+keywords: ['card groups']
 ---
 
 The `Columns` component lets you group multiple `Card` components together. It's most often used to put multiple cards in a grid, by specifying the number of grid columns.


### PR DESCRIPTION
This PR makes two improvements to connect cards ad columns.

* Add a section and link in cards page to columns
* Add `keywords: ['card groups']` to the columns frontmatter to support anyone who is searching the old name for this feature


Closes https://linear.app/mintlify/issue/DOC-31/improvement-columns