### PR TITLE
fix: add /docs to canonical

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1716,7 +1716,7 @@
   },
   "seo": {
     "metatags": {
-      "canonical": "https://mintlify.com"
+      "canonical": "https://mintlify.com/docs"
     }
   }
 }


### PR DESCRIPTION
## Documentation changes

We need to include /docs subpath to make the routes correct
<img width="535" height="91" alt="Screenshot 2025-10-14 at 4 02 56 PM" src="https://github.com/user-attachments/assets/93dc63ab-70d4-48a5-a0b5-74d6733f2454" />
