### PR TITLE
add auth keyword to auth pages

### DIFF
--- a/authentication-personalization/authentication-setup.mdx
+++ b/authentication-personalization/authentication-setup.mdx
@@ -2,13 +2,16 @@
 title: "Authentication setup"
 description: "Guarantee privacy of your docs by authenticating users"
 icon: "file-lock"
+keywords: ["auth"]
 ---
+
 Authentication requires users to log in before accessing your documentation. This guide covers setup for each available handshake method.
 
 **Need help choosing?** See the [overview](/authentication-personalization/overview) to compare options.
 
 <Info>
-  Authentication methods are available on [Growth and Enterprise plans](https://mintlify.com/pricing?ref=authentication).
+  Authentication methods are available on [Growth and Enterprise
+  plans](https://mintlify.com/pricing?ref=authentication).
 </Info>
 
 ## Configuring authentication
@@ -19,26 +22,28 @@ Select the handshake method that you want to configure.
 <Tab title="JWT">
 ### Prerequisites
 
-* An authentication system that can generate and sign JWTs.
-* A backend service that can create redirect URLs.
+- An authentication system that can generate and sign JWTs.
+- A backend service that can create redirect URLs.
 
 ### Implementation
 
 <Steps>
   <Step title="Generate a private key.">
-    1. In your dashboard, go to [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
-    2. Select **Full Authentication** or **Partial Authentication**.
-    3. Select **JWT**.
-    4. Enter the URL of your existing login flow and select **Save changes**.
-    5. Select **Generate new key**.
-    6. Store your key securely where it can be accessed by your backend.
+    1. In your dashboard, go to
+    [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
+    2. Select **Full Authentication** or **Partial Authentication**. 3. Select
+    **JWT**. 4. Enter the URL of your existing login flow and select **Save
+    changes**. 5. Select **Generate new key**. 6. Store your key securely where
+    it can be accessed by your backend.
   </Step>
   <Step title="Integrate Mintlify authentication into your login flow.">
-    Modify your existing login flow to include these steps after user authentication:
-    
-    * Create a JWT containing the authenticated user's info in the `User` format. See [Sending Data](/authentication-personalization/sending-data) for more information.
-    * Sign the JWT with your secret key, using the EdDSA algorithm.
-    * Create a redirect URL back to the `/login/jwt-callback` path of your docs, including the JWT as the hash.
+    Modify your existing login flow to include these steps after user
+    authentication: * Create a JWT containing the authenticated user's info in
+    the `User` format. See [Sending
+    Data](/authentication-personalization/sending-data) for more information. *
+    Sign the JWT with your secret key, using the EdDSA algorithm. * Create a
+    redirect URL back to the `/login/jwt-callback` path of your docs, including
+    the JWT as the hash.
   </Step>
 </Steps>
 
@@ -49,15 +54,16 @@ Your documentation is hosted at `docs.foo.com` with an existing authentication s
 Create a login endpoint at `https://foo.com/docs-login` that extends your existing authentication.
 
 After verifying user credentials:
-* Generate a JWT with user data in Mintlify's format.
-* Sign the JWT and redirect to `https://docs.foo.com/login/jwt-callback#{SIGNED_JWT}`.
+
+- Generate a JWT with user data in Mintlify's format.
+- Sign the JWT and redirect to `https://docs.foo.com/login/jwt-callback#{SIGNED_JWT}`.
 
 <CodeGroup>
 ```ts TypeScript
 import * as jose from 'jose';
 import { Request, Response } from 'express';
 
-const TWO_WEEKS_IN_MS = 1000 * 60 * 60 * 24 * 7 * 2;
+const TWO_WEEKS_IN_MS = 1000 _ 60 _ 60 _ 24 _ 7 \* 2;
 
 const signingKey = await jose.importPKCS8(process.env.MINTLIFY_PRIVATE_KEY, 'EdDSA');
 
@@ -71,14 +77,15 @@ export async function handleRequest(req: Request, res: Response) {
     },
   };
 
-  const jwt = await new jose.SignJWT(user)
-    .setProtectedHeader({ alg: 'EdDSA' })
-    .setExpirationTime('10 s') // 10 second JWT expiration
-    .sign(signingKey);
+const jwt = await new jose.SignJWT(user)
+.setProtectedHeader({ alg: 'EdDSA' })
+.setExpirationTime('10 s') // 10 second JWT expiration
+.sign(signingKey);
 
-  return res.redirect(`https://docs.foo.com/login/jwt-callback#${jwt}`);
+return res.redirect(`https://docs.foo.com/login/jwt-callback#${jwt}`);
 }
-```
+
+````
 
 ```python Python
 import jwt # pyjwt
@@ -106,7 +113,8 @@ async def return_mintlify_auth_status(current_user):
   )
 
   return RedirectResponse(url=f'https://docs.foo.com/login/jwt-callback#{jwt_token}', status_code=302)
-```
+````
+
 </CodeGroup>
 
 ### Redirecting unauthenticated users
@@ -117,38 +125,42 @@ When an unauthenticated user tries to access a protected page, their intended de
 2. Redirect to your login URL with a redirect query parameter: `https://foo.com/docs-login?redirect=%2Fquickstart`.
 3. After authentication, redirect to `https://docs.foo.com/login/jwt-callback?redirect=%2Fquickstart#{SIGNED_JWT}`.
 4. User lands in their original destination.
-</Tab>
+   </Tab>
 <Tab title="OAuth 2.0">
+
 ### Prerequisites
 
-* An OAuth server that supports the Authorization Code Flow.
-* Ability to create an API endpoint accessible by OAuth access tokens (optional, to enable personalization features).
+- An OAuth server that supports the Authorization Code Flow.
+- Ability to create an API endpoint accessible by OAuth access tokens (optional, to enable personalization features).
 
 ### Implementation
 
 <Steps>
   <Step title="Configure your OAuth settings.">
-    1. In your dashboard, go to [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
-    2. Select **Full Authentication** or **Partial Authentication**.
-    3. Select **OAuth** and configure these fields:
-      * **Authorization URL**: Your OAuth endpoint.
-      * **Client ID**: Your OAuth 2.0 client identifier.
-      * **Client Secret**: Your OAuth 2.0 client secret.
-      * **Scopes**: Permissions to request. Use multiple scopes if you need different access levels.
-      * **Token URL**: Your OAuth token exchange endpoint.
-      * **Info API URL** (optional): Endpoint to retrieve user info for personalization. If omitted, the OAuth flow will only be used to verify identity and the user info will be empty.
+    1. In your dashboard, go to
+    [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
+    2. Select **Full Authentication** or **Partial Authentication**. 3. Select
+    **OAuth** and configure these fields: * **Authorization URL**: Your OAuth
+    endpoint. * **Client ID**: Your OAuth 2.0 client identifier. * **Client
+    Secret**: Your OAuth 2.0 client secret. * **Scopes**: Permissions to
+    request. Use multiple scopes if you need different access levels. * **Token
+    URL**: Your OAuth token exchange endpoint. * **Info API URL** (optional):
+    Endpoint to retrieve user info for personalization. If omitted, the OAuth
+    flow will only be used to verify identity and the user info will be empty.
     4. Select **Save changes**.
   </Step>
   <Step title="Configure your OAuth server.">
-    1. Copy the **Redirect URL** from your [authentication settings](https://dashboard.mintlify.com/settings/deployment/authentication).
+    1. Copy the **Redirect URL** from your [authentication
+    settings](https://dashboard.mintlify.com/settings/deployment/authentication).
     2. Add the redirect URL as an authorized redirect URL for your OAuth server.
   </Step>
   <Step title="Create your user info endpoint (optional).">
-    To enable personalization features, create an API endpoint that:
-    * Accepts OAuth access tokens for authentication.
-    * Returns user data in the `User` format. See [Sending Data](/authentication-personalization/sending-data) for more information.
-    
-    Add this endpoint URL to the **Info API URL** field in your [authentication settings](https://dashboard.mintlify.com/settings/deployment/authentication).
+    To enable personalization features, create an API endpoint that: * Accepts
+    OAuth access tokens for authentication. * Returns user data in the `User`
+    format. See [Sending Data](/authentication-personalization/sending-data) for
+    more information. Add this endpoint URL to the **Info API URL** field in
+    your [authentication
+    settings](https://dashboard.mintlify.com/settings/deployment/authentication).
   </Step>
 </Steps>
 
@@ -157,6 +169,7 @@ When an unauthenticated user tries to access a protected page, their intended de
 Your documentation is hosted at `foo.com/docs` and you have an existing OAuth server at `auth.foo.com` that supports the Authorization Code Flow.
 
 **Configure your OAuth server details** in your dashboard:
+
 - **Authorization URL**: `https://auth.foo.com/authorization`
 - **Client ID**: `ydybo4SD8PR73vzWWd6S0ObH`
 - **Scopes**: `['docs-user-info']`
@@ -176,25 +189,27 @@ Your documentation is hosted at `foo.com/docs` and you have an existing OAuth se
 ```
 
 **Configure your OAuth server to allow redirects** to your callback URL.
+
 </Tab>
 <Tab title="Mintlify Dashboard">
 ### Prerequisites
 
-* Your documentation users are also your documentation editors.
+- Your documentation users are also your documentation editors.
 
 ### Implementation
 
 <Steps>
   <Step title="Enable Mintlify dashboard authentication.">
-    1. In your dashboard, go to [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
-    2. Select **Full Authentication** or **Partial Authentication**.
-    3. Select **Mintlify Auth**.
-    4. Select **Enable Mintlify Auth**.
+    1. In your dashboard, go to
+    [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
+    2. Select **Full Authentication** or **Partial Authentication**. 3. Select
+    **Mintlify Auth**. 4. Select **Enable Mintlify Auth**.
   </Step>
   <Step title="Add authorized users.">
-    1. In your dashboard, go to [Members](https://dashboard.mintlify.com/settings/organization/members).
-    2. Add each person who should have access to your documentation.
-    3. Assign appropriate roles based on their editing permissions.
+    1. In your dashboard, go to
+    [Members](https://dashboard.mintlify.com/settings/organization/members). 2.
+    Add each person who should have access to your documentation. 3. Assign
+    appropriate roles based on their editing permissions.
   </Step>
 </Steps>
 
@@ -205,6 +220,7 @@ Your documentation is hosted at `docs.foo.com` and your team uses the dashboard 
 **Enable Mintlify authentication** in your dashboard settings.
 
 **Verify team access** by checking that all team members are added to your organization.
+
 </Tab>
 <Tab title="Password">
 <Info>
@@ -213,17 +229,16 @@ Password authentication provides access control only and does **not** support co
 
 ### Prerequisites
 
-* Your security requirements allow sharing passwords among users.
+- Your security requirements allow sharing passwords among users.
 
 ### Implementation
 
 <Steps>
   <Step title="Create a password.">
-    1. In your dashboard, go to [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
-    2. Select **Full Authentication** or **Partial Authentication**.
-    3. Select **Password**.
-    4. Enter a secure password.
-    5. Select **Save changes**.
+    1. In your dashboard, go to
+    [Authentication](https://dashboard.mintlify.com/settings/deployment/authentication).
+    2. Select **Full Authentication** or **Partial Authentication**. 3. Select
+    **Password**. 4. Enter a secure password. 5. Select **Save changes**.
   </Step>
   <Step title="Distribute access.">
     Securely share the password and documentation URL with authorized users.
@@ -232,8 +247,9 @@ Password authentication provides access control only and does **not** support co
 
 ## Example
 
-Your documentation is hosted at `docs.foo.com` and you need basic access control without tracking individual users. You want to prevent public access while keeping setup simple. 
+Your documentation is hosted at `docs.foo.com` and you need basic access control without tracking individual users. You want to prevent public access while keeping setup simple.
 
 **Create a strong password** in your dashboard. **Share credentials** with authorized users. That's it!
+
 </Tab>
 </Tabs>

--- a/authentication-personalization/overview.mdx
+++ b/authentication-personalization/overview.mdx
@@ -2,16 +2,19 @@
 title: "Overview"
 description: "Control who sees your documentation and customize their experience"
 icon: "badge-info"
+keywords: ["auth"]
 ---
+
 <Info>
-  Authentication methods are available on the [Growth and Enterprise plans](https://mintlify.com/pricing?ref=authentication).
+  Authentication methods are available on the [Growth and Enterprise
+  plans](https://mintlify.com/pricing?ref=authentication).
 </Info>
 
 There are three approaches to manage access and customize your documentation based on user information.
 
-* **Authentication**: Complete privacy protection for all content with full content customization.
-* **Partial authentication**: Page-by-page access control with full content customization.
-* **Personalization**: Content customization with **no security guarantees**. All content remains publicly accessible.
+- **Authentication**: Complete privacy protection for all content with full content customization.
+- **Partial authentication**: Page-by-page access control with full content customization.
+- **Personalization**: Content customization with **no security guarantees**. All content remains publicly accessible.
 
 **Choose authentication** if you need complete security and privacy for all your documentation, including pages, images, search results, and AI assistant features.
 
@@ -26,50 +29,55 @@ Authentication and personalization offer multiple handshake methods for controll
 ### Available for all methods
 
 **JSON Web Token (JWT)**: Custom system where you manage user tokens with full control over the login flow.
-* Pros of JWT:
-  * Reduced risk of API endpoint abuse.
-  * No CORS configuration.
-  * No restrictions on API URLs.
-* Cons of JWT:
-  * Must be compatible with your existing login flow.
-  * Dashboard sessions and docs authentication are decoupled, so your team will log into your dashboard and your docs separately.
-  * When you refresh user data, users must log into your docs again. If your users' data changes frequently, they must log in frequently or risk having stale data in your docs.
+
+- Pros of JWT:
+  - Reduced risk of API endpoint abuse.
+  - No CORS configuration.
+  - No restrictions on API URLs.
+- Cons of JWT:
+  - Must be compatible with your existing login flow.
+  - Dashboard sessions and docs authentication are decoupled, so your team will log into your dashboard and your docs separately.
+  - When you refresh user data, users must log into your docs again. If your users' data changes frequently, they must log in frequently or risk having stale data in your docs.
 
 **OAuth 2.0**: Third-party login integration like Google, GitHub, or other OAuth providers.
-* Pros of OAuth 2.0:
-  * Heightened security standard.
-  * No restrictions on API URLs.
-* Cons of OAuth 2.0:
-  * Requires significant work if setting up an OAuth server for the first time.
-  * Dashboard sessions and docs authentication are decoupled, so your team will log into your dashboard and your docs separately.
 
-### Available for authentication and partial authentication 
+- Pros of OAuth 2.0:
+  - Heightened security standard.
+  - No restrictions on API URLs.
+- Cons of OAuth 2.0:
+  - Requires significant work if setting up an OAuth server for the first time.
+  - Dashboard sessions and docs authentication are decoupled, so your team will log into your dashboard and your docs separately.
+
+### Available for authentication and partial authentication
 
 **Mintlify dashboard**: Allow all of your dashboard users to access your docs.
-* Pros of Mintlify dashboard:
-  * No configuration required.
-  * Enables private preview deployments, restricting access to authenticated users only.
-* Cons of Mintlify dashboard:
-  * Requires all users of your docs to have an account in your Mintlify dashboard.
+
+- Pros of Mintlify dashboard:
+  - No configuration required.
+  - Enables private preview deployments, restricting access to authenticated users only.
+- Cons of Mintlify dashboard:
+  - Requires all users of your docs to have an account in your Mintlify dashboard.
 
 **Password**: Shared access with a single global password. Used for access control only. Does not allow for personalization.
-* Pros of password:
-  * Simple setup with no configuration required to add new users, just share the password.
-* Cons of password:
-  * Lose personalization features since there is no way to differentiate users with the same password.
-  * Must change the password to revoke access.
+
+- Pros of password:
+  - Simple setup with no configuration required to add new users, just share the password.
+- Cons of password:
+  - Lose personalization features since there is no way to differentiate users with the same password.
+  - Must change the password to revoke access.
 
 ### Available for personalization
 
 **Shared session**: Use the same session token as your dashboard to personalize content.
-* Pros of shared session:
-  * Users that are logged into your dashboard are automatically logged into your docs.
-  * User sessions are persistent so you can refresh data without requiring a new login.
-  * Minimal setup.
-* Cons of shared session:
-  * Your docs will make a request to your backend.
-  * You must have a dashboard that uses session authentication.
-  * CORS configuration is generally required.
+
+- Pros of shared session:
+  - Users that are logged into your dashboard are automatically logged into your docs.
+  - User sessions are persistent so you can refresh data without requiring a new login.
+  - Minimal setup.
+- Cons of shared session:
+  - Your docs will make a request to your backend.
+  - You must have a dashboard that uses session authentication.
+  - CORS configuration is generally required.
 
 ## Content customization
 
@@ -108,10 +116,10 @@ Authentication is an enterprise feature. {
 ```
 
 <Note>
-  The information in `user` is only available for logged in users. For
-  logged out users, the value of `user` will be `{}`. To prevent the page from
-  crashing for logged out users, always use optional chaining on your `user`
-  fields. For example, `{user.org?.plan}`.
+  The information in `user` is only available for logged in users. For logged
+  out users, the value of `user` will be `{}`. To prevent the page from crashing
+  for logged out users, always use optional chaining on your `user` fields. For
+  example, `{user.org?.plan}`.
 </Note>
 
 ### API key prefilling

--- a/authentication-personalization/partial-authentication-setup.mdx
+++ b/authentication-personalization/partial-authentication-setup.mdx
@@ -2,6 +2,7 @@
 title: "Partial authentication setup"
 description: "Control access to specific pages"
 icon: "file-lock-2"
+keywords: ["auth"]
 ---
 
 Partial authentication lets you protect private documentation while keeping other pages publicly viewable. Users can browse public content freely and authenticate only when accessing protected pages.


### PR DESCRIPTION
## Documentation changes

when you search auth none of the auth pages show up. This PR adds the auth keyword in order to get it to show up.

![CleanShot 2025-06-23 at 09 54 26@2x](https://github.com/user-attachments/assets/b27d8aa0-9b5c-4544-adc0-64aeabe286aa)

