### PR TITLE
Fix indent in Examples page

### DIFF
--- a/components/examples.mdx
+++ b/components/examples.mdx
@@ -18,8 +18,8 @@ On mobile devices, `<RequestExample>` and `<ResponseExample>` components display
 <RequestExample>
 
 ```bash Request
-  curl --request POST \
-    --url https://dog-api.kinduff.com/api/facts
+curl --request POST \
+  --url https://dog-api.kinduff.com/api/facts
 ```
 
 </RequestExample>
@@ -42,8 +42,8 @@ You can include multiple code blocks inside a single `<RequestExample>`. Each co
 <RequestExample>
 
 ```bash Request
-  curl --request POST \
-    --url https://dog-api.kinduff.com/api/facts
+curl --request POST \
+  --url https://dog-api.kinduff.com/api/facts
 ```
 
 </RequestExample>


### PR DESCRIPTION
## Documentation changes

Code snippet is indented.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unindents `curl` request code blocks in `components/examples.mdx` to correct formatting in `<RequestExample>` examples.
> 
> - **Docs** (`components/examples.mdx`):
>   - Fix indentation of `bash` `<RequestExample>` code blocks (the `curl` lines) for proper rendering in the sidebar examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3130839d50f26571c9854169a91903c5fcde31a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->