### PR TITLE
Remove old DNS screenshot

### DIFF
--- a/customize/custom-domain.mdx
+++ b/customize/custom-domain.mdx
@@ -46,10 +46,6 @@ CNAME | docs | cname.mintlify-dns.com.
   Each domain provider has different ways to add DNS records. Refer to your domain provider's documentation for specific instructions.
 </Tip>
 
-<Frame>
-  <img alt="Sample CNAME settings for a custom domain hosted on Vercel." src="https://mintlify-assets.b-cdn.net/mintlify-dns.png" />
-</Frame>
-
 ### DNS propagation
 
 DNS changes typically take 1-24 hours to propagate globally, though it can take up to 48 hours in some cases. You can verify your DNS is configured correctly using [DNSChecker](https://dnschecker.org).


### PR DESCRIPTION
## Documentation changes

This PR removes an outdated screenshot with the wrong DNS info.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an outdated DNS screenshot from the custom domain documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7e92a8c4d89a084a7ad3e7e919d0f7ee8d0f0f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->