### PR TITLE
Assistant query bucketing

### DIFF
--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -238,16 +238,15 @@ Use assistant insights to understand how users interact with your documentation 
 
 ### Categories
 
-The categories tab uses LLMs to automatically categorize conversations by question topic and theme. Conversations are organized by the most common groupings, helping you quickly identify:
-- Which topics generate the most questions
-- Patterns in user needs and behavior
-- Areas where documentation might need expansion or clarification
+The categories tab uses LLMs to automatically categorize conversations. Categories show a summary of the topic or theme, when a question was last asked about the category, and how many questions have been asked about the category over time.
 
-Review categories to see what areas of your documentation people frequently ask about and check that you have sufficient coverage of those topics.
+Use categories to identify common topics, patterns in user needs and behavior, and areas where documentation might need expansion or clarification.
+
+Click a category to view specific conversations about the category. You can then click individual conversations to view the complete chat thread, including the user's question, the assistant's response, and any sources cited.
 
 ### Chat history
 
-The chat history tab displays chronological records of all assistant conversations. Select any message to view the complete chat thread, including the user's question, the assistant's response, and any sources cited.
+The chat history tab displays chronological records of all assistant conversations. Click any message to view the complete chat thread, including the user's question, the assistant's response, and any sources cited.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Documentation changes

This adds info about clicking an assistant category to see all the conversations in the bucket. Plus some copy editing to the assistant page.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates assistant docs with clearer category insights navigation and revised export flow, plus concise heading and wording improvements.
> 
> - **Assistant docs (`ai/assistant.mdx`)**:
>   - **Insights**:
>     - Expand Categories description and add steps to drill into a category and individual conversations.
>     - Reword Chat history instructions to “Click any message”.
>   - **Export flow**:
>     - Rename section to `Export and analyze queries` and update steps to include clicking `Chat history` before `Export to CSV`.
>   - **Content polish**:
>     - Rename `Making content AI ingestible` to `Make content AI ingestible` and minor copy/wording improvements across sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08f3f1a788c034aaba6800694bb42998552addca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->