### PR TITLE
Flexible OpenAPI navigation and `x-mint`

### DIFF
--- a/api-playground/mdx/configuration.mdx
+++ b/api-playground/mdx/configuration.mdx
@@ -3,7 +3,7 @@ title: 'MDX setup'
 description: 'Generate docs pages for your API endpoints using `MDX`'
 ---
 
-You can manually define API endpoints in individual `MDX` files rather than using an OpenAPI specification. This method provides flexibility for custom content, but we recommend generating API documentation from an OpenAPI specification file for most API documentation projects as it's more maintainable and feature-rich. However, MDX can be useful for documenting small APIs, prototyping, or when you want to feature API endpoints alongside other content.
+You can manually define API endpoints in individual `MDX` files rather than using an OpenAPI specification. This method provides flexibility for custom content, but we recommend generating API documentation from an OpenAPI specification file for most projects because it is more maintainable and feature-rich. However, creating `MDX` pages for an API can be useful to document small APIs or for prototyping.
 
 To generate pages for API endpoints using `MDX`, configure your API settings in `docs.json`, create individual `MDX` files for each endpoint, and use components like `<ParamFields />` to define parameters. From these definitions, Mintlify generates interactive API playgrounds, request examples, and response examples.
 

--- a/api-playground/migrating-from-mdx.mdx
+++ b/api-playground/migrating-from-mdx.mdx
@@ -1,0 +1,168 @@
+---
+title: "Migrating MDX API pages to OpenAPI navigation"
+sidebarTitle: "Migrating from MDX"
+description: "Update from individual MDX endpoint pages to automated OpenAPI generation with flexible navigation"
+icon: "arrow-big-right-dash"
+---
+
+If you are currently using individual `MDX` pages for your API endpoints, you can migrate to autogenerating pages from your OpenAPI specification while retaining the customizability of individual pages.
+
+You can define metadata and content for each endpoint in your OpenAPI specification and organize endpoints precisely where you want them in your navigation.
+
+Follow this migration guide to start building your API documentation from your OpenAPI specification with these benefits:
+
+- Automatic page generation from your OpenAPI spec
+- Flexible navigation options
+- Fewer files to maintain
+- Consistent API documentation format
+
+## Before: Individual MDX pages
+
+Previously, you created separate MDX files for each endpoint and referenced them in your navigation:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": [
+        "api/get-users",
+        "api/post-users", 
+        "api/delete-users"
+      ]
+    }
+  ]
+}
+```
+
+Each endpoint required its own MDX file with manual configuration and content.
+
+## After: OpenAPI navigation
+
+When you complete the migration, you will reference your OpenAPI specification directly in navigation and automatically generate endpoint pages:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference", 
+      "openapi": "openapi.json"
+    }
+  ]
+}
+```
+
+Or selectively include specific endpoints:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "openapi": "openapi.json", 
+      "pages": [
+        "GET /users",
+        "POST /users",
+        "DELETE /users"
+      ]
+    }
+  ]
+}
+```
+
+## Migration steps
+
+<Steps>
+  <Step title="Prepare your OpenAPI specification.">
+    Ensure your OpenAPI specification is valid and includes all endpoints you want to document.
+
+    For any endpoints that you want to customize the metadata or content, add the `x-mint` extension to the endpoint. See [x-mint extension](/api-playground/openapi-setup#x-mint-extension) for more details.
+
+    For any endpoints that you want to exclude from your documentation, add the `x-hidden` extension to the endpoint.
+
+    <Info>
+      Validate your OpenAPI file using the [Swagger Editor](https://editor.swagger.io/) or [Mint CLI](https://www.npmjs.com/package/mint).
+    </Info>
+  </Step>
+  
+  <Step title="Update your navigation structure.">
+    Replace `MDX` page references with OpenAPI endpoints in your `docs.json`.
+
+    ```json
+    {
+      "navigation": {
+        "openapi": "/path/to/openapi.json",
+        "pages": [
+          "introduction",
+          "GET /health",
+          "quickstart", 
+          "POST /users",
+          "GET /users/{id}",
+          "advanced-features"
+        ]
+      }
+    }
+    ```
+
+  </Step>
+
+  <Step title="Remove old MDX files.">
+    After verifying your new navigation works correctly, remove the `MDX` endpoint files that you no longer need.
+  </Step>
+</Steps>
+
+## Navigation patterns
+
+You can customize how your API documentation appears in your navigation.
+
+### Mixed content navigation
+
+Combine automatically generated API pages with other pages:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "openapi": "openapi.json",
+      "pages": [
+        "api/overview",
+        "GET /users",
+        "POST /users", 
+        "api/authentication"
+      ]
+    }
+  ]
+}
+```
+
+### Multiple API versions
+
+Organize different API versions using tabs or groups:
+
+```json
+{
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "API v1",
+        "openapi": "specs/v1.json"
+      },
+      {
+        "tab": "API v2", 
+        "openapi": "specs/v2.json"
+      }
+    ]
+  }
+}
+```
+
+## When to use individual `MDX` pages
+
+Consider keeping individual `MDX` pages when you need:
+
+- Extensive custom content per endpoint like React components or lengthy examples
+- Unique page layouts
+- Experimental documentation approaches for specific endpoints
+
+For most use cases, OpenAPI navigation provides better maintainability and consistency.

--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -93,9 +93,115 @@ If different endpoints within your API require different methods of authenticati
 
 For more information on defining and applying authentication, see [Authentication](https://swagger.io/docs/specification/authentication/) in the OpenAPI documentation.
 
+## `x-mint` extension
+
+The `x-mint` extension is a custom OpenAPI extension that provides additional control over how your API documentation is generated and displayed.
+
+### Metadata
+
+Override the default metadata for generated API pages by adding `x-mint: metadata` to any operation:
+
+```json {7-13}
+{
+  "paths": {
+    "/users": {
+      "get": {
+        "summary": "Get users",
+        "description": "Retrieve a list of users",
+        "x-mint": {
+          "metadata": {
+            "title": "List all users",
+            "description": "Fetch paginated user data with filtering options",
+            "og:title": "Display a list of users",
+          }
+        },
+        "parameters": [
+          {
+            // Parameter configuration
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+TODO: what metadata fields are supported?
+
+The `metadata` extension supports:
+- `title`: Override the page title (defaults to operation summary)
+- `description`: Override the page description (defaults to operation description)  
+- `og:title`: Override the Open Graph title (defaults to operation summary)
+- `og:description`: Override the Open Graph description (defaults to operation description)
+
+### Content
+
+Add content before the auto-generated API documentation using `x-mint: content`:
+
+```json {6-13}
+{
+  "paths": {
+    "/users": {
+      "post": {
+        "summary": "Create user",
+        "x-mint": {
+          "content": "## Prerequisites
+          This endpoint requires admin privileges and has rate limiting.
+          
+          <Note>
+            User emails must be unique across the system.
+          </Note>"
+        },
+        "parameters": [
+          {
+            // Parameter configuration
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `content` extension supports all Mintlify MDX components and formatting.
+
+### href
+
+Redirect an operation to an external URL or existing documentation page using `x-mint: href`:
+
+```json {14-16}
+{
+  "paths": {
+    "/legacy-endpoint": {
+      "get": {
+        "summary": "Legacy endpoint",
+        "x-mint": {
+          "href": "https://legacy-docs.example.com/api/legacy"
+        }
+      }
+    },
+    "/documented-elsewhere": {
+      "post": {
+        "summary": "Special endpoint",
+        "x-mint": {
+          "href": "/custom-guides/special-endpoint-guide"
+        }
+      }
+    }
+  }
+}
+```
+
+When `x-mint: href` is present, the navigation entry will link directly to the specified URL instead of generating an API page.
+
 ## Auto-populate API pages
 
 You can add an `openapi` field to any navigation element in your `docs.json` to auto-populate your docs with a page for each specified endpoint. The `openapi` field can contain the path to an OpenAPI document in your docs repo or the URL of a hosted OpenAPI document.
+
+There are two main approaches for adding endpoint pages into your documentation:
+
+1. **Group-based**: Apply OpenAPI specs at the group level for dedicated API sections.
+2. **Manually-configured**: Set a default OpenAPI spec and selectively include endpoints throughout your navigation.
 
 The metadata for the generated pages will have the following default values:
 
@@ -108,7 +214,11 @@ The metadata for the generated pages will have the following default values:
   If you have some endpoints in your OpenAPI schema that you want to exclude from your auto-populated API pages, add the [x-hidden](/api-playground/customization/managing-page-visibility#x-hidden) property to the endpoint.
 </Tip>
 
-### Example with navigation tabs
+### Group-based API pages
+
+Use group-based configuration when you want to dedicate entire sections to auto-generated API documentation.
+
+#### Example with navigation tabs
 
 ```json {5}
 "navigation": {
@@ -121,7 +231,7 @@ The metadata for the generated pages will have the following default values:
 }
 ```
 
-### Example with navigation groups
+#### Example with navigation groups
 
 ```json {8-11}
 "navigation": {
@@ -146,9 +256,93 @@ The metadata for the generated pages will have the following default values:
   The directory field is optional. If not specified, the files will be placed in the `api-reference` directory of the docs repo.
 </Note>
 
+### Manually-configured API pages
+
+Use manually-configured API pages when you want more control over which endpoints appear where in your documentation. This approach allows you to mix API endpoints with other documentation pages.
+
+#### Set a default OpenAPI spec
+
+Configure a default OpenAPI specification at the navigation level to enable automatic endpoint inclusion throughout your documentation:
+
+```json {3, 13-14}
+{
+  "navigation": {
+    "openapi": "/path/to/openapi.json",
+    "tabs": [
+      {
+        "tab": "Getting started",
+        "pages": ["quickstart", "installation"]
+      },
+      {
+        "tab": "API reference",
+        "pages": [
+          "api-overview",
+          "GET /users",
+          "POST /users",
+          "guides/authentication"
+        ]
+      }
+    ]
+  }
+}
+```
+
+When a default OpenAPI spec is set, any navigation entry that matches an OpenAPI operation (using the format `METHOD /path`) will automatically generate an API page for that endpoint.
+
+#### OpenAPI spec inheritance
+
+OpenAPI specifications are inherited through the navigation hierarchy. Child navigation elements automatically use their parent's OpenAPI spec unless they specify their own:
+
+```json {6, 8-9, 14, 16-17}
+{
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "API v1",
+        "openapi": "/specs/v1.json",
+        "pages": [
+          "GET /users",
+          "POST /users"
+        ]
+      },
+      {
+        "tab": "API v2", 
+        "openapi": "/specs/v2.json",
+        "pages": [
+          "GET /users",
+          "DELETE /users"
+        ]
+      }
+    ]
+  }
+}
+```
+
+#### Mixed navigation
+
+Combine API endpoints with other pages to create your desired navigation structure:
+
+```json
+{
+  "navigation": {
+    "openapi": "/path/to/openapi.json",
+    "pages": [
+      "introduction",
+      "GET /health",
+      "quickstart", 
+      "POST /users",
+      "GET /users/{id}",
+      "advanced-features"
+    ]
+  }
+}
+```
+
 ## Create `MDX` files for API pages
 
-If you want to customize the page metadata, add additional content, omit certain OpenAPI operations, or reorder OpenAPI pages in your navigation, you can create `MDX` pages for each operation. See an [example MDX OpenAPI page from MindsDB](https://github.com/mindsdb/mindsdb/blob/main/docs/rest/databases/create-databases.mdx?plain=1) and how it appears in their [live documentation](https://docs.mindsdb.com/rest/databases/create-databases).
+For control over individual endpoint pages, you can also create `MDX` pages for each operation. This lets you customize page metadata, add content, omit certain operations, or reorder pages in your navigation at the page level.
+
+See an [example MDX OpenAPI page from MindsDB](https://github.com/mindsdb/mindsdb/blob/main/docs/rest/databases/create-databases.mdx?plain=1) and how it appears in their [live documentation](https://docs.mindsdb.com/rest/databases/create-databases).
 
 ### Manually specify files
 

--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -137,7 +137,7 @@ The `x-mint` extension is recommended so that all of your API documentation is a
 
 Individual `MDX` pages are recommended for small APIs or when you want to experiment with changes on a per-page basis.
 
-For more information, see [x-mint](/api-playground/openapi-setup#x-mint) and [MDX Setup](/api-playground/mdx/configuration).
+For more information, see [x-mint extension](/api-playground/openapi-setup#x-mint-extension) and [MDX Setup](/api-playground/mdx/configuration).
 
 ## Further reading
 

--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -123,17 +123,21 @@ You can customize your API playground by defining the following properties in yo
 
 This example configures the API playground to be interactive with example code snippets for cURL, Python, and JavaScript. Only required parameters are shown in the code snippets.
 
-### Custom `MDX` pages
+### Custom endpoint pages
 
-When you need more control over your API documentation, create individual `MDX` pages for your endpoints. This allows you to:
+When you need more control over your API documentation, use the `x-mint` extension in your OpenAPI specification or create individual `MDX` pages for your endpoints.
+
+Both options allow you to:
 
 - Customize page metadata
 - Add additional content like examples
-- Hide specific operations
-- Reorder pages in your navigation
 - Control playground behavior per page
 
-See [MDX Setup](/api-playground/mdx/configuration) for more information on creating individual pages for your API endpoints.
+The `x-mint` extension is reccomended so that all of your API documentation is automatically generated from your OpenAPI specification and maintained in one file.
+
+Individual `MDX` pages are recommended for small APIs or when you want to experiment with changes on a per-page basis.
+
+For more information, see [x-mint](/api-playground/openapi-setup#x-mint) and [MDX Setup](/api-playground/mdx/configuration).
 
 ## Further reading
 

--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -133,7 +133,7 @@ Both options allow you to:
 - Add additional content like examples
 - Control playground behavior per page
 
-The `x-mint` extension is reccomended so that all of your API documentation is automatically generated from your OpenAPI specification and maintained in one file.
+The `x-mint` extension is recommended so that all of your API documentation is automatically generated from your OpenAPI specification and maintained in one file.
 
 Individual `MDX` pages are recommended for small APIs or when you want to experiment with changes on a per-page basis.
 

--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -33,8 +33,8 @@ We recommend generating your API playground from an OpenAPI specification. See [
 
   </Step>
   <Step title="Configure `docs.json`.">
-    Update your `docs.json` to reference your OpenAPI specification. You can add an `openapi` property to any navigation element to auto-populate your docs with a page for each endpoint specified in your OpenAPI document.
-    
+    Update your `docs.json` to reference your OpenAPI specification. Add an `openapi` property to any navigation element to auto-populate your docs with pages for each endpoint specified in your OpenAPI document.
+
     In this example, Mintlify will generate a page for each endpoint specified in `openapi.json` and organize them under the "API reference" group in your navigation.
 
     ```json
@@ -43,6 +43,25 @@ We recommend generating your API playground from an OpenAPI specification. See [
           {
             "group": "API reference",
             "openapi": "openapi.json"
+          }
+      ]
+    }
+    ```
+
+    To generate pages for only specific endpoints, list the endpoints in the `pages` property of the navigation element.
+
+    In this example, only pages for the `GET /users` and `POST /users` endpoints will be generated regardless of what other endpoints are specified in `openapi.json`.
+    
+    ```json
+    {
+        "navigation": [
+          {
+            "group": "API reference",
+            "openapi": "openapi.json",
+            "pages": [
+              "GET /users",
+              "POST /users"
+            ]
           }
       ]
     }

--- a/api-playground/troubleshooting.mdx
+++ b/api-playground/troubleshooting.mdx
@@ -71,4 +71,57 @@ If your API pages aren't displaying correctly, check these common configuration 
 
     Alternatively, if your reverse proxy prevents you from accepting `POST` requests, you can configure Mintlify to send requests directly to your backend with the `api.playground.proxy` setting in the `docs.json`, as described in the [settings documentation](/settings#param-proxy). When using this configuration, you will need to configure CORS on your server since requests will come directly from users' browsers rather than through your proxy.
   </Accordion>
+  <Accordion title="OpenAPI navigation entries are not generating pages">
+    If you are using an OpenAPI navigation configuration, but the pages aren't generating, check these common issues:
+
+    1. **Missing default OpenAPI spec**: Ensure you have an `openapi` field set at the navigation level:
+       ```json
+       {
+         "navigation": {
+           "openapi": "/path/to/openapi.json",
+           "pages": ["GET /users", "POST /users"]
+         }
+       }
+       ```
+
+    2. **Incorrect operation format**: Navigation entries must exactly match the HTTP method and path in your OpenAPI spec:
+       - Correct: `"GET /users/{id}"`
+       - Incorrect: `"get /users/{id}"` (wrong case)
+       - Incorrect: `"GET /users/{id}/"` (extra trailing slash)
+
+    3. **OpenAPI spec inheritance**: If using nested navigation, ensure child groups inherit the correct OpenAPI spec or specify their own.
+
+    4. **Validation issues**: Use `mint openapi-check <path-to-openapi-file>` to verify your OpenAPI document is valid.
+  </Accordion>
+  <Accordion title="Some OpenAPI operations appear in navigation but others don't">
+
+    1. **Hidden operations**: Operations marked with `x-hidden: true` in your OpenAPI spec won't appear in auto-generated navigation.
+
+    2. **Manual vs automatic inclusion**: If you have a `pages` array in your navigation group, only the operations explicitly listed will appear. Remove the `pages` array to include all operations automatically.
+
+    3. **Invalid operations**: Operations with validation errors in the OpenAPI spec may be skipped. Check your OpenAPI document for syntax errors.
+  </Accordion>
+  <Accordion title="Mixed navigation (OpenAPI and MDX pages) not working correctly">
+    When combining OpenAPI operations with regular documentation pages in navigation:
+
+    1. **Default OpenAPI spec required**: You must set a default OpenAPI spec at the navigation level for automatic operation detection:
+       ```json
+       {
+         "navigation": {
+           "openapi": "/path/to/openapi.json",
+           "pages": [
+             "introduction",
+             "GET /users",
+             "guides/authentication"
+           ]
+         }
+       }
+       ```
+
+    2. **File conflicts**: You cannot have both an `MDX` file and a navigation entry for the same operation. For example, if you have `get-users.mdx`, do not also include `"GET /users"` in your navigation.
+
+    3. **Path resolution**: Navigation entries that don't match OpenAPI operations will be treated as file paths. Ensure your `MDX` files exist at the expected locations.
+
+    4. **Case sensitivity**: OpenAPI operation matching is case-sensitive. Ensure HTTP methods are uppercase in navigation entries.
+  </Accordion>
 </AccordionGroup>

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
             "pages": [
               "api-playground/overview",
               "api-playground/openapi-setup",
+              "api-playground/migrating-from-mdx",
               {
                 "group": "Customization",
                 "icon": "wrench",

--- a/navigation.mdx
+++ b/navigation.mdx
@@ -189,8 +189,6 @@ While not required, we highly recommend that you set an `icon` field as well.
 }
 ```
 
----
-
 Anchors that strictly contain external links can be achieved using the `global` keyword:
 
 ```json
@@ -212,6 +210,8 @@ Anchors that strictly contain external links can be achieved using the `global` 
   "tabs": /*...*/
 }
 ```
+
+---
 
 ## Dropdowns
 
@@ -260,9 +260,46 @@ While not required, we also recommend that you set an icon for each dropdown ite
 
 ---
 
+## OpenAPI
+
+Integrate OpenAPI specifications directly into your navigation structure to automatically generate API documentation. Create dedicated API sections or place endpoint pages within other navigation components.
+
+Set a default OpenAPI specification at any level of your navigation hierarchy. Child elements will inherit this specification unless they define their own specification.
+
+```json
+{
+  "navigation": {
+    "openapi": "/path/to/openapi.json",
+    "tabs": [
+      {
+        "tab": "API v1 reference",
+        "pages": [
+          "overview",
+          "authentication",
+          "GET /users",
+          "POST /users"
+        ]
+      },
+      {
+        "tab": "API v2 reference",
+        "openapi": "/specs/v2.json", 
+        "pages": [
+          "GET /users",
+          "POST /users"
+        ]
+      }
+    ]
+  }
+}
+```
+
+For more information about referencing OpenAPI endpoints in your docs, see the [OpenAPI setup](/api-playground/openapi-setup).
+
+---
+
 ## Versions
 
-Versions can be leveraged to partition your navigation into different versions.
+Partition your navigation into different versions.
 
 <img
   className="block dark:hidden pointer-events-none"
@@ -305,7 +342,7 @@ Versions can be leveraged to partition your navigation into different versions.
 
 ## Languages
 
-Languages can be leveraged to partition your navigation into different languages.
+Partition your navigation into different languages.
 
 <img
   className="block dark:hidden pointer-events-none"


### PR DESCRIPTION
## Documentation changes

This PR updates our docs on creating API pages with instructions for the more flexible use of OpenAPI specs and the `x-mint` extension

- Conceptual and procedural information on configuring navigation for endpoint pages generated from OpenAPI specs
- Info on how to use the `x-mint` extension to override metadata and add content to an endpoint page
- Guide on migrating from individual MDX pages for endpoints to using an OpenAPI spec and the `navigation` in `docs.json`

Closes https://linear.app/mintlify/issue/DOC-116/openapi-docs-granular-control

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
