### PR TITLE
Add `model` parameter

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -72,6 +72,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Control whether the pull request is created in draft or non-draft mode. When true, creates a draft pull request. When false, creates a regular (non-draft) pull request ready for review."
+                  },
+                  "model": {
+                    "type": "string",
+                    "enum": ["sonnet", "opus"],
+                    "default": "sonnet",
+                    "description": "The AI model to use for the agent job. Use `sonnet` for faster, cost-effective processing. Use `opus` for more capable, but slower processing."
                   }
                 }
               }


### PR DESCRIPTION
## Documentation changes

This PR documents the `model` parameter for selecting between Sonnet and Opus when using the agent API.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents a new `model` field on `POST /agent/{projectId}/job` to select `sonnet` (default) or `opus`.
> 
> - **API (OpenAPI)**:
>   - Update `admin-openapi.json` for `POST /agent/{projectId}/job`:
>     - Add `model` property to request body (`enum`: `sonnet` | `opus`, default `sonnet`) with description for selecting the AI model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7cf8fbeb05c7de16a21bf1ba896fe333be84ead. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->