### PR TITLE
Update mintignore with defaults

### DIFF
--- a/organize/mintignore.mdx
+++ b/organize/mintignore.mdx
@@ -27,12 +27,27 @@ private-notes.md
 When Mintlify builds your documentation, it reads the `.mintignore` file and excludes any matching files or directories from processing.
 
 Excluded files:
+
 - Don't appear in your published documentation.
 - Aren't indexed for search.
 - Aren't accessible to visitors.
 
+## Default ignored patterns
+
+Mintlify automatically ignores the following directories without requiring any configuration:
+
+- `.git`
+- `.github`
+- `.claude`
+- `.agents`
+- `.idea`
+- `node_modules`
+
+You don't need to add these to your `.mintignore` file.
+
 <Note>
-  Unlike [hidden pages](/organize/hidden-pages), files excluded by `.mintignore` are completely removed from your site and cannot be accessed by URL.
+  Unlike [hidden pages](/organize/hidden-pages), files excluded by `.mintignore`
+  are completely removed from your site and cannot be accessed by URL.
 </Note>
 
 ## Pattern syntax


### PR DESCRIPTION
## Documentation changes

Updating the `.mintignore` documentation to add in the default files/patterns that we ignore. 
<img width="1346" height="1040" alt="CleanShot 2025-12-05 at 10 04 41@2x" src="https://github.com/user-attachments/assets/e8b5d09d-41bd-41ac-9008-0c95ec2a2b4d" />

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a "Default ignored patterns" section listing directories Mintlify ignores by default and tidies Note formatting.
> 
> - **Docs (`organize/mintignore.mdx`)**:
>   - **Default ignored patterns**: Document that Mintlify auto-ignores `.git`, `.github`, `.claude`, `.agents`, `.idea`, and `node_modules`, noting they don't need to be in `.mintignore`.
>   - **Formatting**: Tweak `<Note>` content wrapping and minor spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d81e87d70030b1e5098ce8944ef99c944fcbb43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->