### PR TITLE
Use custom

### DIFF
--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -96,7 +96,7 @@ Custom mode provides a minimalist layout that removes all elements except for th
 ```yaml
 ---
 title: "Custom page title"
-mode: "frame"
+mode: "custom"
 ---
 ```
 


### PR DESCRIPTION
## Documentation changes

In a page, the custom mode uses `custom` and not `frame`.