### PR TITLE
Add new installation page before current

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -22,6 +22,7 @@
             "pages": [
               "index",
               "quickstart",
+              "installation-overview",
               "installation",
               {
                 "group": "Web editor",

--- a/installation-overview.mdx
+++ b/installation-overview.mdx
@@ -1,0 +1,164 @@
+---
+title: "Getting started with Mintlify"
+sidebarTitle: "Overview"
+description: "Choose the best way to get started building documentation with Mintlify"
+icon: "rocket"
+---
+
+Welcome to Mintlify! You have multiple ways to start building beautiful documentation. Choose the approach that best fits your workflow and technical requirements.
+
+## Quick start options
+
+<CardGroup cols={2}>
+<Card title="Web editor" icon="mouse-pointer-2" href="/editor/getting-started">
+  **Recommended for beginners**
+  
+  Start building immediately in your browser with our intuitive web editor. No setup required.
+</Card>
+
+<Card title="Local development" icon="terminal" href="/installation">
+  **Recommended for developers**
+  
+  Use the CLI for local development with your preferred code editor and git workflow.
+</Card>
+</CardGroup>
+
+## Choose your path
+
+### Web editor approach
+
+<Info>
+**Perfect for**: Content creators, marketers, technical writers, and anyone who wants to start quickly without setup.
+</Info>
+
+The web editor provides a complete documentation authoring experience directly in your browser:
+
+- **Zero setup**: Start writing immediately without installing anything
+- **Live preview**: See changes instantly as you type
+- **Git integration**: Automatically syncs with your GitHub repository
+- **Collaborative editing**: Multiple team members can edit simultaneously
+- **Built-in publishing**: Deploy changes with a single click
+
+<Steps>
+<Step title="Sign up and connect your repository">
+  Create a Mintlify account and connect your GitHub repository at [mintlify.com/start](https://mintlify.com/start).
+</Step>
+
+<Step title="Start editing">
+  Use our web editor to create and modify documentation pages with live preview.
+  
+  <Tip>
+  The web editor includes syntax highlighting, autocomplete, and real-time collaboration features.
+  </Tip>
+</Step>
+
+<Step title="Publish your changes">
+  Click **Publish** to deploy your documentation instantly to the web.
+</Step>
+</Steps>
+
+### Local development approach
+
+<Info>
+**Perfect for**: Developers who prefer working locally, teams with complex workflows, or projects requiring custom scripts and automation.
+</Info>
+
+Local development gives you full control over your documentation workflow:
+
+- **Your preferred editor**: Use VS Code, Cursor, Windsurf, or any editor you love
+- **Git workflow**: Standard branching, pull requests, and version control
+- **Advanced features**: Custom scripts, automated testing, and CI/CD integration
+- **Offline editing**: Work without an internet connection
+- **Performance**: Faster for large documentation sites
+
+<Steps>
+<Step title="Install Node.js">
+  Download and install [Node.js](https://nodejs.org/en) (version 16 or later) on your machine.
+  
+  <Check>
+  Verify installation by running `node --version` in your terminal.
+  </Check>
+</Step>
+
+<Step title="Install the Mintlify CLI">
+  Continue to our [CLI installation guide](/installation) for detailed setup instructions.
+</Step>
+
+<Step title="Clone your repository">
+  Clone your documentation repository locally and start the development server.
+</Step>
+</Steps>
+
+## Comparison: Web editor vs. local development
+
+<Tabs>
+<Tab title="Feature comparison">
+| Feature | Web editor | Local development |
+|---------|------------|-------------------|
+| **Setup time** | Instant | ~5 minutes |
+| **Internet required** | Yes | No (after setup) |
+| **Collaboration** | Real-time | Git-based |
+| **Editor features** | Built-in | Your choice |
+| **Advanced workflows** | Limited | Full control |
+| **Performance** | Good | Excellent |
+| **Learning curve** | Minimal | Moderate |
+</Tab>
+
+<Tab title="Use cases">
+**Choose web editor if you:**
+- Want to start immediately without setup
+- Primarily write content rather than code
+- Work in small teams with simple workflows
+- Prefer browser-based tools
+- Need real-time collaboration
+
+**Choose local development if you:**
+- Are comfortable with command-line tools
+- Have existing git-based workflows
+- Need custom build processes or scripts
+- Work with large documentation sites
+- Prefer your own code editor
+- Want to work offline
+</Tab>
+</Tabs>
+
+## Hybrid approach
+
+<Note>
+You're not locked into one approach! Many teams use both methods:
+
+- **Content creators** use the web editor for writing and editing
+- **Developers** use local development for structure, configuration, and complex changes
+- **Everyone** benefits from automatic git synchronization between approaches
+</Note>
+
+Both methods work with the same underlying MDX files and `docs.json` configuration, so you can switch between them seamlessly.
+
+## What's included with Mintlify
+
+Regardless of which approach you choose, you get access to all Mintlify features:
+
+- **Modern components**: Callouts, tabs, accordions, code groups, and more
+- **API documentation**: Auto-generated from OpenAPI specifications  
+- **Authentication**: Restrict access with custom login flows
+- **Analytics**: Built-in insights and integration with popular tools
+- **Custom domains**: Host documentation on your own domain
+- **SEO optimization**: Automatic sitemap generation and meta tags
+- **Search**: Full-text search across your entire documentation
+- **Themes**: Beautiful, customizable designs that match your brand
+
+## Ready to begin?
+
+<CardGroup cols={2}>
+<Card title="Start with web editor" icon="mouse-pointer-2" href="/editor/getting-started">
+  Jump right in with our browser-based editor
+</Card>
+
+<Card title="Set up local development" icon="terminal" href="/installation">
+  Install the CLI and start developing locally  
+</Card>
+</CardGroup>
+
+<Tip>
+If you're not sure which approach to choose, we recommend starting with the web editor. You can always switch to local development later as your needs grow.
+</Tip>

--- a/installation.mdx
+++ b/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CLI installation"
-sidebarTitle: "Installation"
+sidebarTitle: "CLI setup"
 description: "Install the CLI to preview and develop your docs locally"
 icon: "terminal"
 ---


### PR DESCRIPTION
## Documentation changes

Introduces a new "Installation Overview" page to guide users in choosing between web editor and local development approaches, improving the initial onboarding experience. The existing "Installation" page has been renamed to "CLI setup" to clarify its specific focus.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [x] Code examples work as written
- [x] Commands and configurations are correct
- [x] Links resolve to the right destinations
- [x] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [x] Instructions are clear and easy to follow
- [x] Steps are in logical order
- [x] Nothing important is missing
- [x] Examples help illustrate the concepts

### ✅ User experience
- [x] A new user could follow these docs successfully
- [x] Common gotchas or edge cases are addressed
- [x] Error messages or troubleshooting guidance is helpful

---
[Slack Thread](https://mintlify.slack.com/archives/C09FDBTRS2W/p1757995219110469?thread_ts=1757995219.110469&cid=C09FDBTRS2W)

<a href="https://cursor.com/background-agent?bcId=bc-6bae007e-5aea-41de-a159-fb680113fcbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bae007e-5aea-41de-a159-fb680113fcbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

