### PR TITLE
Disable Vale on translated directories

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -35,4 +35,13 @@ BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
 CommentDelimiters = {/*, */}
 
 [changelog.mdx]
-BasedOnStyles =
+BasedOnStyles = ""
+
+[**/es/**]
+BasedOnStyles = ""
+
+[**/fr/**]
+BasedOnStyles = ""
+
+[**/zh/**]
+BasedOnStyles = ""


### PR DESCRIPTION
## Documentation changes

This PR updates our .vale.ini file so that Vale doesn't run on translated content.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
