### PR TITLE
Add alt text to tiles page

### DIFF
--- a/components/tiles.mdx
+++ b/components/tiles.mdx
@@ -7,14 +7,14 @@ keywords: ["tiles", "visual preview", "grid", "showcase"]
 Use tiles to create visual showcase elements with a patterned background, title, and description. Tiles are ideal for displaying component previews, feature highlights, or navigation items in a grid layout.
 
 <Tile href="/components/accordions" title="Accordion" description="Two variants">
-  <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-  <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+  <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+  <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
 </Tile>
 
 ```mdx Tile example
 <Tile href="/components/accordions" title="Accordion" description="Two variants">
-  <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-  <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+  <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+  <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
 </Tile>
 ```
 
@@ -24,32 +24,32 @@ Combine tiles with the [columns component](/components/columns) to create a resp
 
 <Columns cols={3}>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
 </Columns>
 
 ```mdx Grid layout example
 <Columns cols={3}>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
   <Tile href="/components/accordions" title="Accordion" description="Two variants">
-    <img src="/images/tiles/accordion-light.svg" className="block dark:hidden" />
-    <img src="/images/tiles/accordion-dark.svg" className="hidden dark:block" />
+    <img src="/images/tiles/accordion-light.svg" alt="Accordion component preview" className="block dark:hidden" />
+    <img src="/images/tiles/accordion-dark.svg" alt="Accordion component preview (dark mode)" className="hidden dark:block" />
   </Tile>
 </Columns>
 ```


### PR DESCRIPTION
## Documentation changes

Adds missing alt text

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds alt text to light/dark preview images in `components/tiles.mdx` examples and grid sections to improve accessibility.
> 
> - **Docs: `components/tiles.mdx`**
>   - Add `alt` text to tile preview images (light/dark) in inline examples and the grid layout sections for improved accessibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c35ae6eaf01ee26e4dd6a69ac129ad2ce6060666. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->