### PR TITLE
Place code examples in CodeGroups

### DIFF
--- a/code.mdx
+++ b/code.mdx
@@ -184,7 +184,7 @@ sayHello();
 ```
 
 ````mdx Format
-```javascript Line Focus Example focus={2,4-5}
+```javascript focus={2,4-5}
 const greeting = "Hello, World!";
 function sayHello() {
   console.log(greeting);
@@ -208,7 +208,7 @@ sayHello();
 ```
 
 ````mdx Format
-```javascript Show Line Numbers Example lines
+```javascript lines
 const greeting = "Hello, World!";
 function sayHello() {
   console.log(greeting);
@@ -341,7 +341,7 @@ sayHello();
 ```
 
 ````mdx Format
-```javascript
+```javascript wrap
 const greeting = "Hello, World! I am a long line of text that will wrap to the next line.";
 function sayHello() {
   console.log(greeting);
@@ -368,7 +368,7 @@ For multiple consecutive lines, specify the number of lines after a colon:
 The comment syntax must match your programming language (for example, `//` for JavaScript or `#` for Python).
 
 <CodeGroup>
-```js Diff example icon="code" lines
+```js Diff example lines
 const greeting = "Hello, World!"; // [!code ++]
 function sayHello() {
   console.log("Hello, World!"); // [!code --]
@@ -378,7 +378,7 @@ sayHello();
 ```
 
 ````text Format
-```js Diff Example icon="code" lines
+```js lines
 const greeting = "Hello, World!"; // [!code ++]
 function sayHello() {
   console.log("Hello, World!"); // [!code --]


### PR DESCRIPTION
## Documentation changes

This PR updates the samples in https://www.mintlify.com/docs/code to use CodeGroups for the rendered and formatted examples. This makes the page shorter and puts the code blocks in better context rather than having them stacked.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
