### PR TITLE
Fix missing "s" on components.schemas OpenAPI doc section

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -489,7 +489,7 @@ The scraper generates:
 
 ### Create `MDX` files for OpenAPI schemas
 
-You can create individual pages for any OpenAPI schema defined in an OpenAPI document's `components.schema` field:
+You can create individual pages for any OpenAPI schema defined in an OpenAPI document's `components.schemas` field:
 
 <CodeGroup>
 


### PR DESCRIPTION
it's components.schemas, not components.schema: https://swagger.io/specification/#components-object

## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
