### PR TITLE
fix example with languages

### DIFF
--- a/settings.mdx
+++ b/settings.mdx
@@ -25,7 +25,7 @@ For the best editing experience, include the schema reference at the top of your
   },
   "navigation": {
     // Your navigation structure
-  },
+  }
   // The rest of your configuration
 }
 ```
@@ -39,9 +39,10 @@ This section contains the full reference for the `docs.json` file.
 <ResponseField name="theme" required>
   The layout theme of your site.
 
-  One of the following: `mint`, `maple`, `palm`, `willow`, `linden`, `almond`.
-  
-  See [Themes](themes) for more information.
+One of the following: `mint`, `maple`, `palm`, `willow`, `linden`, `almond`.
+
+See [Themes](themes) for more information.
+
 </ResponseField>
 
 <ResponseField name="name" type="string" required>
@@ -135,6 +136,7 @@ This section contains the full reference for the `docs.json` file.
       You can specify a URL for any individual icon, regardless of the library setting.
     </Note>
     </ResponseField>
+
   </Expandable>
 </ResponseField>
 
@@ -232,12 +234,12 @@ This section contains the full reference for the `docs.json` file.
       <Expandable title="Color">
         <ResponseField name="light" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
           Background color for light mode.
-          
+
           Must be a hex code beginning with `#`.
         </ResponseField>
         <ResponseField name="dark" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
           Background color for dark mode.
-          
+
           Must be a hex code beginning with `#`.
         </ResponseField>
       </Expandable>
@@ -370,12 +372,12 @@ This section contains the full reference for the `docs.json` file.
               <Expandable title="Color">
                 <ResponseField name="light" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
                   Anchor color for light mode.
-                  
+
                   Must be a hex code beginning with `#`.
                 </ResponseField>
                 <ResponseField name="dark" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
                   Anchor color for dark mode.
-                  
+
                   Must be a hex code beginning with `#`.
                 </ResponseField>
               </Expandable>
@@ -391,7 +393,7 @@ This section contains the full reference for the `docs.json` file.
 
         <ResponseField name="dropdowns" type="array of object">
           Dropdown menus for organizing related content.
-          
+
           <Expandable title="Dropdowns">
             <ResponseField name="dropdown" type="string" required>
               Display name of the dropdown.
@@ -522,7 +524,7 @@ This section contains the full reference for the `docs.json` file.
 </ResponseField>
 
 <ResponseField name="contextual" type="object">
-  Contextual menu for AI-optimized content and integrations. 
+  Contextual menu for AI-optimized content and integrations.
 
   <Expandable title="Contextual">
     <ResponseField name="options" type="array of &quot;copy&quot; | &quot;view&quot; | &quot;chatgpt&quot; | &quot;claude&quot;" required>
@@ -538,6 +540,7 @@ This section contains the full reference for the `docs.json` file.
         The contextual menu is only available on preview and production deployments.
       </Note>
     </ResponseField>
+
   </Expandable>
 </ResponseField>
 
@@ -553,12 +556,12 @@ This section contains the full reference for the `docs.json` file.
       <Expandable title="Openapi">
         <ResponseField name="source" type="string">
           URL or path to your OpenAPI specification file.
-          
+
           Minimum length: 1
         </ResponseField>
         <ResponseField name="directory" type="string">
           Directory to search for OpenAPI files.
-          
+
           Do not include a leading slash.
         </ResponseField>
       </Expandable>
@@ -574,7 +577,7 @@ This section contains the full reference for the `docs.json` file.
         </ResponseField>
         <ResponseField name="directory" type="string">
           Directory to search for AsyncAPI files.
-          
+
           Do not include a leading slash.
         </ResponseField>
       </Expandable>
@@ -679,7 +682,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="clearbit" type="object">
       Clearbit data enrichment integration.
-      
+
       <Expandable title="Clearbit">
         <ResponseField name="publicApiKey" type="string" required>
           Your Clearbit API key.
@@ -688,7 +691,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="fathom" type="object">
       Fathom analytics integration.
-      
+
       <Expandable title="Fathom">
         <ResponseField name="siteId" type="string" required>
           Your Fathom site ID.
@@ -697,7 +700,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="frontchat" type="object">
       Front chat integration.
-      
+
       <Expandable title="Frontchat">
         <ResponseField name="snippetId" type="string" required>
           Your Front chat snippet ID.
@@ -708,29 +711,29 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="ga4" type="object">
       Google Analytics 4 integration.
-      
+
       <Expandable title="Ga4">
         <ResponseField name="measurementId" type="string matching ^G" required>
           Your Google Analytics 4 measurement ID.
-          
+
           Must match pattern: ^G
         </ResponseField>
       </Expandable>
     </ResponseField>
     <ResponseField name="gtm" type="object">
       Google Tag Manager integration.
-      
+
       <Expandable title="Gtm">
         <ResponseField name="tagId" type="string matching ^G" required>
           Your Google Tag Manager tag ID.
-          
+
           Must match pattern: ^G
         </ResponseField>
       </Expandable>
     </ResponseField>
     <ResponseField name="heap" type="object">
       Heap analytics integration.
-      
+
       <Expandable title="Heap">
         <ResponseField name="appId" type="string" required>
           Your Heap app ID.
@@ -739,7 +742,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="hotjar" type="object">
       Hotjar integration.
-      
+
       <Expandable title="Hotjar">
         <ResponseField name="hjid" type="string" required>
           Your Hotjar ID.
@@ -751,29 +754,29 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="intercom" type="object">
       Intercom integration.
-      
+
       <Expandable title="Intercom">
         <ResponseField name="appId" type="string" required>
           Your Intercom app ID.
-          
+
           Minimum length: 6
         </ResponseField>
       </Expandable>
     </ResponseField>
     <ResponseField name="koala" type="object">
       Koala integration.
-      
+
       <Expandable title="Koala">
         <ResponseField name="publicApiKey" type="string" required>
           Your Koala public API key.
-          
+
           Minimum length: 2
         </ResponseField>
       </Expandable>
     </ResponseField>
     <ResponseField name="logrocket" type="object">
       LogRocket integration.
-      
+
       <Expandable title="Logrocket">
         <ResponseField name="appId" type="string" required>
           Your LogRocket app ID.
@@ -791,7 +794,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="osano" type="object">
       Osano integration.
-      
+
       <Expandable title="Osano">
         <ResponseField name="scriptSource" type="string" required>
           Your Osano script source.
@@ -800,7 +803,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="pirsch" type="object">
       Pirsch analytics integration.
-      
+
       <Expandable title="Pirsch">
         <ResponseField name="id" type="string" required>
           Your Pirsch ID.
@@ -809,11 +812,11 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="posthog" type="object">
       PostHog integration.
-      
+
       <Expandable title="Posthog">
         <ResponseField name="apiKey" type="string matching ^phc\_" required>
           Your PostHog API key.
-          
+
           Must match pattern: ^phc\_
         </ResponseField>
         <ResponseField name="apiHost" type="string (uri)">
@@ -823,7 +826,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="plausible" type="object">
       Plausible analytics integration.
-      
+
       <Expandable title="Plausible">
         <ResponseField name="domain" type="string" required>
           Your Plausible domain.
@@ -835,7 +838,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="segment" type="object">
       Segment integration.
-      
+
       <Expandable title="Segment">
         <ResponseField name="key" type="string" required>
           Your Segment key.
@@ -844,7 +847,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="telemetry" type="object">
       Telemetry settings.
-      
+
       <Expandable title="Telemetry">
         <ResponseField name="enabled" type="boolean">
           Whether to enable telemetry.
@@ -853,7 +856,7 @@ This section contains the full reference for the `docs.json` file.
     </ResponseField>
     <ResponseField name="cookies" type="object">
       Cookie settings.
-      
+
       <Expandable title="Cookies">
         <ResponseField name="key" type="string">
           Key for cookies.
@@ -863,6 +866,7 @@ This section contains the full reference for the `docs.json` file.
         </ResponseField>
       </Expandable>
     </ResponseField>
+
   </Expandable>
 </ResponseField>
 
@@ -870,14 +874,13 @@ This section contains the full reference for the `docs.json` file.
 
 <ResponseField name="errors" type="object">
   Error handling settings.
-  
   <Expandable title="Errors">
     <ResponseField name="404" type="object">
       404 "Page not found" error handling.
-      
       <Expandable title="404">
         <ResponseField name="redirect" type="boolean">
-          Whether to automatically redirect to the home page when a page is not found.
+          Whether to automatically redirect to the home page when a page is not
+          found.
         </ResponseField>
       </Expandable>
     </ResponseField>
@@ -1209,7 +1212,7 @@ This section contains the full reference for the `docs.json` file.
     ```
   </Tab>
   <Tab title="Multi-language example">
-    ```json title="docs.json" wrap lines highlight={13-31}
+    ```json title="docs.json" wrap lines
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1222,66 +1225,87 @@ This section contains the full reference for the `docs.json` file.
       },
       "navigation": {
         "global": {
-          "languages": [
+          "anchors": [
             {
-              "language": "en",
-              "default": true,
-              "href": "/en"
+              "anchor": "Documentation",
+              "href": "https://mintlify.com/docs"
             },
             {
-              "language": "es",
-              "href": "/es"
-            },
-            {
-              "language": "pt-BR",
-              "href": "/pt-BR"
-            },
-            {
-              "language": "ko",
-              "href": "/ko"
-            }
-          ],
-          "dropdowns": [
-            {
-              "dropdown": "Documentation",
-              "icon": "book",
-              "description": "How to use the Example Co. product",
-              "groups": [
-                {
-                  "group": "Getting started",
-                  "pages": [
-                    "index",
-                    "quickstart"
-                  ]
-                },
-                {
-                  "group": "Customization",
-                  "pages": [
-                    "settings",
-                    "users",
-                    "features"
-                  ]
-                },
-                {
-                  "group": "Billing",
-                  "pages": [
-                    "billing/overview",
-                    "billing/payments",
-                    "billing/subscriptions"
-                  ]
-                }
-              ]
-            },
-            {
-              "dropdown": "Changelog",
-              "icon": "history",
-              "description": "Updates and changes",
-              "pages": [
-                "changelog"
-              ]
+              "anchor": "Changelog",
+              "href": "https://mintlify.com/docs/changelog"
             }
           ]
-        }
+        },
+        "languages": [ // [!code highlight:3]
+          {
+            "language": "en",
+            "dropdowns": [
+              {
+                "dropdown": "Documentation",
+                "icon": "book",
+                "description": "How to use the Example Co. product",
+                "pages": [
+                  {
+                    "group": "Getting started",
+                    "pages": ["index", "quickstart"]
+                  },
+                  {
+                    "group": "Customization",
+                    "pages": ["settings", "users", "features"]
+                  },
+                  {
+                    "group": "Billing",
+                    "pages": [
+                      "billing/overview",
+                      "billing/payments",
+                      "billing/subscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "dropdown": "Changelog",
+                "icon": "history",
+                "description": "Updates and changes",
+                "pages": ["changelog"]
+              }
+            ]
+          },
+          {
+            "language": "es",// [!code highlight]
+            "dropdowns": [
+              {
+                "dropdown": "Documentación",
+                "icon": "book",
+                "description": "Cómo usar el producto de Example Co.",
+                "pages": [
+                  {
+                    "group": "Comenzando",
+                    "pages": ["es/index", "es/quickstart"]
+                  },
+                  {
+                    "group": "Personalización",
+                    "pages": ["es/settings", "es/users", "es/features"]
+                  },
+                  {
+                    "group": "Billing",
+                    "pages": [
+                      "es/billing/overview",
+                      "es/billing/payments",
+                      "es/billing/subscriptions"
+                    ]
+                  }
+                ]
+              },
+              {
+                "dropdown": "Changelog",
+                "icon": "history",
+                "description": "Actualizaciones y cambios",
+                "pages": ["es/changelog"]
+              }
+            ]
+          }
+        ]
       },
       "logo": {
         "light": "/logo-light.svg",
@@ -1361,12 +1385,7 @@ This section contains the full reference for the `docs.json` file.
         }
       },
       "contextual": {
-        "options": [
-          "copy",
-          "view",
-          "chatgpt",
-          "claude"
-        ]
+        "options": ["copy", "view", "chatgpt", "claude"]
       },
       "errors": {
         "404": {


### PR DESCRIPTION
## Documentation changes
Docs.json example with multiple languages is incorrect and misleading. This pr addresses this issue.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
