### PR TITLE
Clarify how `colors` work

### DIFF
--- a/settings.mdx
+++ b/settings.mdx
@@ -52,7 +52,7 @@ See [Themes](themes) for more information.
 </ResponseField>
 
 <ResponseField name="colors" type="object" required>
-  The colors to use in your documentation. A primary color is required. For example:
+  The colors used in your documentation. Themes apply colors to different components. A primary color is required. For example:
   ```json
   {
     "colors": {
@@ -63,17 +63,17 @@ See [Themes](themes) for more information.
 
   <Expandable title="Colors">
     <ResponseField name="primary" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$" required>
-      The primary color of your theme.
+      The primary color of your theme. Used as the emphasis color in light mode.
       
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="light" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      Light color variant of your theme.
+      A light color variant of your theme. Used as the emphasis color in dark mode.
       
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="dark" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      Dark color variant of your theme.
+      A dark color variant of your theme. Used as a tertiary color for emphasis depending on the theme.
       
       Must be a hex code beginning with `#`.
     </ResponseField>

--- a/settings.mdx
+++ b/settings.mdx
@@ -52,28 +52,21 @@ See [Themes](themes) for more information.
 </ResponseField>
 
 <ResponseField name="colors" type="object" required>
-  The colors used in your documentation. Themes apply colors to different components. A primary color is required. For example:
-  ```json
-  {
-    "colors": {
-      "primary": "#ff0000"
-    }
-  }
-  ```
+  The colors used in your documentation. Colors are applied differently across themes. If you only provide a primary color, it will be used for all color elements.
 
   <Expandable title="Colors">
     <ResponseField name="primary" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$" required>
-      The primary color of your theme. Used as the emphasis color in light mode.
+      The primary color for your documentation. Generally used for emphasis in light mode, with some variation by theme.
       
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="light" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      A light color variant of your theme. Used as the emphasis color in dark mode.
+      The color used for emphasis in dark mode.
       
       Must be a hex code beginning with `#`.
     </ResponseField>
     <ResponseField name="dark" type="string matching ^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$">
-      A dark color variant of your theme. Used as a tertiary color for emphasis depending on the theme.
+      The color used for buttons and hover states across both light and dark modes, with some variation by theme.
       
       Must be a hex code beginning with `#`.
     </ResponseField>


### PR DESCRIPTION
## Documentation changes

This PR updates the `colors` section of the navigation page.

`colors` are unique since they have a `light` and `dark` param, but they don't relate to light/dark mode like other `light`/`dark` parameters for other fields.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
