### PR TITLE
Document switch from Prism to Shiki for syntax highlighting

### DIFF
--- a/code.mdx
+++ b/code.mdx
@@ -40,9 +40,7 @@ class HelloWorld {
 
 ## Syntax Highlighting
 
-Put the name of your programming language after the three backticks to get syntax highlighting.
-
-We use [Prism](https://prismjs.com/#supported-languages) for syntax highlighting. [Test Drive Prism](https://prismjs.com/test.html#language=markup) lists all the languages supported.
+Enable syntax highlighting by adding the language name after the opening backticks of a code snippet.
 
 ```java
 class HelloWorld {
@@ -61,6 +59,8 @@ class HelloWorld {
 }
 ```
 ````
+
+We use [Shiki](https://shiki.style/guide) for syntax highlighting and support all available [languages](https://shiki.style/languages).
 
 ## Names
 


### PR DESCRIPTION
This PR updates https://mintlify.com/docs/code#syntax-highlighting since we now use Shiki for syntax highlighting.