### PR TITLE
Update references to `metadata` in SEO page

### DIFF
--- a/settings/seo.mdx
+++ b/settings/seo.mdx
@@ -15,7 +15,7 @@ You can fully customize your site's meta tags by adding the `metatags` field to 
 
 ## Global meta tags
 
-You can set default meta tags by adding the `metadata` field to your `docs.json`.
+To set default meta tags for all pages, add the `metatags` field to your `docs.json`.
 
 ```json
 "seo": {
@@ -27,20 +27,20 @@ You can set default meta tags by adding the `metadata` field to your `docs.json`
 
 ## Page-specific meta tags
 
-Add your meta tags to the page's metadata like so:
+To set page-specific meta tags, add them to a page's frontmatter.
 
 ```mdx
 ---
-title: 'Your Example Page Title'
-'og:image': 'link to your meta tag image'
+title: "Your example page title"
+"og:image": "link to your meta tag image"
 ---
 ```
 
-<Warning>
-  Meta tags with colons need to be typed with quotes around them when you put them in the page metadata.
-</Warning>
+<Note>
+  Meta tags with colons must be wrapped in quotes.
+</Note>
 
-## Common Meta Tags Reference
+## Common meta tags reference
 Below is a comprehensive list of meta tags you can add to your `docs.json`. These meta tags help improve your site's SEO, social sharing, and browser compatibility.
 
 You can preview how your meta tags will appear on different platforms using [metatags.io](https://metatags.io/).
@@ -165,7 +165,7 @@ noindex: true
 ---
 ```
 
-You can also specify `noindex` for all pages in your docs by setting the `metadata.robots` field to `"noindex"` in your `docs.json`:
+You can also specify `noindex` for all pages in your docs by setting the `metatags.robots` field to `"noindex"` in your `docs.json`:
 
 ```json
 "seo": {


### PR DESCRIPTION
## Documentation changes

The SEO page incorrectly references `metadata` instead of `metatags`. This PR fixes that and cleans up some other style issues.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
