### PR TITLE
Update page icon types

### DIFF
--- a/pages.mdx
+++ b/pages.mdx
@@ -5,8 +5,6 @@ icon: "letter-text"
 keywords: ["tags", "tag"]
 ---
 
-import IconsOptional from "/snippets/icons-optional.mdx";
-
 Each page is an MDX file, which combines Markdown content with React components to let you create rich, interactive documentation.
 
 ## Page metadata
@@ -30,7 +28,21 @@ Use metadata to control:
   A short title that displays in the sidebar navigation.
 </ResponseField>
 
-<IconsOptional />
+<ResponseField name="icon" type="string">
+  The icon to display.
+  
+  Options:
+  - [Font Awesome icon](https://fontawesome.com/icons) name
+  - [Lucide icon](https://lucide.dev/icons) name
+  - URL to an externally hosted icon
+  - Path to an icon file in your project
+</ResponseField>
+
+<ResponseField name="iconType" type="string">
+  The [Font Awesome](https://fontawesome.com/icons) icon style. Only used with Font Awesome icons. 
+  
+  Options: `regular`, `solid`, `light`, `thin`, `sharp-solid`, `duotone`, `brands`.
+</ResponseField>
 
 <ResponseField name="tag" type="string">
   A tag that appears next to your page title in the sidebar.


### PR DESCRIPTION
## Documentation changes

This PR updates the page metadata section because you cannot put an SVG in the YAML frontmatter of a page.

Closes https://linear.app/mintlify/issue/DOC-157/update-the-pages-page-for-icons

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
