### PR TITLE
Add Twoslash code block info

### DIFF
--- a/code.mdx
+++ b/code.mdx
@@ -77,6 +77,35 @@ class HelloWorld {
 ```
 ````
 
+### Twoslash
+
+In JavaScript and TypeScript code blocks, use `twoslash` to enable interactive type information. Users can hover over variables, functions, and parameters to see types and errors like in an IDE. 
+
+
+```ts title="Twoslash Example" twoslash
+type Pet = "cat" | "dog" | "hamster";
+
+function adoptPet(name: string, type: Pet) {
+  return `${name} the ${type} is now adopted!`;
+}
+
+// Hover to see the inferred types
+const message = adoptPet("Mintie", "cat");
+```
+
+````mdx
+```ts title="Twoslash Example" twoslash
+type Pet = "cat" | "dog" | "hamster";
+
+function adoptPet(name: string, type: Pet) {
+  return `${name} the ${type} is now adopted! 🎉`;
+}
+
+// Hover to see the inferred types
+const message = adoptPet("Mintie", "cat");
+```
+````
+
 ### Title
 
 Add a title to label your code example. Use `title="Your title"` or a string on a single line.


### PR DESCRIPTION
## Documentation changes

This PR documents the `twoslash` keyword for code blocks and adds an example.

Note: currently only working locally with `mint-twoslash`

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
