### PR TITLE
CLI docs update

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -29,16 +29,6 @@ icon: "terminal"
     npm i -g mint
     ```
 
-
-    ```bash yarn
-    yarn global add mint
-    ```
-
-
-    ```bash pnpm
-    pnpm add -g mint
-    ```
-
     </CodeGroup>
   </Step>
   <Step title="Preview locally.">
@@ -61,15 +51,6 @@ npx mint dev
 ```
 
 
-```bash yarn
-yarn dlx mint dev
-```
-
-
-```bash pnpm
-pnpm dlx mint dev
-```
-
 </CodeGroup>
 
 ## Updates
@@ -88,15 +69,6 @@ If this `mint update` command is not available on your local version, re-install
 npm i -g mint@latest
 ```
 
-
-```bash yarn
-yarn global upgrade mint
-```
-
-
-```bash pnpm
-pnpm up --global mint
-```
 
 </CodeGroup>
 
@@ -158,11 +130,34 @@ If you use JetBrains, we recommend the [MDX IntelliJ IDEA plugin](https://plugin
   <Accordion title='Error: Could not load the "sharp" module using the darwin-arm64 runtime'>
     This may be due to an outdated version of node. Try the following:
 
-    1. Remove the currently-installed version of the mint CLI: `npm remove -g mint`
+    1. Remove the currently-installed version of the mint CLI: `npm uninstall -g mint`
     2. Upgrade to Node.js.
     3. Reinstall the mint CLI: `npm install -g mint`
   </Accordion>
   <Accordion title="Issue: Encountering an unknown error">
     Solution: Go to the root of your device and delete the `~/.mintlify` folder. Afterwards, run `mint dev` again.
+  </Accordion>
+  <Accordion title="Error: permission denied">
+    This is due to not having the required permissions to globally install node packages.
+    Solution: Try running `sudo npm i -g mint`. You will be prompted for your password, which is the one you use to unlock your computer.
+  </Accordion>
+  <Accordion title="The local preview doesn't look the same as my docs do on the web">
+    Likely this is due to an outdated version of the CLI.
+    Solution: Run `mint update` to get the latest changes.
+  </Accordion>
+  <Accordion title="mintlify vs. mint package">
+    When having any problems with the CLI package, the first thing we'll ask you to do when troubleshooting is paste the output of `npm ls -g`, which shows what packages are globally installed on your machine. You may see that you have a package named "mint" and a package named "mintlify" installed. It will be less confusing to have only one of them installed.
+    1. Uninstall the old package:
+    ```bash
+      npm uninstall -g mintlify
+    ```
+    2. Clear your npm cache:
+    ```bash
+      npm cache clean --force
+    ```
+    3. Reinstall the new package:
+    ```bash
+      npm install -g mint
+    ```
   </Accordion>
 </AccordionGroup>

--- a/installation.mdx
+++ b/installation.mdx
@@ -123,18 +123,23 @@ If you use JetBrains, we recommend the [MDX IntelliJ IDEA plugin](https://plugin
     3. Reinstall the mint CLI: `npm install -g mint`
   </Accordion>
   <Accordion title="Issue: Encountering an unknown error">
-    Solution: Go to the root of your device and delete the `~/.mintlify` folder. Afterwards, run `mint dev` again.
+    **Solution**: Go to the root of your device and delete the `~/.mintlify` folder. Afterwards, run `mint dev` again.
   </Accordion>
   <Accordion title="Error: permission denied">
     This is due to not having the required permissions to globally install node packages.
-    Solution: Try running `sudo npm i -g mint`. You will be prompted for your password, which is the one you use to unlock your computer.
+
+    **Solution**: Try running `sudo npm i -g mint`. You will be prompted for your password, which is the one you use to unlock your computer.
   </Accordion>
   <Accordion title="The local preview doesn't look the same as my docs do on the web">
-    Likely this is due to an outdated version of the CLI.
-    Solution: Run `mint update` to get the latest changes.
+    This is likely due to an outdated version of the CLI.
+
+   **Solution:** Run `mint update` to get the latest changes.
   </Accordion>
   <Accordion title="mintlify vs. mint package">
-    When having any problems with the CLI package, the first thing we'll ask you to do when troubleshooting is paste the output of `npm ls -g`, which shows what packages are globally installed on your machine. You may see that you have a package named "mint" and a package named "mintlify" installed. It will be less confusing to have only one of them installed.
+    If you have any problems with the CLI package, you should first run `npm ls -g`. This command shows what packages are globally installed on your machine.
+    
+    If you have a package named `mint` and a package named `mintlify` installed, you should uninstall `mintlify`.
+    
     1. Uninstall the old package:
     ```bash
       npm uninstall -g mintlify

--- a/installation.mdx
+++ b/installation.mdx
@@ -23,13 +23,11 @@ icon: "terminal"
 <Steps>
   <Step title="Install the CLI.">
     Run the following command to install the [CLI](https://www.npmjs.com/package/mint):
-    <CodeGroup>
 
-    ```bash npm
+    ```bash
     npm i -g mint
     ```
 
-    </CodeGroup>
   </Step>
   <Step title="Preview locally.">
     Navigate to your docs directory (where your `docs.json` file is located) and execute the following command:
@@ -44,14 +42,9 @@ icon: "terminal"
 
 Alternatively, if you do not want to install the CLI globally, you can run a one-time script:
 
-<CodeGroup>
-
-```bash npm
+```bash
 npx mint dev
 ```
-
-
-</CodeGroup>
 
 ## Updates
 
@@ -63,14 +56,9 @@ mint update
 
 If this `mint update` command is not available on your local version, re-install the CLI with the latest version:
 
-<CodeGroup>
-
-```bash npm
+```bash
 npm i -g mint@latest
 ```
-
-
-</CodeGroup>
 
 ## Custom ports
 


### PR DESCRIPTION
## Documentation changes

1. Removing the `yarn` and `pnpm` installation instructions: these make it way harder to debug. Even with just `npm` there are complications from different node versions, nvm, etc. Let's *keep it simple*.
2. Adding more troubleshooting cases: David Aviles and an Anaconda guy ran into needing to use `sudo` this week, having both packages confuses our customers and makes it harder to debug for them, and we never mention what to do when CLI doesn't match web (probably a top CLI bug report)

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
