### PR TITLE
Add webhooks section to OpenAPI setup

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -4,7 +4,7 @@ description: "Reference OpenAPI endpoints in your docs pages"
 icon: "file-json"
 ---
 
-OpenAPI is a specification for describing REST APIs. Mintlify supports OpenAPI 3.0+ documents to generate interactive API documentation and keep it up to date.
+OpenAPI is a specification for describing APIs. Mintlify supports OpenAPI 3.0+ documents to generate interactive REST API documentation, and OpenAPI 3.1+ for documenting webhooks.
 
 ## Add an OpenAPI specification file
 
@@ -186,8 +186,6 @@ version: "version-string" (not required)
 
 <Note>
   The method and path must exactly match the definition in your OpenAPI specification. If the endpoint doesn't exist in the OpenAPI file, the page will be empty.
-
-  For webhooks, use `webhook` (case insensitive) instead of the HTTP method (like `GET` or `POST`) in your reference.
 </Note>
 
 ### Autogenerate `MDX` files
@@ -239,3 +237,29 @@ openapi-schema: "schema-key"
 ```
 
 </CodeGroup>
+
+## Webhooks
+
+Webhooks are HTTP callbacks that your API sends to notify external systems when events occur. If your OpenAPI 3.1+ document defines webhooks, you can document them alongside your regular API endpoints.
+
+### Define webhooks in your OpenAPI specification
+
+Add a `webhooks` field to your OpenAPI document alongside the `paths` field.
+
+For more information on defining webhooks, see [Webhooks](https://spec.openapis.org/oas/v3.1.0#oasWebhooks) in the OpenAPI documentation.
+
+### Reference webhooks in MDX files
+
+When creating MDX pages for webhooks, use `webhook` instead of HTTP methods like `GET` or `POST`:
+
+```mdx
+---
+title: "Example webhook"
+description: "Triggered when an event occurs"
+openapi: "path/to/openapi-file webhook example-webhook-name"
+---
+```
+
+<Note>
+  The webhook name must exactly match the key defined in your OpenAPI specification's `webhooks` field.
+</Note>

--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -4,7 +4,7 @@ description: "Reference OpenAPI endpoints in your docs pages"
 icon: "file-json"
 ---
 
-OpenAPI is a specification for describing APIs. Mintlify supports OpenAPI 3.0+ documents to generate interactive REST API documentation, and OpenAPI 3.1+ for documenting webhooks.
+OpenAPI is a specification for describing APIs. Mintlify supports OpenAPI 3.0+ documents to generate interactive API documentation and keep it up to date.
 
 ## Add an OpenAPI specification file
 
@@ -240,7 +240,7 @@ openapi-schema: "schema-key"
 
 ## Webhooks
 
-Webhooks are HTTP callbacks that your API sends to notify external systems when events occur. If your OpenAPI 3.1+ document defines webhooks, you can document them alongside your regular API endpoints.
+Webhooks are HTTP callbacks that your API sends to notify external systems when events occur. Webhooks are supported in OpenAPI 3.1+ documents.
 
 ### Define webhooks in your OpenAPI specification
 


### PR DESCRIPTION
## Documentation changes

This PR adds info on web hooks to https://mintlify.com/docs/api-playground/openapi-setup. Right now, there is just a brief mention about webhooks in a note which is too hard to find. This adds a section with info that webhooks are supported in OpenAPI 3.1+ and how to specify a webhook in a n MDX page.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
