### PR TITLE
Add Discord and Slack integration docs

### DIFF
--- a/ai/assistant-integrations.mdx
+++ b/ai/assistant-integrations.mdx
@@ -1,0 +1,148 @@
+---
+title: "Assistant integrations"
+description: "Connect Discord and Slack to enable AI-powered assistance in your community channels."
+keywords: ["Discord", "Slack", "integrations", "AI assistant", "community support"]
+---
+
+Connect your Discord servers and Slack workspaces to the Mintlify Assistant to provide AI-powered documentation assistance directly in your community channels. The assistant answers questions, cites sources from your documentation, and helps users find information without leaving Discord or Slack.
+
+## Access integrations
+
+Navigate to the integrations page in your dashboard to connect Discord and Slack:
+
+1. Go to your [dashboard](https://dashboard.mintlify.com).
+2. Select **Assistant** from the products menu.
+3. Click the **Integrations** tab.
+
+<Frame>
+  <img src="/images/assistant/integrations-tab-light.png" alt="The Assistant settings page with the Integrations tab highlighted." className="block dark:hidden" />
+  <img src="/images/assistant/integrations-tab-dark.png" alt="The Assistant settings page with the Integrations tab highlighted." className="hidden dark:block" />
+</Frame>
+
+The integrations page displays all available integrations. Connected integrations appear in the **Connected apps** section, while available integrations appear in the **All Apps** section.
+
+## Connect Discord
+
+Connect your Discord server to enable the Mintlify Assistant bot in your channels. The bot answers questions about your documentation when mentioned or when users interact with it.
+
+### Prerequisites
+
+- Admin permissions in your Discord server
+- An active Mintlify Assistant subscription
+
+### Connect your server
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations) in your dashboard.
+2. Find **Discord** in the integrations list.
+3. Click **Connect**.
+4. Select the Discord server you want to connect from the OAuth authorization screen.
+5. Review the permissions and click **Authorize**.
+
+<Frame>
+  <img src="/images/assistant/discord-integration-light.png" alt="Discord integration card with Connect button." className="block dark:hidden" />
+  <img src="/images/assistant/discord-integration-dark.png" alt="Discord integration card with Connect button." className="hidden dark:block" />
+</Frame>
+
+After authorization, you return to the integrations page with a success message. The Discord integration moves to the **Connected apps** section with a **Connected** status badge.
+
+### Use the assistant in Discord
+
+Once connected, the Mintlify Assistant bot appears in your Discord server. Users can interact with the bot to ask questions about your documentation:
+
+- **Mention the bot**: Type `@Mintlify Assistant` followed by your question in any channel where the bot has access.
+- **Direct message**: Send a direct message to the bot with your question.
+
+The assistant searches your documentation and responds with relevant information, including citations and links to source pages.
+
+### Configure Discord integration
+
+Click **Configure** on the Discord integration card to manage bot settings, channel permissions, and other options for your Discord server.
+
+## Connect Slack
+
+Connect your Slack workspace to enable the Mintlify Assistant in your channels. The assistant answers questions about your documentation when mentioned or when users interact with it.
+
+### Prerequisites
+
+- Admin permissions in your Slack workspace
+- An active Mintlify Assistant subscription
+
+### Connect your workspace
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations) in your dashboard.
+2. Find **Slack** in the integrations list.
+3. Click **Connect**.
+4. Select the Slack workspace you want to connect from the authorization screen.
+5. Review the permissions and click **Allow**.
+
+<Frame>
+  <img src="/images/assistant/slack-integration-light.png" alt="Slack integration card with Connect button." className="block dark:hidden" />
+  <img src="/images/assistant/slack-integration-dark.png" alt="Slack integration card with Connect button." className="hidden dark:block" />
+</Frame>
+
+After authorization, you return to the integrations page with a success message. The Slack integration moves to the **Connected apps** section with a **Connected** status badge.
+
+### Use the assistant in Slack
+
+Once connected, the Mintlify Assistant bot appears in your Slack workspace. Users can interact with the bot to ask questions about your documentation:
+
+- **Mention the bot**: Type `@Mintlify Assistant` followed by your question in any channel where the bot has been added.
+- **Direct message**: Send a direct message to the bot with your question.
+- **Slash command**: Use `/mintlify` followed by your question in any channel.
+
+The assistant searches your documentation and responds with relevant information, including citations and links to source pages.
+
+### Configure Slack integration
+
+Click **Configure** on the Slack integration card to manage bot settings, channel permissions, and other options for your Slack workspace.
+
+## Manage integrations
+
+### View connection status
+
+The integrations page displays the connection status for each integration:
+
+- **Connected**: The integration is active and working.
+- **Not connected**: The integration is available but not yet connected.
+
+Connected integrations display a green **Connected** status badge and appear in the **Connected apps** section at the top of the page.
+
+### Disconnect an integration
+
+To disconnect an integration:
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations).
+2. Find the integration in the **Connected apps** section.
+3. Click **Configure**.
+4. Click **Disconnect** or **Remove** to disconnect the integration.
+
+After disconnecting, the integration moves back to the **All Apps** section and the assistant bot is removed from your Discord server or Slack workspace.
+
+## Troubleshooting
+
+<Accordion title="Integration not appearing after connection">
+  If the integration doesn't appear as connected after authorization:
+  
+  - Refresh the integrations page in your dashboard.
+  - Verify you completed the OAuth authorization flow.
+  - Check that you have the necessary permissions in Discord or Slack.
+  - Contact [support](mailto:support@mintlify.com) if the issue persists.
+</Accordion>
+
+<Accordion title="Bot not responding in Discord or Slack">
+  If the assistant bot doesn't respond to questions:
+  
+  - Verify the bot has access to the channel where you're asking questions.
+  - Check that your Assistant subscription is active.
+  - Ensure you're mentioning the bot correctly (`@Mintlify Assistant`).
+  - Review your message allowance in the dashboard to confirm you haven't exceeded your limit.
+</Accordion>
+
+<Accordion title="Authorization errors">
+  If you encounter errors during the OAuth authorization flow:
+  
+  - Verify you have admin permissions in your Discord server or Slack workspace.
+  - Try disconnecting and reconnecting the integration.
+  - Clear your browser cache and cookies, then try again.
+  - Contact [support](mailto:support@mintlify.com) if the error persists.
+</Accordion>

--- a/docs.json
+++ b/docs.json
@@ -154,6 +154,7 @@
                 "icon": "wrench",
                 "pages": [
                   "ai/assistant",
+                  "ai/assistant-integrations",
                   "ai/contextual-menu",
                   {
                     "group": "Insights",


### PR DESCRIPTION
Created comprehensive documentation for the new Discord and Slack assistant integrations. The documentation covers OAuth connection flows, bot usage, configuration options, and troubleshooting for both platforms.

## Files changed
- `ai/assistant-integrations.mdx` - New documentation page for Discord and Slack integrations
- `docs.json` - Added new page to navigation under Optimize section

cc @densumesh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new page documenting Discord and Slack Assistant integrations and links it in the Optimize navigation.
> 
> - **Docs**:
>   - New `ai/assistant-integrations.mdx` detailing Discord and Slack integrations: access, OAuth connection, usage (mentions, DMs, slash command), configuration, status management, disconnect, and troubleshooting.
> - **Navigation**:
>   - Add `ai/assistant-integrations` under Optimize in `docs.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit befb18ee788cf0ee18b2d103775809219485b130. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->