### PR TITLE
Update colors in `docs.json`

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,9 @@
   "theme": "maple",
   "name": "Mintlify",
   "colors": {
-    "primary": "#0D9373",
-    "light": "#55D799",
-    "dark": "#0D9373"
+    "primary": "#166E3F",
+    "light": "#26BD6C",
+    "dark": "#166E3F"
   },
   "favicon": "/favicon.ico",
   "icons": {


### PR DESCRIPTION
## Documentation changes

This PR adjusts the `colors` prop in our `docs.json` to use greens from our design system that have better contrast. This meets WCAG AA for `colors.primary` and `colors.dark` on light background, and WCAG AAA for `colors.light` on dark background, `colors.dark`. This fails contrast requirements for `colors.dark` on a dark background, but there is currently no way to achieve WCAG AA for `colors.dark` on light and dark backgrounds.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
