### PR TITLE
Capitalize href

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -154,7 +154,7 @@ Add content before the auto-generated API documentation using `x-mint: content`:
 
 The `content` extension supports all Mintlify MDX components and formatting.
 
-### href
+### Href
 
 Change the URL of the endpoint page in your docs using `x-mint: href`:
 


### PR DESCRIPTION
## Documentation changes

Capitalize the "Href" section title.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
