### PR TITLE
Include `/mcp` in note about reserved paths

### DIFF
--- a/navigation.mdx
+++ b/navigation.mdx
@@ -9,7 +9,7 @@ The [navigation](settings#param-navigation) property in [docs.json](settings) de
 With proper navigation configuration, you can organize your content into a logical hierarchy that makes it easy for users to find exactly what they're looking for.
 
 <Info>
-  Do not use `api` as a title for any navigation element. The `/api` path is reserved in production and will cause pages to return 404 errors if their URLs contain `/api`.
+  Do not use `api` or `mcp` as titles for any navigation element. The `/api` and `/mcp` paths are reserved in production and will cause pages to return 404 errors if their URLs contain `/api` or `/mcp`.
 </Info>
 
 ## Pages


### PR DESCRIPTION
## Documentation changes

The `/mcp` path is now reserved in production for hosted MCP servers. This PR updates the note in navigation about reserved paths to include `/mcp`

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
