### PR TITLE
Document auto-expand setting for API parameters

### DIFF
--- a/settings.mdx
+++ b/settings.mdx
@@ -522,6 +522,15 @@ This section contains the full reference for the docs.json file.
         </ResponseField>
       </Expandable>
     </ResponseField>
+    <ResponseField name="params" type="object">
+      Configurations for the API parameters
+
+      <Expandable title="Params">
+        <ResponseField name="expanded" type="&quot;all&quot; | &quot;closed&quot;">
+          The view mode of expandable API parameters. Defaults to `closed`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
     <ResponseField name="playground" type="object">
       Configurations for the API playground
 


### PR DESCRIPTION
This PR documents that you can configure parameter fields to auto-expand and that they default to being closed.

Closes https://linear.app/mintlify/issue/DOC-42/document-auto-expand-param-fields-option