### PR TITLE
Update mint update docs

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -74,19 +74,13 @@ pnpm dlx mint dev
 
 ## Updates
 
-You can update the client and CLI versions independently.
-
-### Client version
-
-If your local preview is out of sync with the production version, update your client version:
+If your local preview is out of sync with what you see on the web in the production version, update your local CLI:
 
 ```bash
 mint update
 ```
 
-### CLI version
-
-Update the CLI to the latest version:
+If this `mint update` command is not available on your local version, re-install the CLI with the latest version:
 
 <CodeGroup>
 
@@ -170,10 +164,5 @@ If you use JetBrains, we recommend the [MDX IntelliJ IDEA plugin](https://plugin
   </Accordion>
   <Accordion title="Issue: Encountering an unknown error">
     Solution: Go to the root of your device and delete the `~/.mintlify` folder. Afterwards, run `mint dev` again.
-  </Accordion>
-  <Accordion title="Issue: The update command is not available">
-    If running `mint update` returns the command menu, your current version of the CLI does not include the `update` command.
-    
-    Use `npm i -g mint@latest` to update the CLI.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Documentation changes

This PR removes the difference between CLI and client in our docs, since customers don't know/care that we package the client in the CLI under the hood. Running `mint update` updates both. It also moves the troubleshooting command to re-install the CLI at the latest version locally up the page with the code group that has npm/yarn/pnpm versions of the command.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
