### PR TITLE
fix image dimensions documentation for HTML embeds

### DIFF
--- a/image-embeds.mdx
+++ b/image-embeds.mdx
@@ -37,24 +37,55 @@ Image files must be less than 20 MB. For larger files, host them on a CDN servic
 For more control over image display, use HTML `<img>` tags:
 
 ```html
-<img 
-  src="/images/dashboard.png" 
+<img
+  src="/images/dashboard.png"
   alt="Main dashboard interface"
-  height="300"
+  style={{ height: '300px' }}
   className="rounded-lg"
 />
 ```
+
+#### Control image dimensions
+
+To set image dimensions, use the `style` prop with CSS properties:
+
+```html
+<!-- Set width -->
+<img
+  src="/images/example.png"
+  alt="Example image"
+  style={{ width: '350px' }}
+/>
+
+<!-- Set height -->
+<img
+  src="/images/example.png"
+  alt="Example image"
+  style={{ height: '200px' }}
+/>
+
+<!-- Set both width and height -->
+<img
+  src="/images/example.png"
+  alt="Example image"
+  style={{ width: '300px', height: '200px' }}
+/>
+```
+
+<Note>
+  Use the `style` prop instead of HTML attributes like `width` and `height` for dimension control in Mintlify.
+</Note>
 
 #### Disable zoom functionality
 
 To disable the default zoom on click for images, add the `noZoom` property:
 
 ```html highlight="4"
-<img 
-  src="/images/screenshot.png" 
+<img
+  src="/images/screenshot.png"
   alt="Descriptive alt text"
-  noZoom 
-  height="200"
+  noZoom
+  style={{ height: '200px' }}
 />
 ```
 
@@ -64,11 +95,11 @@ To make an image a clickable link, wrap the image in an anchor tag and add the `
 
 ```html
 <a href="https://mintlify.com" target="_blank">
-  <img 
-    src="/images/logo.png" 
+  <img
+    src="/images/logo.png"
     alt="Mintlify logo"
-    noZoom 
-    height="100"
+    noZoom
+    style={{ height: '100px' }}
   />
 </a>
 ```
@@ -114,7 +145,7 @@ Embed YouTube videos using iframe elements:
   className="w-full aspect-video rounded-xl"
   src="https://www.youtube.com/embed/4KzFe50RQkQ"
   title="YouTube video player"
-  frameBorder="0"
+  style={{ border: 'none' }}
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>
@@ -125,7 +156,7 @@ Embed YouTube videos using iframe elements:
   className="w-full aspect-video rounded-xl"
   src="https://www.youtube.com/embed/4KzFe50RQkQ"
   title="YouTube video player"
-  frameBorder="0"
+  style={{ border: 'none' }}
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
   allowFullScreen
 ></iframe>


### PR DESCRIPTION
Closes #1342 

## Summary
Fixed the issues in the docs. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to use `style` for image dimensions and `style={{ border: 'none' }}` for iframes, adding examples and guidance.
> 
> - **Docs (`image-embeds.mdx`)**:
>   - **HTML `<img>` embeds**:
>     - Replace `height`/`width` attributes with `style` prop for dimensions (e.g., `style={{ height: '200px' }}`).
>     - Add "Control image dimensions" section with examples for width, height, and both.
>     - Add note recommending `style` over HTML `width`/`height`.
>     - Update `noZoom` and linked image examples to use `style` for sizing.
>   - **YouTube iframes**:
>     - Replace `frameBorder="0"` with `style={{ border: 'none' }}` in both examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1be34e0fcfd7ed703fa6cfcb3bff851eeea2546c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->