### PR TITLE
fix: add canonical

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1713,5 +1713,10 @@
     "ga4": {
       "measurementId": "G-RCYWHL7EQ7"
     }
+  },
+  "seo": {
+    "metatags": {
+      "canonical": "https://mintlify.com"
+    }
   }
 }


### PR DESCRIPTION
## Documentation changes

Add canonical to set the correct canonical url which is important for SEO. Right now it is:
<img width="547" height="51" alt="Screenshot 2025-10-14 at 3 39 41 PM" src="https://github.com/user-attachments/assets/5a150051-af48-48ba-8e8a-56b4049405bc" />
