### PR TITLE
Document expandable categories feature in assistant insights

### DIFF
--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -242,7 +242,15 @@ The categories tab uses LLMs to automatically categorize conversations. Categori
 
 Use categories to identify common topics, patterns in user needs and behavior, and areas where documentation might need expansion or clarification.
 
-Click a category to view specific conversations about the category. You can then click individual conversations to view the complete chat thread, including the user's question, the assistant's response, and any sources cited.
+#### View related conversations
+
+Click a category row to expand it and view related conversations grouped under that category. The expanded view displays:
+
+- A list of conversations related to the category
+- The first user message from each conversation
+- The number of messages in each conversation thread
+
+Click an individual conversation to open a side panel with the complete chat thread, including the user's question, the assistant's response, and any sources cited.
 
 ### Chat history
 


### PR DESCRIPTION
Updated the Assistant documentation to reflect the new expandable categories feature. Users can now click category rows to expand and view related conversations, with details about the first message and thread length.

**Files changed:**
- `ai/assistant.mdx` - Added documentation for expandable category rows under "Assistant insights"

cc @rtbarnes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for expanding category rows to view related conversations and details in Assistant insights.
> 
> - **Docs – Assistant insights (`ai/assistant.mdx`)**:
>   - **Categories**:
>     - Adds subsection `View related conversations` describing expandable category rows.
>     - Details shown when expanded: list of related conversations, first user message, and thread message count.
>     - Notes that clicking a conversation opens a side panel with the full chat thread and sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43344e5af87849daf178e387c0bc0cbae8834680. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->