### PR TITLE
Add duplicate "Hello world" line to quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -6,6 +6,8 @@ keywords: ["quickstart","deploy","get started","first steps"]
 
 Hello world
 
+Hello world
+
 After completing this guide, you will have a live documentation site ready to customize and expand.
 
 <Info>


### PR DESCRIPTION
Added an additional "Hello world" line to the quickstart page. This creates a duplicate greeting at the top of the guide.

## Files changed
- `quickstart.mdx` - Added duplicate "Hello world" line after the first greeting

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two Hello world lines at the top of `quickstart.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b14a757e0179442e0f2e0f4f5e5a98e5ad81f906. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->