### PR TITLE
Add pnpm back to CLI docs

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -24,9 +24,15 @@ icon: "terminal"
   <Step title="Install the CLI.">
     Run the following command to install the [CLI](https://www.npmjs.com/package/mint):
 
-    ```bash
+  <CodeGroup>
+    ```bash npm
     npm i -g mint
     ```
+
+    ```bash pnpm
+    pnpm i -g mint
+    ```
+  </CodeGroup>
 
   </Step>
   <Step title="Preview locally.">
@@ -137,6 +143,8 @@ If you use JetBrains, we recommend the [MDX IntelliJ IDEA plugin](https://plugin
   </Accordion>
   <Accordion title="mintlify vs. mint package">
     If you have any problems with the CLI package, you should first run `npm ls -g`. This command shows what packages are globally installed on your machine.
+
+    If you don't use npm or don't see it in the -g list, try `which mint` to locate the installation.
     
     If you have a package named `mint` and a package named `mintlify` installed, you should uninstall `mintlify`.
     

--- a/installation.mdx
+++ b/installation.mdx
@@ -30,7 +30,7 @@ icon: "terminal"
     ```
 
     ```bash pnpm
-    pnpm i -g mint
+    pnpm add -g mint
     ```
   </CodeGroup>
 
@@ -62,9 +62,15 @@ mint update
 
 If this `mint update` command is not available on your local version, re-install the CLI with the latest version:
 
-```bash
-npm i -g mint@latest
-```
+ <CodeGroup>
+    ```bash npm
+    npm i -g mint@latest
+    ```
+
+    ```bash pnpm
+    pnpm add -g mint@latest
+    ```
+  </CodeGroup>
 
 ## Custom ports
 
@@ -158,7 +164,7 @@ If you use JetBrains, we recommend the [MDX IntelliJ IDEA plugin](https://plugin
     ```
     3. Reinstall the new package:
     ```bash
-      npm install -g mint
+    npm i -g mint
     ```
   </Accordion>
 </AccordionGroup>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -82,9 +82,15 @@ The code-based workflow integrates with your existing development environment an
 
 To work locally with your documentation, install the Command Line Interface (CLI), called [mint](https://www.npmjs.com/package/mint), by running this command in your terminal:
 
-```bash
-npm i -g mint
-```
+<CodeGroup>
+  ```bash npm
+  npm i -g mint
+  ```
+
+  ```bash pnpm
+  pnpm add -g mint
+  ```
+</CodeGroup>
 
 <Info>
   You need Node.js installed on your machine. If you encounter installation issues, check the troubleshooting guide.


### PR DESCRIPTION
## Documentation changes

We shipped improvements to pnpm compatibility in https://github.com/mintlify/mint/pull/3428
This PR adds the CodeGroup snippet for installing with pnpm back into the docs

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
