### PR TITLE
Update changelog for Analytics rebrand

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,13 @@ rss: true
 noindex: true
 ---
 
+<Update label="December 11, 2025" tags={["Improvements"]} rss={{ title: "Dashboard sidebar menu update", description: "Renamed Insights to Analytics in dashboard sidebar" }}>
+  ## Dashboard sidebar menu update
+
+  The dashboard sidebar menu item has been renamed from "Insights" to "Analytics" with an updated icon. The chart-column icon replaces the previous lightbulb icon for better visual clarity. Page titles and headers have been updated accordingly for consistency throughout the dashboard.
+
+</Update>
+
 <Update label="December 9, 2025" tags={["New releases"]} rss={{ title: "Preview widget", description: "Track changed files in preview deployments with an interactive widget" }}>
   ## Preview widget
 


### PR DESCRIPTION
Added changelog entry documenting the dashboard sidebar menu update from "Insights" to "Analytics" with the new chart-column icon. This reflects the changes made in PR #5000 for consistency across user-facing documentation.

**Files changed:**
- `changelog.mdx` - Added December 11, 2025 update entry

cc @jmsbaduor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a changelog entry documenting the dashboard sidebar rename from "Insights" to "Analytics" with updated icon and titles/headers.
> 
> - **Changelog (`changelog.mdx`)**:
>   - Add December 11, 2025 update: rename dashboard sidebar "Insights" → "Analytics", switch icon (lightbulb → chart-column), and update related page titles/headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0876d03ed5d2b7fadd06fc309e6aa81a23f546d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->