### PR TITLE
Update the type of "default" in ParamField to be "any"

### DIFF
--- a/components/fields.mdx
+++ b/components/fields.mdx
@@ -23,7 +23,8 @@ The `<ParamField>` component is used to define parameters for your APIs or SDKs.
 ### Properties
 
 <ParamField body="query, path, body, or header" type="string">
-  Whether the parameter is a query, path, body, or header. Followed by the parameter name.
+  Whether the parameter is a query, path, body, or header. Followed by the
+  parameter name.
 </ParamField>
 
 <ParamField body="type" type="string">
@@ -43,7 +44,7 @@ Arrays can be defined using the `[]` suffix. For example `string[]`.
   Indicate whether the parameter is deprecated.
 </ParamField>
 
-<ParamField body="default" type="string">
+<ParamField body="default" type="any">
   Default value populated when the request value is empty
 </ParamField>
 


### PR DESCRIPTION
## Documentation changes

In https://github.com/mintlify/mint/pull/3545, the type of "default" in ParamField was changed to "any". This updates the docs to reflect this.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
