### PR TITLE
fix(docs): update vercel generator to use subpath for root rewrite

### DIFF
--- a/snippets/es/vercel-json-generator.mdx
+++ b/snippets/es/vercel-json-generator.mdx
@@ -14,7 +14,7 @@ export const VercelJsonGenerator = () => {
       },
       {
         source: `/${subpath}`,
-        destination: `https://${subdomain}.mintlify.app`
+        destination: `https://${subdomain}.mintlify.app/${subpath}`
       },
       {
         source: `/${subpath}/llms.txt`,

--- a/snippets/fr/vercel-json-generator.mdx
+++ b/snippets/fr/vercel-json-generator.mdx
@@ -14,7 +14,7 @@ export const VercelJsonGenerator = () => {
       },
       {
         source: `/${subpath}`,
-        destination: `https://${subdomain}.mintlify.app`
+        destination: `https://${subdomain}.mintlify.app/${subpath}`
       },
       {
         source: `/${subpath}/llms.txt`,

--- a/snippets/vercel-json-generator.mdx
+++ b/snippets/vercel-json-generator.mdx
@@ -14,7 +14,7 @@ export const VercelJsonGenerator = () => {
       },
       {
         source: `/${subpath}`,
-        destination: `https://${subdomain}.mintlify.app`
+        destination: `https://${subdomain}.mintlify.app/${subpath}`
       },
       {
         source: `/${subpath}/llms.txt`,

--- a/snippets/zh/vercel-json-generator.mdx
+++ b/snippets/zh/vercel-json-generator.mdx
@@ -14,7 +14,7 @@ export const VercelJsonGenerator = () => {
       },
       {
         source: `/${subpath}`,
-        destination: `https://${subdomain}.mintlify.app`
+        destination: `https://${subdomain}.mintlify.app/${subpath}`
       },
       {
         source: `/${subpath}/llms.txt`,


### PR DESCRIPTION
## Documentation changes

This pull request updates the Vercel JSON generator code snippets in multiple language files to ensure that the destination path includes the subpath variable. This change ensures that requests to a given subpath are correctly routed to the corresponding subpath on the target domain.

* Updated the `destination` field in the Vercel JSON generator snippets (`snippets/vercel-json-generator.mdx`, `snippets/es/vercel-json-generator.mdx`, `snippets/fr/vercel-json-generator.mdx`, `snippets/zh/vercel-json-generator.mdx`) to append `/${subpath}` to the destination URL, ensuring correct path forwarding.


This now correctly matches the documentation found in the code defined above on the /deploy/vercel route:


  ```json
  {
    "rewrites": [
      {
        "source": "/docs",
        "destination": "https://[subdomain].mintlify.dev/docs"
      },
      {
        "source": "/docs/:match*",
        "destination": "https://[subdomain].mintlify.dev/docs/:match*"
      }
    ]
  }
  ```

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
