### PR TITLE
Add Assistant integrations documentation

### DIFF
--- a/ai/assistant-integrations.mdx
+++ b/ai/assistant-integrations.mdx
@@ -1,0 +1,200 @@
+---
+title: "Assistant integrations"
+description: "Connect Discord and Slack to bring AI-powered documentation assistance to your community channels."
+keywords: ["Discord", "Slack", "integrations", "chat", "community"]
+---
+
+<Info>
+  Assistant integrations are available on [Pro and Custom plans](https://mintlify.com/pricing?ref=assistant).
+</Info>
+
+## About assistant integrations
+
+Assistant integrations extend your Mintlify Assistant to Discord servers and Slack workspaces. When connected, the assistant can answer questions about your documentation directly in your community channels, helping users find information without leaving their preferred communication platform.
+
+The assistant uses the same AI-powered search and retrieval system as the web assistant, providing:
+
+* **Accurate answers** from your documentation with source citations.
+* **Code examples** that users can copy and implement.
+* **Contextual responses** based on your documentation content.
+
+Each message sent through Discord or Slack integrations counts toward your plan's message allowance, just like messages from the web assistant.
+
+## Access integrations
+
+Navigate to the integrations page from your dashboard to connect Discord and Slack.
+
+1. Go to your [dashboard](https://dashboard.mintlify.com).
+2. Select your documentation site.
+3. Navigate to **Products** > **Assistant** > **Settings**.
+4. Click the **Integrations** tab.
+
+<Frame>
+  <img src="/images/assistant/integrations-tab-light.png" alt="The Assistant settings page with the Integrations tab highlighted." className="block dark:hidden" />
+  <img src="/images/assistant/integrations-tab-dark.png" alt="The Assistant settings page with the Integrations tab highlighted." className="hidden dark:block" />
+</Frame>
+
+The integrations page displays all available integrations and their connection status. Connected integrations appear in the **Connected apps** section, while available integrations appear in the **All Apps** section.
+
+## Connect Discord
+
+Connect your Discord server to enable the assistant to answer questions in Discord channels.
+
+### Prerequisites
+
+- Admin permissions on your Discord server.
+- An active Mintlify Pro or Custom plan.
+
+### Connect your server
+
+1. Navigate to the **Integrations** tab in your Assistant settings.
+2. Find Discord in the **All Apps** section.
+3. Click **Connect**.
+4. Sign in to Discord if prompted.
+5. Select the server where you want to add the assistant.
+6. Review the permissions and click **Authorize**.
+
+<Frame>
+  <img src="/images/assistant/discord-connect-light.png" alt="The Discord integration card with the Connect button." className="block dark:hidden" />
+  <img src="/images/assistant/discord-connect-dark.png" alt="The Discord integration card with the Connect button." className="hidden dark:block" />
+</Frame>
+
+After authorization, Discord redirects you back to the integrations page. The Discord integration moves to the **Connected apps** section with a **Connected** status badge.
+
+### Configure Discord channels
+
+After connecting your Discord server, configure which channels the assistant can access.
+
+1. Navigate to the **Integrations** tab in your Assistant settings.
+2. Find Discord in the **Connected apps** section.
+3. Click **Configure**.
+4. Select the channels where you want the assistant to respond to questions.
+5. Save your configuration.
+
+The assistant only responds in channels you explicitly enable. This gives you control over where the assistant appears in your Discord server.
+
+## Connect Slack
+
+Connect your Slack workspace to enable the assistant to answer questions in Slack channels.
+
+### Prerequisites
+
+- Admin permissions on your Slack workspace.
+- An active Mintlify Pro or Custom plan.
+
+### Connect your workspace
+
+1. Navigate to the **Integrations** tab in your Assistant settings.
+2. Find Slack in the **All Apps** section.
+3. Click **Connect**.
+4. Sign in to Slack if prompted.
+5. Select the workspace where you want to add the assistant.
+6. Review the permissions and click **Allow**.
+
+<Frame>
+  <img src="/images/assistant/slack-connect-light.png" alt="The Slack integration card with the Connect button." className="block dark:hidden" />
+  <img src="/images/assistant/slack-connect-dark.png" alt="The Slack integration card with the Connect button." className="hidden dark:block" />
+</Frame>
+
+After authorization, Slack redirects you back to the integrations page. The Slack integration moves to the **Connected apps** section with a **Connected** status badge.
+
+### Configure Slack channels
+
+After connecting your Slack workspace, configure which channels the assistant can access.
+
+1. Navigate to the **Integrations** tab in your Assistant settings.
+2. Find Slack in the **Connected apps** section.
+3. Click **Configure**.
+4. Select the channels where you want the assistant to respond to questions.
+5. Save your configuration.
+
+The assistant only responds in channels you explicitly enable. This gives you control over where the assistant appears in your Slack workspace.
+
+## Manage integrations
+
+View and manage all connected integrations from the integrations page.
+
+### View connection status
+
+The integrations page shows the connection status for each integration:
+
+- **Connected apps**: Integrations currently connected to your documentation.
+- **All Apps**: Available integrations that you can connect.
+
+Each connected integration displays a **Connected** status badge and a **Configure** button.
+
+### Disconnect an integration
+
+Remove an integration to stop the assistant from responding in that platform.
+
+1. Navigate to the **Integrations** tab in your Assistant settings.
+2. Find the integration in the **Connected apps** section.
+3. Click **Configure**.
+4. Click **Disconnect** or **Remove**.
+5. Confirm the disconnection.
+
+After disconnecting, the integration moves back to the **All Apps** section and the assistant stops responding in that platform.
+
+## How integrations work
+
+When you connect Discord or Slack, the assistant monitors messages in enabled channels. Users can ask questions naturally, and the assistant responds with information from your documentation.
+
+### Message handling
+
+The assistant processes messages in connected channels:
+
+1. A user asks a question in an enabled channel.
+2. The assistant searches your documentation for relevant information.
+3. The assistant responds with an answer, citing sources from your documentation.
+4. Users can click source links to view the full documentation page.
+
+### Privacy and permissions
+
+Integrations require specific permissions to function:
+
+**Discord permissions:**
+- Read messages in enabled channels.
+- Send messages in enabled channels.
+- Embed links to documentation.
+
+**Slack permissions:**
+- Read messages in enabled channels.
+- Send messages in enabled channels.
+- Embed links to documentation.
+
+The assistant only accesses channels you explicitly enable. It does not read or store messages from other channels.
+
+## Troubleshooting
+
+<Accordion title="Integration not appearing after connection">
+  If an integration doesn't appear in the **Connected apps** section after authorization:
+
+  1. Refresh the integrations page.
+  2. Verify you completed the authorization flow.
+  3. Check that you have admin permissions on the platform.
+  4. Try disconnecting and reconnecting the integration.
+
+  If the issue persists, [contact support](mailto:support@mintlify.com).
+</Accordion>
+
+<Accordion title="Assistant not responding in channels">
+  If the assistant doesn't respond to questions in your channels:
+
+  1. Verify the integration shows as **Connected** on the integrations page.
+  2. Check that you enabled the specific channel in the integration configuration.
+  3. Ensure the assistant is enabled in your [Assistant settings](/ai/assistant).
+  4. Verify you haven't exceeded your message allowance or spend limit.
+
+  If the issue persists, [contact support](mailto:support@mintlify.com).
+</Accordion>
+
+<Accordion title="Authorization failed">
+  If authorization fails when connecting an integration:
+
+  1. Verify you have admin permissions on the platform.
+  2. Check that you're signed in to the correct account.
+  3. Try using a different browser or clearing your browser cache.
+  4. Ensure your organization allows third-party app installations.
+
+  If the issue persists, [contact support](mailto:support@mintlify.com).
+</Accordion>

--- a/docs.json
+++ b/docs.json
@@ -154,6 +154,7 @@
                 "icon": "wrench",
                 "pages": [
                   "ai/assistant",
+                  "ai/assistant-integrations",
                   "ai/contextual-menu",
                   {
                     "group": "Insights",


### PR DESCRIPTION
Created comprehensive documentation for the new Discord and Slack Assistant integrations feature. The documentation covers connecting integrations, managing channels, and troubleshooting common issues.

## Files changed
- `ai/assistant-integrations.mdx` - New documentation page for Assistant integrations
- `docs.json` - Added new page to navigation in Optimize section

cc @densumesh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Assistant integrations doc (Discord/Slack) and links it in the Optimize navigation.
> 
> - **Documentation**:
>   - Add `ai/assistant-integrations.mdx` detailing Discord and Slack integrations: access/setup, channel configuration, management (status, disconnect), permissions/privacy, and troubleshooting.
> - **Navigation**:
>   - Include `ai/assistant-integrations` in `docs.json` under `Optimize` alongside `ai/assistant`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd84417d0b05fb9216531e1e95b944a11b52c8f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->