### PR TITLE
Add link to docs.json schema to AI tool guides

### DIFF
--- a/guides/claude-code.mdx
+++ b/guides/claude-code.mdx
@@ -49,6 +49,10 @@ Copy this example template or make changes for your docs specifications:
 - Check existing patterns for consistency
 - Start by making the smallest reasonable changes
 
+## docs.json
+
+- Refer to the [docs.json schema](https://mintlify.com/docs.json) when building the docs.json file and site navigation
+
 ## Frontmatter requirements for pages
 - title: Clear, descriptive page title
 - description: Concise summary for SEO/navigation

--- a/guides/cursor.mdx
+++ b/guides/cursor.mdx
@@ -68,6 +68,10 @@ You are an AI writing assistant specialized in creating exceptional technical do
 
 ## Mintlify component reference
 
+### docs.json
+
+- Refer to the [docs.json schema](https://mintlify.com/docs.json) when building the docs.json file and site navigation
+
 ### Callout components
 
 #### Note - Additional helpful information

--- a/guides/windsurf.mdx
+++ b/guides/windsurf.mdx
@@ -62,6 +62,10 @@ description: "Concise description for SEO and navigation"
 
 ## Mintlify components
 
+### docs.json
+
+- Refer to the [docs.json schema](https://mintlify.com/docs.json) when building the docs.json file and site navigation
+
 ### Callouts
 
 - `<Note>` for helpful supplementary information


### PR DESCRIPTION
## Documentation changes

This PR links to https://mintlify.com/docs.json in all the example rules for AI assistants.

Closes https://linear.app/mintlify/issue/DOC-124/add-docsjson-reference-to-all-ai-rules

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
