### PR TITLE
Clarify that auth restricts MCP server generation

### DIFF
--- a/mcp.mdx
+++ b/mcp.mdx
@@ -8,7 +8,7 @@ icon: 'audio-waveform'
 
 The Model Context Protocol (MCP) is an open protocol that connects your functions to LLMs and AI applications. With Mintlify's integration, you can automatically generate an MCP server from your existing documentation or OpenAPI specifications, enabling seamless AI-powered interactions with your product.
 
-## Quick Usage Guide
+## Quick usage guide
 
 Any public documentation hosted on Mintlify can be extracted as an MCP server using a simple command:
 
@@ -36,7 +36,7 @@ These can be found in your [Mintlify Dashboard](https://dashboard.mintlify.com/s
   <img src="/images/mcp/mcp-terminal.png" alt="API Keys" />
 </Frame>
 
-### Select MCP Clients
+### Select MCP clients
 
 After authentication, you'll choose which MCP clients to enable for your server:
 
@@ -46,19 +46,19 @@ After authentication, you'll choose which MCP clients to enable for your server:
 
 Once configured, your MCP server is ready to use with the command provided in the terminal.
 
-## Configuring Your MCP Server
+## Configuring your MCP server
 
 Now let's take a look at how to configure your MCP server.
 
-### Default Functionality
+### Default functionality
 
 All MCP servers include the `search` tool by default, allowing users to query information across your entire documentation.
 
-### Adding API Functions
+### Adding API functions
 
 If you have an OpenAPI specification, you can expose specific endpoints as MCP tools by using the `x-mcp` extension at either the file or endpoint level.
 
-#### File-Level Configuration
+#### File-level configuration
 
 Enable MCP for all endpoints in a specification file:
 
@@ -72,7 +72,7 @@ Enable MCP for all endpoints in a specification file:
 }
 ```
 
-#### Endpoint-Level Configuration
+#### Endpoint-level configuration
 
 Enable MCP for specific endpoints only:
 
@@ -89,11 +89,11 @@ Enable MCP for specific endpoints only:
 }
 ```
 
-### Authentication Handling
+### Authentication handling
 
 If your OpenAPI spec defines authentication using securitySchemes, these authentication methods will be automatically applied to your MCP server.
 
-### Monitoring Your MCP Server
+### Monitoring your MCP server
 
 After publishing your changes, you can view all available MCP tools in the **Available Tools** section on the MCP server page in your dashboard.
 
@@ -104,7 +104,7 @@ After publishing your changes, you can view all available MCP tools in the **Ava
 
 ## Distribution
 
-### User Installation
+### User installation
 
 Your users can install and use your MCP server with:
 

--- a/mcp.mdx
+++ b/mcp.mdx
@@ -10,7 +10,7 @@ The Model Context Protocol (MCP) is an open protocol that connects your function
 
 ## Quick usage guide
 
-Any public documentation hosted on Mintlify can be extracted as an MCP server using a simple command:
+Any public documentation hosted on Mintlify can be extracted as an MCP server using the following command:
 
 ```bash
 npx mint-mcp add <your-subdomain-or-domain>
@@ -30,10 +30,10 @@ npx mint-mcp add mintlify.com
 
 When you run the command, you'll need to provide two API keys, `External Admin Key` and `Assistant API Key`.
 
-These can be found in your [Mintlify Dashboard](https://dashboard.mintlify.com/settings/organization/api-keys) under **Settings > API Keys**.
+These can be found in your [dashboard](https://dashboard.mintlify.com/settings/organization/api-keys) under **Settings > API Keys**.
 
 <Frame>
-  <img src="/images/mcp/mcp-terminal.png" alt="API Keys" />
+  <img src="/images/mcp/mcp-terminal.png" alt="Terminal prompt asking What is the Bearer Token for Mintlify External API?" />
 </Frame>
 
 ### Select MCP clients
@@ -41,7 +41,7 @@ These can be found in your [Mintlify Dashboard](https://dashboard.mintlify.com/s
 After authentication, you'll choose which MCP clients to enable for your server:
 
 <Frame>
-  <img src="/images/mcp/mcp-terminal-completed.png" alt="MCP Clients" />
+  <img src="/images/mcp/mcp-terminal-completed.png" alt="MCP Clients listed in the terminal." />
 </Frame>
 
 Once configured, your MCP server is ready to use with the command provided in the terminal.
@@ -91,15 +91,15 @@ Enable MCP for specific endpoints only:
 
 ### Authentication handling
 
-If your OpenAPI spec defines authentication using securitySchemes, these authentication methods will be automatically applied to your MCP server.
+If your OpenAPI spec defines authentication using `securitySchemes`, these authentication methods will be automatically applied to your MCP server.
 
 ### Monitoring your MCP server
 
 After publishing your changes, you can view all available MCP tools in the **Available Tools** section on the MCP server page in your dashboard.
 
 <Frame>
-  <img src="/images/mcp/mcp-server-page-light.png" alt="MCP Dashboard" class="block dark:hidden" />
-  <img src="/images/mcp/mcp-server-page-dark.png" alt="MCP Dashboard" class="hidden dark:block" />
+  <img src="/images/mcp/mcp-server-page-light.png" alt="MCP dashboard with Available tools section emphasized" class="block dark:hidden" />
+  <img src="/images/mcp/mcp-server-page-dark.png" alt="MCP dashboard with Available tools section emphasized" class="hidden dark:block" />
 </Frame>
 
 ## Distribution

--- a/mcp.mdx
+++ b/mcp.mdx
@@ -8,9 +8,13 @@ icon: 'audio-waveform'
 
 The Model Context Protocol (MCP) is an open protocol that connects your functions to LLMs and AI applications. With Mintlify's integration, you can automatically generate an MCP server from your existing documentation or OpenAPI specifications, enabling seamless AI-powered interactions with your product.
 
-## Quick usage guide
+<Note>
+  MCP servers can only be generated for public documentation. Documentation behind end-user authentication cannot be accessed for server generation.
+</Note>
 
-Any public documentation hosted on Mintlify can be extracted as an MCP server using the following command:
+## Generating your MCP server
+
+Public documentation hosted on Mintlify can be extracted as an MCP server using the following command:
 
 ```bash
 npx mint-mcp add <your-subdomain-or-domain>


### PR DESCRIPTION
## Documentation changes

This adds a note to https://mintlify.com/docs/mcp about how authentication restricts MCP server generation. Also makes some general copyedits to the page.

Closes https://linear.app/mintlify/issue/DOC-76/add-a-callout-to-the-mcp-page-on-the-dashboard-that-enabling-auth

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
