### PR TITLE
override latex stylesheet

### DIFF
--- a/create/text.mdx
+++ b/create/text.mdx
@@ -149,7 +149,7 @@ For longer quotes or multiple paragraphs:
 
 ## Mathematical expressions
 
-We support LaTeX for rendering mathematical expressions and equations.
+We support LaTeX for rendering mathematical expressions and equations. You can override automated detection by configuring `styles.latex` in your `docs.json` [settings](/organize/settings#param-latex).
 
 ### Inline math
 

--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -133,6 +133,9 @@ This section contains the full reference for the `docs.json` file.
     <ResponseField name="eyebrows" type='"section" | "breadcrumbs"'>
       The style of the page eyebrow. Choose `section` to show the section name or `breadcrumbs` to show the full navigation path. Defaults to `section`.
     </ResponseField>
+    <ResponseField name="latex" type="boolean">
+      Controls whether LaTeX stylesheets are included, overriding automatic detection.
+    </ResponseField>
     <ResponseField name="codeblocks" type='"system" | "dark" | string | object'>
       Code block theme configuration. Defaults to `"system"`.
 


### PR DESCRIPTION
## Documentation changes

Added a setting to override default LaTeX detection.

Note: I won't merge this PR until these two PRs have been pushed: [1](https://github.com/mintlify/server/pull/2666), [2](https://github.com/mintlify/mint/pull/4564)

[Load katex.css only for sites that use LaTeX](https://linear.app/mintlify/issue/ENG-4722/load-katexcss-only-for-sites-that-use-latex)

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
