### PR TITLE
Add Color component to changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,33 @@ rss: true
 noindex: true
 ---
 
+<Update label="December 11, 2025" tags={["New releases"]} rss={{ title: "Color component", description: "Display color palettes in your documentation with compact and table variants" }}>
+  ## Color component
+
+  Display color palettes in your documentation with the new `<Color>` component. The component supports two variants (compact and table), all CSS color formats (hex, rgb, rgba, hsl, oklch), theme-aware colors, and click-to-copy functionality.
+
+  **Compact variant** displays colors in a grid layout:
+  ```mdx
+  <Color variant="compact">
+    <Color.Item name="blue-500" value="#3B82F6" />
+    <Color.Item name="blue-600" value="#2563EB" />
+  </Color>
+  ```
+
+  **Table variant** organizes colors into rows with titles:
+  ```mdx
+  <Color variant="table">
+    <Color.Row title="Primary">
+      <Color.Item name="primary-500" value="#3B82F6" />
+      <Color.Item name="primary-600" value="#2563EB" />
+    </Color.Row>
+  </Color>
+  ```
+
+  Learn more in the [Color component documentation](/components/color).
+
+</Update>
+
 <Update label="December 9, 2025" tags={["New releases"]} rss={{ title: "Preview widget", description: "Track changed files in preview deployments with an interactive widget" }}>
   ## Preview widget
 


### PR DESCRIPTION
Added a new changelog entry for December 11, 2025 announcing the Color component feature. The entry includes usage examples for both compact and table variants, highlights key features like CSS color format support and theme-aware colors, and links to the component documentation.

**Files changed:**
- `changelog.mdx` - Added new Color component announcement

cc @pqoqubbw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a December 11, 2025 changelog entry announcing the Color component with compact/table examples and a docs link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df9de485ed827d0b5c4809204e92473ea1e2a55a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->