### PR TITLE
Improvement: GitHub app permissions

### DIFF
--- a/settings/github.mdx
+++ b/settings/github.mdx
@@ -30,7 +30,7 @@ your docs are hosted.
 
 When you install the GitHub app, you will be prompted to grant the following permissions:
 
-- **Read** access to `metadata`.
+- **Read** access to `metadata`
 - **Read** and **write** access to `checks`, `code`, `deployments`, `pull requests`,
   and `workflows`
 


### PR DESCRIPTION
This PR updates https://mintlify.com/docs/settings/github#permissions to include the correct permissions that our GH app requests. Current page is inaccurate.

Closes https://github.com/mintlify/docs/issues/285