### PR TITLE
Disable indexing on changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -2,6 +2,7 @@
 title: "Product updates"
 description: "New updates and improvements"
 rss: true
+noindex: true
 ---
 
 <Update label="June 2025" rss={{ title: "June Product Updates", description: "AI assistant updates and subscribable changelogs" }}>


### PR DESCRIPTION
## Documentation changes

This PR adds `noindex: true` to the changelog.

Because the changelog represents moments in time and not an always up to date source of truth, we should remove it from the assistant's indexing. This should help the assistant stop referencing deprecated items that are in the changelog, but not the rest of the docs like `mint.json` and the AI widget.

However, this also disables SEO indexing, so cc @tiffany-mintlify to make sure there aren't unintended consequences of that.

Ultimately, there shouldn't be an expectation that the changelog is evergreen. Things will change over time and we shouldn't be trying to maintain accuracy in the changelog. Both for transparency and because that is just duplicating the docs, but in a worse way.

Part of https://linear.app/mintlify/issue/DOC-122/formalize-changelog-process 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
