### PR TITLE
fix: update API endpoint for assistant message integration

### DIFF
--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -26,7 +26,7 @@ import { useChat } from 'ai/react';
 
 function MyComponent({ domain }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${process.env.MINTLIFY_TOKEN}`,
     },

--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://api-dsc.mintlify.com/v1"
+      "url": "https://api.mintlify.com/discovery/v1"
     }
   ],
   "security": [
@@ -510,7 +510,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. See the [Assistant API Key documentation](/docs/api-reference/introduction#assistant-api-key) for details on how to get your API key."
+        "description": "The Authorization header expects a Bearer token. See the [Assistant API Key documentation](/api/introduction#assistant-api-key) for details on how to get your API key."
       }
     }
   }

--- a/es/api/assistant/create-assistant-message.mdx
+++ b/es/api/assistant/create-assistant-message.mdx
@@ -28,7 +28,7 @@ import { useChat } from 'ai/react';
 
 function MyComponent({ domain }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${process.env.MINTLIFY_TOKEN}`,
     },

--- a/es/guides/assistant-embed.mdx
+++ b/es/guides/assistant-embed.mdx
@@ -183,7 +183,7 @@ export function AssistantWidget({ domain, docsURL }) {
   }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${import.meta.env.VITE_MINTLIFY_TOKEN}`,
     },

--- a/fr/api/assistant/create-assistant-message.mdx
+++ b/fr/api/assistant/create-assistant-message.mdx
@@ -28,7 +28,7 @@ import { useChat } from 'ai/react';
 
 function MyComponent({ domain }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${process.env.MINTLIFY_TOKEN}`,
     },

--- a/fr/guides/assistant-embed.mdx
+++ b/fr/guides/assistant-embed.mdx
@@ -183,7 +183,7 @@ export function AssistantWidget({ domain, docsURL }) {
   }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${import.meta.env.VITE_MINTLIFY_TOKEN}`,
     },

--- a/guides/assistant-embed.mdx
+++ b/guides/assistant-embed.mdx
@@ -171,7 +171,7 @@ export function AssistantWidget({ domain, docsURL }) {
   }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${import.meta.env.VITE_MINTLIFY_TOKEN}`,
     },

--- a/zh/api/assistant/create-assistant-message.mdx
+++ b/zh/api/assistant/create-assistant-message.mdx
@@ -28,7 +28,7 @@ import { useChat } from 'ai/react';
 
 function MyComponent({ domain }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${process.env.MINTLIFY_TOKEN}`,
     },

--- a/zh/guides/assistant-embed.mdx
+++ b/zh/guides/assistant-embed.mdx
@@ -183,7 +183,7 @@ export function AssistantWidget({ domain, docsURL }) {
   }, []);
 
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: `https://api-dsc.mintlify.com/v1/assistant/${domain}/message`,
+    api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
       'Authorization': `Bearer ${import.meta.env.VITE_MINTLIFY_TOKEN}`,
     },


### PR DESCRIPTION
## Documentation change

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Assistant API endpoints to `https://api.mintlify.com/discovery/v1` across docs/examples and adjusts OpenAPI server URL and API key docs link.
> 
> - **Assistant API endpoint update**
>   - Replace `https://api-dsc.mintlify.com/v1/assistant/...` with `https://api.mintlify.com/discovery/v1/assistant/...` in `useChat` examples across `api/assistant/create-assistant-message.mdx`, `guides/assistant-embed.mdx`, and localized files (`es/`, `fr/`, `zh/`).
> - **OpenAPI spec**
>   - Update `servers[0].url` to `https://api.mintlify.com/discovery/v1` in `discovery-openapi.json`.
>   - Fix bearer auth description link to `/api/introduction#assistant-api-key`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d834b11c819ddc258b81a0a8c57000b78e0bdaa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->