### PR TITLE
X-mint nit about version and deprecated

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -101,7 +101,7 @@ The `x-mint` extension is a custom OpenAPI extension that provides additional co
 
 ### Metadata
 
-Override the default metadata for generated API pages by adding `x-mint: metadata` to any operation. You can use any metadata field that would be valid in `MDX` frontmatter except for `openapi`, `version`, or `deprecated`:
+Override the default metadata for generated API pages by adding `x-mint: metadata` to any operation. You can use any metadata field that would be valid in `MDX` frontmatter except for `openapi`:
 
 ```json {7-13}
 {


### PR DESCRIPTION
## Documentation changes

It was decided in the `x-mint` PR to allow `x-mint: metadata` to set `version` and `deprecated`, but this wasn't reflected in the docs update. 

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
