### PR TITLE
Add hidden page on PDF exports

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -508,6 +508,9 @@
       "destination": "api-reference/assistant/*"
     }
   ],
+  "seo": {
+    "indexing": "all"
+  },
   "integrations": {
     "ga4": {
       "measurementId": "G-RCYWHL7EQ7"

--- a/docs.json
+++ b/docs.json
@@ -508,9 +508,6 @@
       "destination": "api-reference/assistant/*"
     }
   ],
-  "seo": {
-    "indexing": "all"
-  },
   "integrations": {
     "ga4": {
       "measurementId": "G-RCYWHL7EQ7"

--- a/pdf-exports.mdx
+++ b/pdf-exports.mdx
@@ -1,0 +1,22 @@
+---
+title: "PDF exports"
+description: "Export your docs as a single PDF file"
+---
+
+<Info>
+PDF exports are available on [Custom plans](https://mintlify.com/pricing).
+</Info>
+
+You can export your docs as a single PDF file for offline viewing. The PDF will contain all the content in the docs, including images and links, and a navigable table of contents.
+
+## Exporting a PDF
+
+1. Navigate to the [General](https://dashboard.mintlify.com/settings/deployment/general) page in the Project Settings section of your dashboard.
+2. Select the **Export all content** button.
+3. Optionally, customize the export options:
+    - **Page format**: Choose the page size of the PDF.
+    - **Scale percentage**: Adjust the scale of the PDF.
+    - **Include footer**: Include a footer with the page number and total pages.
+4. Select **Export** to start the export process.
+5. Once the export is complete, you will receive an email with a download link.
+6. Click the download link to download the PDF file.


### PR DESCRIPTION
## Documentation changes

This PR adds a hidden page about PDF exports. It includes the plan they're available for (Custom), that it exports all content in your docs, and the steps to export a PDF.

Adding this as a hidden page since it's a pretty niche task and it seems better to only display it for people who search for it rather than further expanding what is in the sidebar navigation.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
