### PR TITLE
Clarify branch for trigger update endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
     "/project/update/{projectId}": {
       "post": {
         "summary": "Trigger update",
-        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. By default, the update is triggered from your configured deployment branch.",
+        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. The update is triggered from your configured deployment branch.",
         "parameters": [
           {
             "name": "projectId",


### PR DESCRIPTION
## Documentation changes

This PR makes the description of https://www.mintlify.com/docs/api/update/trigger more precise by removing "By default" from the description since the update is always triggered from the deployment branch.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the `POST /project/update/{projectId}` description to state updates are triggered from the configured deployment branch (removes “By default”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94dfe6f1a686a8e222e4aa8f1086715ec32f2c28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->