### PR TITLE
fix: Update links on index

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -46,27 +46,27 @@ export const HeroCard = ({ filename, title, description, href }) => {
     </div>
 
     <div className="px-6 lg:px-0 mt-12 lg:mt-24 grid sm:grid-cols-2 gap-x-6 gap-y-4">
-      <HeroCard filename="rocket" title="Quickstart" description="Deploy your first docs site in minutes with our step-by-step guide" href="/quickstart" />
+      <HeroCard filename="rocket" title="Quickstart" description="Deploy your first docs site in minutes with our step-by-step guide" href="/docs/quickstart" />
 
       <HeroCard
         filename="cli"
         title="CLI installation"
         description="Install the CLI to preview and develop your docs locally"
-        href="/installation"
+        href="/docs/installation"
       />
 
       <HeroCard
         filename="editor"
         title="Web editor"
         description="Make quick updates and manage content with our browser-based editor"
-        href="/editor"
+        href="/docs/editor"
       />
 
       <HeroCard
         filename="components"
         title="Components"
         description="Build rich, interactive documentation with our ready-to-use components"
-        href="/components"
+        href="/docs/text"
       />
     </div>
   </div>


### PR DESCRIPTION
## Documentation changes

- Fix some broken links to include the `/docs` base URL.
- `/components` doesn't seem to have a relevant page so I'm pointing to the first component in the list instead: `/docs/text`

Closes #1011

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [x] Code examples work as written
- [x] Commands and configurations are correct
- [x] Links resolve to the right destinations
- [x] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [x] Instructions are clear and easy to follow
- [x] Steps are in logical order
- [x] Nothing important is missing
- [x] Examples help illustrate the concepts

### ✅ User experience
- [x] A new user could follow these docs successfully
- [x] Common gotchas or edge cases are addressed
- [x] Error messages or troubleshooting guidance is helpful
