### PR TITLE
Domain identifier for chat API

### DIFF
--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -31,7 +31,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The domain identifier that can be found in the top left corner of the Mintlify dashboard"
+            "description": "The domain identifier from your `domain.mintlify.app` URL. Can be found in the top left of your dashboard."
           }
         ],
         "requestBody": {


### PR DESCRIPTION
## Documentation changes

This PR adds a little more detail to what the domain identifier is for the chat API.

Closes https://linear.app/mintlify/issue/DOC-132/how-to-find-subdomain-for-chat-api

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
