### PR TITLE
Remove deprecated assistant thumbs up/down analytics events

### DIFF
--- a/integrations/analytics/overview.mdx
+++ b/integrations/analytics/overview.mdx
@@ -627,8 +627,6 @@ We send the following events to your analytics provider. All events use the `doc
 | `docs.footer.powered_by_mintlify_click` | When a user clicks the "Powered by Mintlify" link.                                                        |
 | `docs.assistant.source_click`           | When a user clicks a citation in a chat.                                                                  |
 | `docs.assistant.suggestion_click`       | When a user clicks a suggestion in a chat.                                                                |
-| `docs.assistant.thumbs_up`              | When a user clicks the positive feedback button in a chat.                                                |
-| `docs.assistant.thumbs_down`            | When a user clicks the negative feedback button in a chat.                                                |
 | `docs.assistant.completed`              | When a chat session is completed.                                                                         |
 | `docs.assistant.enter`                  | When a user initiates a chat.                                                                             |
 | `docs.assistant.ask_ai_on_text_selection` | When a user selects text and clicks "Ask AI" to ask about the selection.                                |


### PR DESCRIPTION
## Summary

This PR removes the `docs.assistant.thumbs_up` and `docs.assistant.thumbs_down` analytics events from the documentation to align with PR #4804, which removed client-side analytics tracking for these events. The events have been deprecated as feedback is now handled server-side only.

## Files Changed

- `integrations/analytics/overview.mdx` - Removed two rows from the analytics events table documenting the deprecated thumbs up/down events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `docs.assistant.thumbs_up` and `docs.assistant.thumbs_down` from the analytics events table in `integrations/analytics/overview.mdx`.
> 
> - **Docs**:
>   - Remove `docs.assistant.thumbs_up` and `docs.assistant.thumbs_down` from the analytics events table in `integrations/analytics/overview.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25fd7f78257c4f4e904ec34da81c5f8ed0f63f7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->