### PR TITLE
Note to not use trailing slash in monorepo setup

### DIFF
--- a/guides/monorepo.mdx
+++ b/guides/monorepo.mdx
@@ -34,7 +34,10 @@ Navigate to [Git Settings](https://dashboard.mintlify.com/settings/deployment/gi
 </Step>
 <Step title="Set your documentation path">
 1. Select the **Set up as monorepo** toggle button.
-2. Enter the relative path to your docs directory.
+2. Enter the relative path to your docs directory. For example, if your docs are in the `docs` directory, enter `/docs`.
+<Note>
+  Do not include a trailing slash in the path.
+</Note>
 3. Select **Save changes**.
 </Step>
 </Steps>


### PR DESCRIPTION
## Documentation changes

This PR adds a note to not use a trailing slash when setting up a monorepo since it'll cause errors.

Closes https://linear.app/mintlify/issue/DOC-35/add-a-callout-that-a-trailing-slash-in-the-content-directory-is

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
