### PR TITLE
fixed all of the redirects in the accordian that was missing leading …

### DIFF
--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -481,28 +481,28 @@ This section contains the full reference for the `docs.json` file.
       </Expandable>
     </ResponseField>
     <ResponseField name="languages" type="array of object">
-      Language switcher for [multi-language](organize/navigation#languages) sites.
+      Language switcher for [multi-language](/organize/navigation#languages) sites.
     </ResponseField>
     <ResponseField name="versions" type="array of object">
-      Version switcher for sites with multiple [versions](organize/navigation#versions).
+      Version switcher for sites with multiple [versions](/organize/navigation#versions).
     </ResponseField>
     <ResponseField name="tabs" type="array of object">
-      Top-level navigation [tabs](organize/navigation#tabs).
+      Top-level navigation [tabs](/organize/navigation#tabs).
     </ResponseField>
     <ResponseField name="anchors" type="array of object">
-      Sidebar [anchors](organize/navigation#anchors).
+      Sidebar [anchors](/organize/navigation#anchors).
     </ResponseField>
     <ResponseField name="dropdowns" type="array of object">
-      [Dropdowns](organize/navigation#dropdowns) for grouping related content.
+      [Dropdowns](/organize/navigation#dropdowns) for grouping related content.
     </ResponseField>
     <ResponseField name="products" type="array of object">
-      Product switcher for sites with multiple [products](organize/navigation#products).
+      Product switcher for sites with multiple [products](/organize/navigation#products).
     </ResponseField>
     <ResponseField name="groups" type="array of object">
-      [Groups](organize/navigation#groups) for organizing content into sections.
+      [Groups](/organize/navigation#groups) for organizing content into sections.
     </ResponseField>
     <ResponseField name="pages" type="array of string or object">
-      Individual [pages](organize/navigation#pages) that make up your documentation.
+      Individual [pages](/organize/navigation#pages) that make up your documentation.
     </ResponseField>
   </Expandable>
 </ResponseField>


### PR DESCRIPTION

## Documentation changes

Changed all of the redirects for a page that were broken, now should work since I added leading slash.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
