### PR TITLE
Update Agent documentation for new panel interface

### DIFF
--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -54,7 +54,12 @@ Use the agent in Slack to collaborate with your team on documentation updates.
 
 ## Connect repositories as context
 
-The agent can only access repositories that you connect through the Mintlify GitHub App. Configure which repositories the agent can access in the agent panel **Settings** or in the [GitHub App settings](https://github.com/apps/mintlify/installations/new).
+The agent can only access repositories that you connect through the Mintlify GitHub App. Configure which repositories the agent can access:
+
+1. Open the agent panel using <kbd>⌘</kbd>+<kbd>I</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux).
+2. Click the **Settings** icon (gear icon) in the panel header.
+3. In the "Set up external sources" section, click **Configure** to manage repository access.
+4. Alternatively, configure repositories directly in the [GitHub App settings](https://github.com/apps/mintlify/installations/new).
 
 ## Embed the agent via API
 


### PR DESCRIPTION
Updated the Agent documentation to reflect the new panel-based interface introduced in PR #4711. The agent now opens in a resizable side panel accessed via keyboard shortcut instead of a dedicated page.

**Files changed:**
- `ai/agent.mdx` - Updated access instructions, panel description, Slack setup steps, and repository configuration steps

cc @handotdev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps Agent docs to reflect the new dashboard side panel UI, clarifying access, settings navigation, Slack setup, and repository configuration, with a note about outdated screenshots.
> 
> - **Documentation** (`ai/agent.mdx`):
>   - **Dashboard panel UI**:
>     - Updates access instructions (keyboard shortcuts) and describes a resizable right-side panel on desktop and full-screen modal on mobile.
>     - Adds a note that screenshots show the previous dedicated page and will be updated.
>     - Clarifies that the panel has three views accessible from the header.
>   - **Slack integration setup**:
>     - Revises steps to open the panel via shortcut and use the Settings gear icon.
>     - Streamlines connect/link steps and test actions.
>   - **Repository access**:
>     - Expands steps to configure repositories via the panel’s “Set up external sources” > Configure, with alternative GitHub App settings link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8905c92b51db8592b5b8b94add455e204347316f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->