### PR TITLE
Specify page-level playground settings

### DIFF
--- a/api-playground/mdx/configuration.mdx
+++ b/api-playground/mdx/configuration.mdx
@@ -59,7 +59,7 @@ To generate pages for API endpoints using `MDX`, configure your API settings in 
 
     </Note>
 
-    You can override the globally-defined display mode for the API playground per page by adding `playground` at the top of the `MDX` file:
+    You can override the globally-defined display mode for the API playground for a page by adding `playground` to the frontmatter:
 
     ```mdx
     ---
@@ -69,51 +69,10 @@ To generate pages for API endpoints using `MDX`, configure your API settings in 
     ---
     ```
 
-    ## Page-level playground control
+    - `playground: 'interactive'` - Display the interactive playground.
+    - `playground: 'simple'` - Display a copyable endpoint with no playground.
+    - `playground: 'none'` - Hide the playground.
 
-    The `playground` frontmatter property allows you to control the API playground functionality on individual pages, overriding any global settings defined in `docs.json`. This is particularly useful for endpoints that don't benefit from interactive testing.
-
-    ### Available options
-
-    - `playground: 'interactive'` - Full interactive playground with request forms and response display
-    - `playground: 'simple'` - Shows a copyable endpoint with no interactive elements
-    - `playground: 'none'` - Completely hides the playground section
-
-    ### Common use cases
-
-    **Webhook endpoints**: Since webhooks are triggered by external systems rather than user requests, an interactive playground isn't useful. Use `playground: 'none'` to focus on documentation:
-
-    ```mdx
-    ---
-    title: 'Order Status Webhook'
-    api: 'POST https://api.yoursite.com/webhooks/order-status'
-    playground: 'none'
-    ---
-
-    This webhook is triggered when an order status changes in our system.
-    Configure your webhook endpoint to receive these notifications.
-    ```
-
-    **Internal or admin endpoints**: For endpoints that shouldn't be tested by regular users:
-
-    ```mdx
-    ---
-    title: 'Admin User Management'
-    api: 'DELETE https://api.yoursite.com/admin/users/{id}'
-    playground: 'simple'
-    ---
-    ```
-
-    **Documentation-heavy endpoints**: When you want to emphasize written documentation over interactive testing:
-
-    ```mdx
-    ---
-    title: 'Complex Analytics Query'
-    api: 'POST https://api.yoursite.com/analytics/query'
-    playground: 'simple'
-    ---
-    ```
-    
   </Step>
 
   <Step title="Add your endpoints to your docs">

--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -112,7 +112,7 @@ When you need more control over your API documentation, create individual `MDX` 
 - Add additional content like examples
 - Hide specific operations
 - Reorder pages in your navigation
-- Control playground behavior per page (useful for webhooks and admin endpoints)
+- Control playground behavior per page
 
 See [MDX Setup](/api-playground/mdx/configuration) for more information on creating individual pages for your API endpoints.
 


### PR DESCRIPTION
## Documentation changes

This updates our docs around specifying the API playground at the page level.

Closes https://linear.app/mintlify/issue/DOC-92/enable-api-playground-at-page-level

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
