### PR TITLE
Document expandable categories feature in Assistant insights

### DIFF
--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -242,7 +242,14 @@ The categories tab uses LLMs to automatically categorize conversations. Categori
 
 Use categories to identify common topics, patterns in user needs and behavior, and areas where documentation might need expansion or clarification.
 
-Click a category to view specific conversations about the category. You can then click individual conversations to view the complete chat thread, including the user's question, the assistant's response, and any sources cited.
+#### View related conversations
+
+Categories are expandable to reveal related conversations. To explore conversations within a category:
+
+1. Click a category row to expand it and view related conversations.
+2. Click an individual conversation to open a side panel with the complete chat thread, including the user's question, the assistant's response, and any sources cited.
+
+The expandable interface lets you drill down from high-level patterns to specific user interactions, making it easier to understand the context behind common questions.
 
 ### Chat history
 


### PR DESCRIPTION
## Summary

Updated the Assistant documentation to reflect the new expandable categories feature in the dashboard. Users can now click category rows to expand them and view related conversations, then drill down into individual chat threads.

## Files Changed

- `ai/assistant.mdx` - Added documentation for expandable categories feature under "Assistant insights" section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation explaining expandable categories that reveal related conversations and open full chat threads in a side panel.
> 
> - **Docs**
>   - Update `ai/assistant.mdx` under **Assistant insights › Categories**:
>     - Add "View related conversations" section describing expandable category rows.
>     - Include steps to expand a category and open a conversation side panel showing full chat threads and sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfc83d1ff6a9e1b859705077e80afc728c1fc8c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->