### PR TITLE
Update info on the colors param

### DIFF
--- a/settings.mdx
+++ b/settings.mdx
@@ -66,12 +66,12 @@ See [Themes](themes) for more information.
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="light" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      Primary color variant for light mode.
+      Light color variant of your theme.
       
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="dark" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      Primary color variant for dark mode.
+      Dark color variant of your theme.
       
       Must be a hex code beginning with `#`.
     </ResponseField>


### PR DESCRIPTION
## Documentation changes

The info on https://mintlify.com/docs/settings#param-colors is inaccurate right now. This PR corrects the section to explain that `light` and `dark` are setting the light and dark colors for the theme and do not have an influence on light or dark mode.

Closes https://linear.app/mintlify/issue/DOC-72/update-colors-section-of-settings

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
