### PR TITLE
Disable drilldown

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,6 +11,9 @@
   "icons": {
     "library": "lucide"
   },
+  "interaction": {
+    "drilldown": false
+  },
   "navigation": {
     "languages": [
       {


### PR DESCRIPTION
## Documentation changes

This PR sets `interaction.drilldown` to `false` on our docs. Drilldown makes selecting a page in a group harder on mobile, so disabling.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
