### PR TITLE
Add notes with DNS propagation details

### DIFF
--- a/advanced/subpath/cloudflare.mdx
+++ b/advanced/subpath/cloudflare.mdx
@@ -3,6 +3,8 @@ title: "Cloudflare"
 description: "Host documentation at a /docs subpath using Cloudflare Workers"
 ---
 
+import Propagating from "/snippets/custom-subpath-propagating.mdx";
+
 To host your documentation at a `/docs` subpath using Cloudflare, you will need to create and configure a Cloudflare Worker.
 
 <Info>
@@ -57,8 +59,9 @@ async function handleRequest(request) {
 }
 ```
 
-Select `Deploy` and wait for the changes to propagate (it can take up to a few
-hours).
+Select **Deploy** and wait for the changes to propagate.
+
+<Propagating />
 
 ### Test your Worker
 
@@ -137,4 +140,6 @@ If you use Webflow to host your main site and want to serve Mintlify docs at `/d
   }
   }
   ```
-5. Select Deploy and wait for the changes to propagate, which can take up to a few hours.
+5. Select **Deploy** and wait for the changes to propagate.
+
+<Propagating />

--- a/advanced/subpath/route53-cloudfront.mdx
+++ b/advanced/subpath/route53-cloudfront.mdx
@@ -4,6 +4,8 @@ sidebarTitle: "AWS"
 description: "Host documentation at a /docs subdirectory using AWS services"
 ---
 
+import Propagating from "/snippets/custom-subpath-propagating.mdx";
+
 ## Create Cloudfront Distribution
 
 Navigate to [Cloudfront](https://aws.amazon.com/cloudfront) inside the AWS console and click on `Create distribution`
@@ -139,4 +141,6 @@ Click `Create records`.
   You may need to remove the existing A record if one currently exists.
 </Note>
 
-And voila! You should be able to have your documentation served at `/docs` for your primary domain.
+And voila! Your documentation will be served at `/docs` for your primary domain.
+
+<Propagating />

--- a/snippets/custom-subpath-gating.mdx
+++ b/snippets/custom-subpath-gating.mdx
@@ -1,4 +1,4 @@
 <Info>
   **Prerequisite**: Your primary domain (company.com) is hosted on {platform}
-  and you are on the [Pro plan or above](https://mintlify.com/pricing).
+  and you are on the [Pro, Growth, or Enterprise plan](https://mintlify.com/pricing).
 </Info>

--- a/snippets/custom-subpath-propagating.mdx
+++ b/snippets/custom-subpath-propagating.mdx
@@ -1,0 +1,3 @@
+<Note>
+  After configuring your DNS, custom subdomains are usually available within a few minutes. DNS propagation can sometimes take 1-4 hours, and in rare cases up to 48 hours. If your subdomain is not immediately available, please wait before troubleshooting.
+</Note>


### PR DESCRIPTION
## Documentation changes

This PR adds notes to https://mintlify.com/docs/advanced/subpath/route53-cloudfront and https://mintlify.com/docs/advanced/subpath/cloudflare about DNS propagation times. This usually happens near instantly, but can take a few hours when setting up custom subdomains. Some users get tripped up by this.

Closes https://linear.app/mintlify/issue/DOC-74/improve-docs-on-setting-up-custom-subdirectory

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
