### PR TITLE
Update Vale CI info

### DIFF
--- a/deploy/ci.mdx
+++ b/deploy/ci.mdx
@@ -38,12 +38,12 @@ To see the results of this check, visit GitHub's check results page for a specif
 
 ### Vale
 
-[Vale](https://vale.sh/) is an open source rule-based prose linter which supports a range of document types, including Markdown and MDX.
+[Vale](https://vale.sh/) is an open source rule-based prose linter which supports a range of document types, including Markdown and MDX. Use Vale to check for consistency of style and tone in your documentation.
 
 Mintlify supports automatically running Vale in a CI check and displaying the results as a check status.
 
 #### Configuration
-If you have a `.vale.ini` file in the root content directory for your deployment, the Vale CI check uses that configuration file and any configuration files in your specified `stylesPath`.
+If you have a `.vale.ini` file in the root content directory of your deployment, the Vale CI check uses that configuration file and any configuration files in your specified `stylesPath`.
 
 If you don't have a Vale config file, the default configuration automatically loads.
 
@@ -51,21 +51,22 @@ If you don't have a Vale config file, the default configuration automatically lo
 # Top level styles
 StylesPath = /app/styles
 MinAlertLevel = suggestion
+# Inline HTML tags to ignore (code/tt for code snippets, img/url for links/images, a for anchor tags)
 IgnoredScopes = code, tt, img, url, a
-SkippedScopes = script, style, pre, figure, code
+SkippedScopes = script, style, pre, figure
 
 # Vocabularies
 Vocab = Mintlify
 
-# This is required since Vale doesn't officially support MDX
-[formats]
-mdx = md
+# Packages
+Packages = MDX
 
-# MDX support
+# Only match MDX
 [*.mdx]
 BasedOnStyles = Vale
 Vale.Terms = NO # Enforces really harsh capitalization rules, keep off
 
+# Ignore JSX/MDX-specific syntax patterns
 # `import ...`, `export ...`
 # `<Component ... />`
 # `<Component>...</Component>`
@@ -74,13 +75,13 @@ TokenIgnores = (?sm)((?:import|export) .+?$), \
 (?<!`)(<\w+ ?.+ ?\/>)(?!`), \
 (<[A-Z]\w+>.+?<\/[A-Z]\w+>)
 
-# Exclude:
+# Exclude multiline JSX and curly braces
 # `<Component \n ... />`
 BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
 (?sm)^({.+.*})
-
-CommentDelimiters = {/*, */}
 ````
+
+The default Vale vocabulary includes the following words.
 
 ```text Default Vale vocabulary expandable
 Mintlify
@@ -352,57 +353,62 @@ next
 toc
 ```
 
+To add your own vocabulary for the default configuration, create a `styles/config/vocabularies/Mintlify` directory with `accept.txt` and `reject.txt` files.
+
+- `accept.txt`: Words that should be ignored by the Vale linter. For example, product names or uncommon terms.
+- `reject.txt`: Words that should be flagged as errors. For example, jargon or words that are not appropriate for the tone of your documentation.
+
 ```text Example Vale file structure
-  - docs.json
-  - .vale.ini
-  - styles/...
-  - text.md
+/your-project
+  |- docs.json
+  |- .vale.ini
+  |- styles/
+    |- config/
+      |- vocabularies/
+        |- Mintlify/
+          |- accept.txt
+          |- reject.txt
+  |- example-page.mdx
 ```
 
 ```text Example monorepo Vale file structure
-  - main.ts
-  - docs/
-    - docs.json
-    - .vale.ini
-    - styles/...
-    - text.md
-  - test/
+/your-monorepo
+  |- main.ts
+  |- docs/
+    |- docs.json
+    |- .vale.ini
+    |- styles/
+      |- config/
+      |- vocabularies/
+        |- Mintlify/
+          |- accept.txt
+          |- reject.txt
+    |- example-page.mdx
+  |- test/
 ```
 
 <Note>
-Please note that for security reasons, absolute `stylesPath`, or `stylesPath` which include `..` values aren't supported. Please use relative paths and include the `stylesPath` in your repository.
+For security reasons, absolute `stylesPath`, or `stylesPath` which include `..` values aren't supported.
+
+Use relative paths and include the `stylesPath` in your repository.
 </Note>
 
 #### Packages
-Vale supports a range of [packages](https://vale.sh/docs/keys/packages), which can be used to check for spelling and style errors.
-Any packages you include in your repository under the correct `stylesPath` are automatically installed and used in your Vale configuration.
+Vale supports a range of [packages](https://vale.sh/docs/keys/packages), which can be used to check for spelling and style errors. Any packages you include in your repository under the correct `stylesPath` are automatically installed and used in your Vale configuration.
 
 For packages not included in your repository, you may specify any packages from the [Vale package registry](https://vale.sh/explorer), and they're automatically downloaded and used in your Vale configuration.
 
 <Note>
-Please note that for security reasons, automatically downloading packages that aren't from the [Vale package registry](https://vale.sh/explorer) is not supported.
+For security reasons, automatically downloading packages that aren't from the [Vale package registry](https://vale.sh/explorer) is **not** supported.
 </Note>
 
 #### Vale with `MDX`
-Vale doesn't natively support `MDX`, but Vale's author has provided a [custom extension](https://github.com/errata-ai/MDX) to support it.
 
-If you prefer not to use this extension, the following lines can be added to the configured `.vale.ini` file:
-```ini
-[formats]
-mdx = md
+<Note>
+MDX native support requires Vale 3.10.0 or later. Check your Vale version with `vale --version`.
+</Note>
 
-[*.mdx]
-CommentDelimiters = {/*, */}
-
-TokenIgnores = (?sm)((?:import|export) .+?$), \
-(?<!`)(<\w+ ?.+ ?\/>)(?!`), \
-(<[A-Z]\w+>.+?<\/[A-Z]\w+>)
-
-BlockIgnores = (?sm)^(<\w+\n .*\s\/>)$, \
-(?sm)^({.+.*})
-```
-
-To use Vale's in-document comments, use MDX-style comments `{/* ... */}`. If you use the `CommentDelimiters = {/*, */}` [setting](https://vale.sh/docs/keys/commentdelimiters) in your configuration, Vale automatically interprets these comments while linting. This means you can easily use Vale's built-in features, like skipping lines or sections.
+To use Vale's in-document comments in MDX files, use MDX-style comments `{/* ... */}`:
 
 ```mdx
 {/* vale off */}
@@ -412,14 +418,4 @@ This text is ignored by Vale
 {/* vale on */}
 ```
 
-
-If you choose not to use `CommentDelimiters` but still choose to use Vale's comments, you must wrap any Vale comments in MDX comments `{/* ... */}`. For example:
-
-```mdx
-{/* <!-- vale off --> */}
-
-This text is ignored by Vale
-
-{/* <!-- vale on --> */}
-```
-These comment tags aren't supported within Mintlify components but will function correctly anywhere at the base level of a document.
+Vale automatically recognizes and respects these comments in MDX files without additional configuration. Use comments to skip lines or sections that should be ignored by the linter.


### PR DESCRIPTION
## Documentation changes

This PR updates the default config file to reflect MDX-native capabilities of Vale 3.10+.

Also adds information on how to update the accepted/rejected vocabulary.

Closes https://linear.app/mintlify/issue/DOC-204/update-vale-docs

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes Vale CI docs with MDX-native configuration, custom vocabulary setup, and clarified security/package guidance.
> 
> - **Docs (CI/Vale)**:
>   - **MDX-native config**: Update default `.vale.ini` for Vale ≥3.10 with `Packages = MDX`, refined `IgnoredScopes`/`SkippedScopes`, and MDX-specific token/block ignores; remove legacy `formats`/`CommentDelimiters` guidance.
>   - **Vocabulary management**: Add instructions for custom vocab via `styles/config/vocabularies/Mintlify/{accept.txt,reject.txt}` with example project and monorepo structures.
>   - **Notes**: Clarify security constraints on `stylesPath` and external packages; add version note for MDX support and usage of MDX-style inline comments recognized by Vale.
>   - **Copy edits**: Minor wording clarifications throughout the Vale section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2edb85844835b6c35040ebd6d72611c71b5cdd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->