### PR TITLE
feat: add hosted mcp options in context menu

### DIFF
--- a/ai/contextual-menu.mdx
+++ b/ai/contextual-menu.mdx
@@ -10,12 +10,18 @@ The contextual menu provides quick access to AI-optimized content and direct int
 
 ## Menu options
 
-- **Copy page**: Copies the current page as Markdown for pasting as context into AI tools.
-- **View as Markdown**: Opens the current page as Markdown.
-- **Open in ChatGPT**: Creates a ChatGPT conversation with the current page as context.
-- **Open in Claude**: Creates a Claude conversation with the current page as context.
-- **Open in Perplexity**: Creates a Perplexity conversation with the current page as context.
-- **[Your custom options](#adding-custom-options)**: Add your own options to the menu.
+The contextual menu includes several pre-built options that you can enable by adding their identifier to your configuration.
+
+| Option | Identifier | Description |
+|:--------|:------------|:-------------|
+| **Copy page** | `copy` | Copies the current page as Markdown for pasting as context into AI tools |
+| **View as Markdown** | `view` | Opens the current page as Markdown |
+| **Open in ChatGPT** | `chatgpt` | Creates a ChatGPT conversation with the current page as context |
+| **Open in Claude** | `claude` | Creates a Claude conversation with the current page as context |
+| **Open in Perplexity** | `perplexity` | Creates a Perplexity conversation with the current page as context |
+| **Copy MCP Server URL** | `mcp` | Copies the MCP server URL to the clipboard |
+| **Open in Cursor** | `cursor` | Installs the hosted MCP server in Cursor |
+| **Open in VSCode** | `vscode` | Installs the hosted MCP server in VSCode |
 
 <Frame>
     <img 
@@ -36,7 +42,10 @@ Add the `contextual` field to your `docs.json` file and specify which options yo
      "view",
      "chatgpt",
      "claude",
-     "perplexity"
+     "perplexity",
+     "mcp",
+     "cursor",
+     "vscode"
    ]
  }
 }
@@ -75,7 +84,10 @@ Create custom options in the contextual menu by adding an object to the `options
         </ResponseField>
 
         <ResponseField name="value" type="string" required>
-          The query parameter value. Use `$page` to insert the current page content in Markdown or `$path` to insert the current page path.
+          The query parameter value. We will replace the following placeholders with the corresponding values:
+          - Use `$page` to insert the current page content in Markdown.
+          - Use `$path` to insert the current page path.
+          - Use `$mcp` to insert the hosted MCP server URL.
         </ResponseField>
       </Expandable>
     </ResponseField>
@@ -103,3 +115,35 @@ Example custom option:
     }
 }
 ```
+
+### Custom option examples
+
+<AccordionGroup>
+<Accordion title="Simple link">
+```json
+{
+  "title": "Request a feature",
+  "description": "Join the discussion on GitHub",
+  "icon": "plus",
+  "href": "https://github.com/orgs/mintlify/discussions/categories/feature-requests"
+}
+```
+</Accordion>
+
+<Accordion title="Dynamic link with page content">
+```json
+{
+  "title": "Share on X",
+  "description": "Share this page on X",
+  "icon": "x",
+  "href": {
+    "base": "https://x.com/intent/tweet",
+    "query": {
+      "key": "text",
+      "value": "Check out this documentation: $page"
+    }
+  }
+}
+```
+</Accordion>
+</AccordionGroup>


### PR DESCRIPTION
## Documentation changes

Add `mcp`, `cursor`, `vscode` in context menu.