### PR TITLE
fix: change indexing property to string

### DIFF
--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -162,7 +162,7 @@ Only pages included in your `docs.json` are included by default. To include hidd
 
 ```json
 "seo": {
-    "indexing": all
+    "indexing": "all"
 }
 ```
 


### PR DESCRIPTION
## Documentation changes

Our `seo.indexing` property is a string. This PR updates a stray occurrence to properly quote the string value

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the JSON example in `optimize/seo.mdx` by quoting the `seo.indexing` value as "all".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34628182e9144a3c847ba211d1a7152568dcee10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->