### PR TITLE
Enabling MCP server on search documentation endpoint

### DIFF
--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -417,6 +417,11 @@
     },
     "/search/{domain}": {
       "post": {
+        "x-mint": {
+          "mcp": {
+            "enabled": true
+          }
+        },
         "summary": "Search documentation",
         "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.",
         "parameters": [


### PR DESCRIPTION
Testing out MCP servers on API routes that require authentication of some sort (in this case, a bearer token)

## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables MCP for `POST /search/{domain}` by adding `x-mint.mcp.enabled: true` to the OpenAPI spec.
> 
> - **OpenAPI (discovery-openapi.json)**:
>   - **Search endpoint**: Added `x-mint.mcp.enabled: true` to `POST /search/{domain}` to enable MCP integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d76fdd82cb307349bece567449d621e3f88adfd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->