### PR TITLE
Fix capitalization

### DIFF
--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -22,7 +22,7 @@ To get started, add the agent to your Slack workspace and mention it with `@mint
 ## Add the agent to your Slack workspace
 
 <Note>
-  If your Slack Workspace Owner requires admin approval to install apps, ask them to approve the mintlify app before you connect it.
+  If your Slack Workspace Owner requires admin approval to install apps, ask them to approve the Mintlify app before you connect it.
 </Note>
 
 1. Navigate to the [agent](https://dashboard.mintlify.com/products/agent) page of your dashboard.


### PR DESCRIPTION
## Documentation changes

This PR capitalizes Mintlify. The Mintlify GitHub app is lowercase `mintlify`, but it looks weird and most people will see it as a typo.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
