### PR TITLE
API cleanup

### DIFF
--- a/api/agent/create-agent-job.mdx
+++ b/api/agent/create-agent-job.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: POST /agent/{projectID}/job
+openapi: POST /agent/{projectId}/job
 ---
 
 This endpoint creates an agent job based on provided messages and branch information. The job executes asynchronously and returns a streaming response with the execution details and results.

--- a/api/agent/get-agent-job.mdx
+++ b/api/agent/get-agent-job.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: GET /agent/{projectID}/job/{id}
+openapi: GET /agent/{projectId}/job/{id}
 ---
 
 ## Usage

--- a/api/agent/get-all-jobs.mdx
+++ b/api/agent/get-all-jobs.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: GET /agent/{projectID}/jobs
+openapi: GET /agent/{projectId}/jobs
 ---
 
 ## Usage

--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: POST /assistant/{projectID}/message
+openapi: POST /assistant/{domain}/message
 ---
 
 ## Rate limits

--- a/api/assistant/search.mdx
+++ b/api/assistant/search.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /search/{projectID}"
+openapi: "POST /search/{domain}"
 ---

--- a/api/update/status.mdx
+++ b/api/update/status.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "GET /project/update-status/{statusID}"
+openapi: "GET /project/update-status/{statusId}"
 ---

--- a/api/update/trigger.mdx
+++ b/api/update/trigger.mdx
@@ -1,3 +1,3 @@
 ---
-openapi: "POST /project/update/{projectID}"
+openapi: "POST /project/update/{projectId}"
 ---


### PR DESCRIPTION
## Documentation changes

This PR fixes some inaccuracies in how to find project ID and domain parameters, removes deprecated endpoints, and removes unused endpoints from OpenAPI specs.

* `admin-openapi.json`
  * Removes hallucinated endpoints
  * Clearer info to find and copy your project ID
* `/assistant`
  * delete `create-topic.mdx`
  * delete `generate-message.mdx`
* `discovery-openapi.json`
  * Accurate information on where to find `{domain}`
  * Remove deprecated `/chat/topic` and `/chat/message` paths
* `docs.json`
  * Sentence case `API reference` group name
* `openapi.json`
  * Clearer information on how to find `{projectId}`

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
