### PR TITLE
Add "type type type type" to quickstart page

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -6,6 +6,8 @@ keywords: ["quickstart","deploy","get started","first steps"]
 
 After completing this guide, you will have a live documentation site ready to customize and expand.
 
+type type type type
+
 <Info>
   **Prerequisites**: Before you begin, [create an account](https://mintlify.com/start) and complete onboarding.
 </Info>


### PR DESCRIPTION
Added the requested text "type type type type" to the quickstart page as specified by the user. This change updates the quickstart documentation with the literal text content requested.

Files changed:
- quickstart.mdx

---

Created by Mintlify agent