### PR TITLE
Document delete deployment feature

### DIFF
--- a/deploy/deployments.mdx
+++ b/deploy/deployments.mdx
@@ -10,7 +10,7 @@ If your latest changes are not appearing on your live site, first check that the
 
 If the GitHub app is connected, but changes are still not deploying, you can manually trigger a rebuild from your dashboard.
 
-## Manually triggering a deployment
+## Manually trigger a deployment
 
 <Steps>
   <Step title="Verify your latest commit was successful.">
@@ -25,16 +25,17 @@ If the GitHub app is connected, but changes are still not deploying, you can man
   </Step>
 </Steps>
 
-## Deleting a deployment
+## Delete a deployment
 
-You can permanently delete a deployment from the Danger Zone in your dashboard settings. This action is irreversible and will remove all deployment data, including any associated preview deployments.
+You can permanently delete a deployment from the [Danger zone](https://dashboard.mintlify.com/settings/organization/danger-zone) in your dashboard settings. This action is irreversible and will remove all deployment data, including any associated preview deployments.
 
 <Steps>
-  <Step title="Navigate to the Danger Zone.">
-    Go to your [dashboard](https://dashboard.mintlify.com), then navigate to **Settings** > **Organization** > **Danger zone**.
+  <Step title="Navigate to the Danger zone.">
+    Go to the [Danger zone](https://dashboard.mintlify.com/settings/organization/danger-zone) in the settings page of your dashboard.
   </Step>
   <Step title="Delete the deployment.">
-    In the **Delete my deployment** section, provide a reason for deletion and click the delete button. You'll be asked to confirm the deletion.
+    1. In the **Delete my deployment** section, provide a reason for deletion.
+    2. Click the delete button. You'll be asked to confirm the deletion.
   </Step>
 </Steps>
 


### PR DESCRIPTION
Added documentation for the new delete deployment feature in the dashboard. Users can now find instructions on how to permanently delete deployments through the Danger Zone settings.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add docs for deleting deployments via the Dashboard Danger zone; minor heading tweak for manual deploys.
> 
> - **Docs** (`deploy/deployments.mdx`):
>   - Add section: Delete a deployment via Dashboard Danger zone, with steps, irreversible warning, and post-deletion redirect behavior.
>   - Minor: Rename heading to "Manually trigger a deployment".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 691c76303b495de4a137c4fd6b105216ec11c6d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->