### PR TITLE
Fix Clarity icon

### DIFF
--- a/integrations/analytics/overview.mdx
+++ b/integrations/analytics/overview.mdx
@@ -41,7 +41,26 @@ Automatically send data about your documentation engagement to your third party 
   title="Clarity"
   href="/integrations/analytics/clarity"
   horizontal
-  icon="/images/integrations/clarity.png"
+  icon={
+    <svg
+      className="h-6 w-6"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+    >
+      <image
+        xlinkHref="/images/integrations/clarity.png"
+        width="24"
+        height="24"
+        x="0"
+        y="0"
+        preserveAspectRatio="xMidYMid meet"
+      />
+    </svg>
+  }
 />
 
 <Card


### PR DESCRIPTION
## Documentation changes

Clarity icons shows up locally but not in prod.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful
