### PR TITLE
Add tip on using view component

### DIFF
--- a/components/view.mdx
+++ b/components/view.mdx
@@ -4,11 +4,11 @@ description: "Create multi-view content for different programming languages or f
 keywords: ["selector", "language-specific content", "content switching"]
 ---
 
-Use the View component to create content that changes based on the selected view in a multi-view dropdown. This is particularly useful for showing code examples or documentation specific to different programming languages or frameworks.
+Use the `View` component to create content that changes based on the selected view in a multi-view dropdown. This is particularly useful for showing code examples or documentation specific to different programming languages or frameworks.
 
-<Callout>
-Use one view component per page. The multi-view dropdown is shared across the entire page.
-</Callout>
+<Tip>
+  Use one view component per language per page. Use [tabs](/components/tabs) for procedures that differ by language and [code groups](/components/code-groups) for code examples that differ by language.
+</Tip>
 
 <View title="JavaScript" icon="js">
   This content is only visible when JavaScript is selected.


### PR DESCRIPTION
## Documentation changes

This adds a tip on using view components to only use one language per view per page and recommends tabs and code groups when appropriate.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a tip and minor wording tweak to the `View` component documentation.
> 
> - **Docs: `components/view.mdx`**
>   - Add a Tip advising one view per language per page; recommend `tabs` for procedures and `code groups` for code examples.
>   - Clarify intro and format component name with backticks (`View`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9e936c21e0ab9ebbafc06e973e246c69015f7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->