### PR TITLE
Update Agent documentation for new panel interface

### DIFF
--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -53,7 +53,11 @@ By default, the agent opens pull requests attributed to the Mintlify bot. To att
 
 ## Connect repositories as context
 
-The agent can only access repositories that you connect through the Mintlify GitHub App. Configure which repositories the agent can access in the agent panel **Settings** or in the [GitHub App settings](https://github.com/apps/mintlify/installations/new).
+The agent can only access repositories that you connect through the Mintlify GitHub App. Configure which repositories the agent can access:
+
+1. Open the agent panel using <kbd>⌘</kbd>+<kbd>I</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux).
+1. Click the **Settings** icon (gear icon) in the panel header.
+1. In the "Set up external sources" section, click **Configure** to manage repository access through the [GitHub App settings](https://github.com/apps/mintlify/installations/new).
 
 ## Customize agent behavior
 

--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -35,12 +35,11 @@ Use the agent in Slack to collaborate with your team on documentation updates.
   If your Slack Workspace Owner requires admin approval to install apps, ask them to approve the Mintlify app before you connect it.
 </Note>
 
-1. Open the agent panel in your dashboard. 
-1. Click the **Settings** button.
-    <Frame>
-    <img src="/images/agent/dashboard-settings-light.png" alt="The settings button in light mode." className="block dark:hidden" />
-    <img src="/images/agent/dashboard-settings-dark.png" alt="The settings button in dark mode." className="hidden dark:block" />
-    </Frame>
+1. Open the agent panel in your dashboard using <kbd>⌘</kbd>+<kbd>I</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux).
+1. Click the **Settings** icon (gear icon) in the panel header.
+    <Note>
+    Screenshots showing the new panel interface will be updated soon.
+    </Note>
 1. In the Slack integration section, click **Connect**.
 1. Follow the Slack prompts to add the `mintlify` app to your workspace.
 1. Follow the Slack prompts to link your Mintlify account to your Slack workspace.

--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -19,9 +19,9 @@ Use the agent to:
 
 ## Use the agent in the dashboard
 
-Access the agent in a from your dashboard using the keyboard shortcut <kbd>⌘</kbd>+<kbd>I</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux), or by clicking the **Ask agent** button. The agent panel is resizable on desktop. On mobile devices, the agent opens in full-screen.
+Access the agent from your dashboard using the keyboard shortcut <kbd>⌘</kbd>+<kbd>I</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>I</kbd> (Windows/Linux). The agent opens in a resizable panel on the right side of your dashboard on desktop. On mobile devices, the agent opens in a modal dialog.
 
-The agent panel has three views.
+The agent panel has three views accessible from the header:
 
 - **Chat**: Send prompts to the agent to update your documentation. The agent creates pull requests based on your instructions and displays links to view the pull requests or open the changes in the web editor.
 - **History**: Browse past conversations and continue working on previous requests. Click any conversation to load it in the chat view.


### PR DESCRIPTION
Updated the Agent documentation to reflect the new resizable panel interface introduced in the dashboard. The documentation now accurately describes how users access the Agent via keyboard shortcut and interact with the panel's three views (Chat, History, Settings).

**Files changed:**
- `ai/agent.mdx` - Updated dashboard access instructions, panel description, Slack integration steps, and repository connection instructions

cc @handotdev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update agent docs for new dashboard panel UI and refresh Slack and GitHub setup steps.
> 
> - **Docs (`ai/agent.mdx`)**:
>   - **Dashboard panel**: Clarify access via keyboard shortcut; describe right-side resizable panel on desktop and modal on mobile.
>   - **Panel views**: Specify three views are accessible from the header: `Chat`, `History`, `Settings`.
>   - **Slack integration**: Update steps to open panel with shortcut, use the header gear `Settings` icon, and add a note about pending screenshots.
>   - **Repository access**: Replace generic guidance with steps to open panel, use the header gear, and configure repos via "Set up external sources" linking to GitHub App settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 138903b9ac5ac65ecdbf284110e5421dcb8d6059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->