### PR TITLE
Test editor v5

### DIFF
--- a/editor.mdx
+++ b/editor.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Visual editor"
+title: "Visual editor v5"
 description: "Create, maintain, and publish documentation in your browser."
-keywords: ["visual editor", "WYSIWYG", "web editor"]
+keywords: ["visual editor","WYSIWYG","web editor"]
 ---
 
 <img
@@ -38,7 +38,7 @@ Here is how you'll typically work in the visual editor:
   <Step title="Edit your content">
     Make changes in the visual editor. Press <kbd>/</kbd>
 
-     to open the component menu.
+    to open the component menu.
   </Step>
   <Step title="Preview your changes">
     Visual mode shows you how your changes will appear on your live site. Use this to verify everything looks correct.
@@ -88,7 +88,7 @@ Visual mode provides a WYSIWYG experience where changes that you make in the edi
 
 ### Markdown mode
 
-Markdown mode provides direct access to the underlying `MDX` code of your documentation. This mode is ideal for when you need precise control over component properties or when you prefer to write in Markdown syntax.
+Markdown mode provides direct access to the files that make up your documentation. This mode is ideal for when you need precise control over component properties or when you prefer to write in MDX syntax.
 
 <Frame>
   <img
@@ -110,7 +110,15 @@ Markdown mode provides direct access to the underlying `MDX` code of your docume
 
 Use the sidebar file explorer to browse your documentation files. Click on any file to open it in the editor.
 
-Press <kbd>Command</kbd> + <kbd>P</kbd> on macOS or <kbd>Ctrl</kbd> + <kbd>P</kbd> on Windows to search for files by name.
+Press <kbd>Command</kbd>
+
+ + <kbd>P</kbd>
+
+ on macOS or <kbd>Ctrl</kbd>
+
+ + <kbd>P</kbd>
+
+ on Windows to search for files by name.
 
 ### Create new pages
 
@@ -242,13 +250,13 @@ In visual mode, press <kbd>/</kbd>
   />
 </Frame>
 
-In Markdown mode, you directly edit the `MDX` of your pages. This can be helpful when you need to:
+In Markdown mode, you can directly edit the MDX of your pages. This can be helpful when you need to:
 
 - Set specific component properties
 - Work with complex nested components
-- Copy and paste `MDX` content from other sources
+- Copy and paste MDX content from other sources
 
-See [Format text](/create/text) and [Format code](/create/code) for more information on how to write using Markdown syntax.
+See [Format text](/create/text) and [Format code](/create/code) for more information on how to write using MDX syntax.
 
 ## Publish your changes
 
@@ -330,26 +338,26 @@ Once your pull request is created:
 
 The visual editor supports all common keyboard shortcuts such as copy, paste, undo, and select all, and the following shortcuts:
 
-| Command                          | macOS                                                | Windows                                                  |
-| :------------------------------- | :--------------------------------------------------- | :------------------------------------------------------- |
-| **Search files**                 | <kbd>Cmd</kbd>   + <kbd>P</kbd>                      | <kbd>Control</kbd>   + <kbd>P</kbd>                      |
-| **Add link to highlighted text** | <kbd>Cmd</kbd>   + <kbd>K</kbd>                      | <kbd>Control</kbd>   + <kbd>K</kbd>                      |
-| **Add line break**               | <kbd>Cmd</kbd>   + <kbd>Enter</kbd>                  | <kbd>Control</kbd>   + <kbd>Enter</kbd>                  |
-| **Bold**                         | <kbd>Cmd</kbd>   + <kbd>B</kbd>                      | <kbd>Control</kbd>   + <kbd>B</kbd>                      |
-| **Italic**                       | <kbd>Cmd</kbd>   + <kbd>I</kbd>                      | <kbd>Control</kbd>   + <kbd>I</kbd>                      |
-| **Underline**                    | <kbd>Cmd</kbd>   + <kbd>U</kbd>                      | <kbd>Control</kbd>   + <kbd>U</kbd>                      |
-| **Strikethrough**                | <kbd>Cmd</kbd>   + <kbd>Shift</kbd>   + <kbd>S</kbd> | <kbd>Control</kbd>   + <kbd>Shift</kbd>   + <kbd>S</kbd> |
-| **Code**                         | <kbd>Cmd</kbd>   + <kbd>E</kbd>                      | <kbd>Control</kbd>   + <kbd>E</kbd>                      |
-| **Normal text**                  | <kbd>Cmd</kbd>   + <kbd>Alt</kbd>   + <kbd>0</kbd>   | <kbd>Control</kbd>   + <kbd>Alt</kbd>   + <kbd>0</kbd>   |
-| **Heading 1**                    | <kbd>Cmd</kbd>   + <kbd>Alt</kbd>   + <kbd>1</kbd>   | <kbd>Control</kbd>   + <kbd>Alt</kbd>   + <kbd>1</kbd>   |
-| **Heading 2**                    | <kbd>Cmd</kbd>   + <kbd>Alt</kbd>   + <kbd>2</kbd>   | <kbd>Control</kbd>   + <kbd>Alt</kbd>   + <kbd>2</kbd>   |
-| **Heading 3**                    | <kbd>Cmd</kbd>   + <kbd>Alt</kbd>   + <kbd>3</kbd>   | <kbd>Control</kbd>   + <kbd>Alt</kbd>   + <kbd>3</kbd>   |
-| **Heading 4**                    | <kbd>Cmd</kbd>   + <kbd>Alt</kbd>   + <kbd>4</kbd>   | <kbd>Control</kbd>   + <kbd>Alt</kbd>   + <kbd>4</kbd>   |
-| **Ordered list**                 | <kbd>Cmd</kbd>   + <kbd>Shift</kbd>   + <kbd>7</kbd> | <kbd>Control</kbd>   + <kbd>Shift</kbd>   + <kbd>7</kbd> |
-| **Unordered list**               | <kbd>Cmd</kbd>   + <kbd>Shift</kbd>   + <kbd>8</kbd> | <kbd>Control</kbd>   + <kbd>Shift</kbd>   + <kbd>8</kbd> |
-| **Blockquote**                   | <kbd>Cmd</kbd>   + <kbd>Shift</kbd>   + <kbd>B</kbd> | <kbd>Control</kbd>   + <kbd>Shift</kbd>   + <kbd>B</kbd> |
-| **Subscript**                    | <kbd>Cmd</kbd>   + <kbd>,</kbd>                      | <kbd>Control</kbd>   + <kbd>,</kbd>                      |
-| **Superscript**                  | <kbd>Cmd</kbd>   + <kbd>.</kbd>                      | <kbd>Control</kbd>   + <kbd>.</kbd>                      |
+| Command                          | macOS                                                    | Windows                                                      |
+| :------------------------------- | :------------------------------------------------------- | :----------------------------------------------------------- |
+| **Search files**                 | <kbd>Cmd</kbd>     + <kbd>P</kbd>                        | <kbd>Control</kbd>     + <kbd>P</kbd>                        |
+| **Add link to highlighted text** | <kbd>Cmd</kbd>     + <kbd>K</kbd>                        | <kbd>Control</kbd>     + <kbd>K</kbd>                        |
+| **Add line break**               | <kbd>Cmd</kbd>     + <kbd>Enter</kbd>                    | <kbd>Control</kbd>     + <kbd>Enter</kbd>                    |
+| **Bold**                         | <kbd>Cmd</kbd>     + <kbd>B</kbd>                        | <kbd>Control</kbd>     + <kbd>B</kbd>                        |
+| **Italic**                       | <kbd>Cmd</kbd>     + <kbd>I</kbd>                        | <kbd>Control</kbd>     + <kbd>I</kbd>                        |
+| **Underline**                    | <kbd>Cmd</kbd>     + <kbd>U</kbd>                        | <kbd>Control</kbd>     + <kbd>U</kbd>                        |
+| **Strikethrough**                | <kbd>Cmd</kbd>     + <kbd>Shift</kbd>     + <kbd>S</kbd> | <kbd>Control</kbd>     + <kbd>Shift</kbd>     + <kbd>S</kbd> |
+| **Code**                         | <kbd>Cmd</kbd>     + <kbd>E</kbd>                        | <kbd>Control</kbd>     + <kbd>E</kbd>                        |
+| **Normal text**                  | <kbd>Cmd</kbd>     + <kbd>Alt</kbd>     + <kbd>0</kbd>   | <kbd>Control</kbd>     + <kbd>Alt</kbd>     + <kbd>0</kbd>   |
+| **Heading 1**                    | <kbd>Cmd</kbd>     + <kbd>Alt</kbd>     + <kbd>1</kbd>   | <kbd>Control</kbd>     + <kbd>Alt</kbd>     + <kbd>1</kbd>   |
+| **Heading 2**                    | <kbd>Cmd</kbd>     + <kbd>Alt</kbd>     + <kbd>2</kbd>   | <kbd>Control</kbd>     + <kbd>Alt</kbd>     + <kbd>2</kbd>   |
+| **Heading 3**                    | <kbd>Cmd</kbd>     + <kbd>Alt</kbd>     + <kbd>3</kbd>   | <kbd>Control</kbd>     + <kbd>Alt</kbd>     + <kbd>3</kbd>   |
+| **Heading 4**                    | <kbd>Cmd</kbd>     + <kbd>Alt</kbd>     + <kbd>4</kbd>   | <kbd>Control</kbd>     + <kbd>Alt</kbd>     + <kbd>4</kbd>   |
+| **Ordered list**                 | <kbd>Cmd</kbd>     + <kbd>Shift</kbd>     + <kbd>7</kbd> | <kbd>Control</kbd>     + <kbd>Shift</kbd>     + <kbd>7</kbd> |
+| **Unordered list**               | <kbd>Cmd</kbd>     + <kbd>Shift</kbd>     + <kbd>8</kbd> | <kbd>Control</kbd>     + <kbd>Shift</kbd>     + <kbd>8</kbd> |
+| **Blockquote**                   | <kbd>Cmd</kbd>     + <kbd>Shift</kbd>     + <kbd>B</kbd> | <kbd>Control</kbd>     + <kbd>Shift</kbd>     + <kbd>B</kbd> |
+| **Subscript**                    | <kbd>Cmd</kbd>     + <kbd>,</kbd>                        | <kbd>Control</kbd>     + <kbd>,</kbd>                        |
+| **Superscript**                  | <kbd>Cmd</kbd>     + <kbd>.</kbd>                        | <kbd>Control</kbd>     + <kbd>.</kbd>                        |
 
 ## Troubleshooting
 
@@ -367,14 +375,11 @@ Find solutions to common issues you might encounter while using the visual edito
 
     1. Check deployment status in your dashboard.
     2. Hard refresh your browser (<kbd>Ctrl</kbd>
+       - <kbd>F5</kbd>
 
-        + <kbd>F5</kbd>
-
-        or <kbd>Cmd</kbd>
-
-        + <kbd>Shift</kbd>
-
-        + <kbd>R</kbd>
+       or <kbd>Cmd</kbd>
+       - <kbd>Shift</kbd>
+       - <kbd>R</kbd>
 
        )
     3. Clear your browser cache.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Retitles the editor docs to “Visual editor v5” and updates MDX/shortcut wording and formatting throughout.
> 
> - **Documentation (editor.mdx)**
>   - **Title**: Rename page to `Visual editor v5`.
>   - **Markdown mode**: Update description to reference project files and MDX syntax; adjust MDX references in bullets/links.
>   - **Shortcuts**: Reformat file search shortcut and the keyboard shortcuts table for clearer key combos.
>   - **Minor copy/formatting**: Tweak punctuation/whitespace in steps and troubleshooting text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 162bde7bd20ca90e0b419e8e2aa75e5951aba31a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->