### PR TITLE
Fix broken link in SEO

### DIFF
--- a/settings/seo.mdx
+++ b/settings/seo.mdx
@@ -6,9 +6,7 @@ icon: 'search'
 
 The platform automatically generates most meta tags.
 
-However, you can fully customize them by adding the [metadata](settings#param-metadata) field to your `docs.json` or the page's frontmatter.
-
-
+However, you can fully customize them by adding the `metatags` field to your `docs.json` or the page's frontmatter.
 
 ## Global meta tags
 


### PR DESCRIPTION
SEO has a broken link. We can just tell people in the SEO page what property to use (`metatags`) instead of linking to another article.