### PR TITLE
Replace references to '/api' in docs

### DIFF
--- a/api-playground/troubleshooting.mdx
+++ b/api-playground/troubleshooting.mdx
@@ -65,9 +65,9 @@ If your API pages aren't displaying correctly, check these common configuration 
   <Accordion title="Requests from the API Playground don't work">
     If you have a custom domain configured, this could be an issue with your reverse proxy. By
     default, requests made via the API Playground start with a `POST` request to the
-    `/api/request` path on the docs site. If your reverse proxy is configured to only allow `GET`
+    `/_mintlify/api/request` path on the docs site. If your reverse proxy is configured to only allow `GET`
     requests, then all of these requests will fail. To fix this, configure your reverse proxy to
-    allow `POST` requests to the `/api/request` path.
+    allow `POST` requests to the `/_mintlify/api/request` path.
 
     Alternatively, if your reverse proxy prevents you from accepting `POST` requests, you can configure Mintlify to send requests directly to your backend with the `api.playground.proxy` setting in the `docs.json`, as described in the [settings documentation](/settings#param-proxy). When using this configuration, you will need to configure CORS on your server since requests will come directly from users' browsers rather than through your proxy.
   </Accordion>

--- a/snippets/vercel-json-generator.mdx
+++ b/snippets/vercel-json-generator.mdx
@@ -5,8 +5,12 @@ export const VercelJsonGenerator = () => {
   const vercelConfig = {
     rewrites: [
       {
+        source: "/_mintlify/api/request",
+        destination: `https://${subdomain}.mintlify.app/_mintlify/api/request`
+      },
+      {
         source: "/api/request",
-        destination: `https://${subdomain}.mintlify.app/api/request`
+        destination: `https://${subdomain}.mintlify.app/_mintlify/api/request`
       },
       {
         source: `/${subdirectory}`,


### PR DESCRIPTION
Replace references to '/api' in docs