### PR TITLE
Add assistant integrations documentation

### DIFF
--- a/ai/assistant-integrations.mdx
+++ b/ai/assistant-integrations.mdx
@@ -1,0 +1,168 @@
+---
+title: "Assistant integrations"
+description: "Connect Discord and Slack to enable the AI assistant in your community channels."
+keywords: ["Discord", "Slack", "integrations", "community support"]
+---
+
+Connect your Discord servers and Slack workspaces to the Mintlify Assistant to provide AI-powered documentation support directly in your community channels. The assistant answers questions using information from your documentation, helping users get instant help without leaving their preferred communication platform.
+
+## About assistant integrations
+
+Assistant integrations extend your documentation's AI capabilities to Discord and Slack. When connected, the assistant:
+
+* **Answers questions** in Discord servers and Slack channels using information from your documentation.
+* **Cites sources** with links back to your documentation pages.
+* **Provides context-aware responses** based on your documentation content.
+
+Each message sent through Discord or Slack integrations counts toward your plan's message allowance, just like messages sent through your documentation site.
+
+## Access integrations
+
+Navigate to the integrations page in your dashboard to connect Discord and Slack:
+
+1. Go to your [dashboard](https://dashboard.mintlify.com).
+2. Select **Assistant** from the products menu.
+3. Click the **Integrations** tab.
+
+<Frame>
+  <img src="/images/assistant/integrations-tab-light.png" alt="The assistant settings page with the Integrations tab highlighted." className="block dark:hidden" />
+  <img src="/images/assistant/integrations-tab-dark.png" alt="The assistant settings page with the Integrations tab highlighted." className="hidden dark:block" />
+</Frame>
+
+The integrations page displays all available integrations. Connected integrations appear in the **Connected apps** section, while available integrations appear in the **All Apps** section.
+
+## Connect Discord
+
+Connect your Discord server to enable the assistant to answer questions in Discord channels.
+
+### Prerequisites
+
+- [Mintlify Pro or Custom plan](https://mintlify.com/pricing)
+- Administrator permissions for your Discord server
+
+### Connect your server
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations) in your dashboard.
+2. Find **Discord** in the integrations list.
+3. Click **Connect**.
+4. Select the Discord server you want to connect from the OAuth authorization screen.
+5. Click **Authorize** to grant the Mintlify Assistant access to your server.
+
+After authorization, you return to the integrations page where Discord appears in the **Connected apps** section with a **Connected** status badge.
+
+<Frame>
+  <img src="/images/assistant/discord-connected-light.png" alt="Discord integration showing Connected status badge." className="block dark:hidden" />
+  <img src="/images/assistant/discord-connected-dark.png" alt="Discord integration showing Connected status badge." className="hidden dark:block" />
+</Frame>
+
+### Configure Discord channels
+
+After connecting your Discord server, configure which channels the assistant can access:
+
+1. In Discord, go to your server settings.
+2. Navigate to **Integrations**.
+3. Find the Mintlify Assistant bot.
+4. Configure channel permissions to control where the assistant can respond to questions.
+
+### Use the assistant in Discord
+
+Once configured, users can interact with the assistant in your Discord server:
+
+- **Mention the bot**: Tag `@Mintlify Assistant` followed by your question.
+- **Direct message**: Send a direct message to the Mintlify Assistant bot.
+
+The assistant responds with information from your documentation and includes source citations when available.
+
+## Connect Slack
+
+Connect your Slack workspace to enable the assistant to answer questions in Slack channels.
+
+### Prerequisites
+
+- [Mintlify Pro or Custom plan](https://mintlify.com/pricing)
+- Administrator permissions for your Slack workspace
+
+### Connect your workspace
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations) in your dashboard.
+2. Find **Slack** in the integrations list.
+3. Click **Connect**.
+4. Select the Slack workspace you want to connect.
+5. Review the permissions and click **Allow** to authorize the Mintlify Assistant.
+
+After authorization, you return to the integrations page where Slack appears in the **Connected apps** section with a **Connected** status badge.
+
+<Frame>
+  <img src="/images/assistant/slack-connected-light.png" alt="Slack integration showing Connected status badge." className="block dark:hidden" />
+  <img src="/images/assistant/slack-connected-dark.png" alt="Slack integration showing Connected status badge." className="hidden dark:block" />
+</Frame>
+
+### Configure Slack channels
+
+After connecting your Slack workspace, add the assistant to specific channels:
+
+1. In Slack, navigate to the channel where you want to enable the assistant.
+2. Type `/invite @Mintlify Assistant` to add the bot to the channel.
+3. Repeat for each channel where you want the assistant available.
+
+### Use the assistant in Slack
+
+Once added to channels, users can interact with the assistant in your Slack workspace:
+
+- **Mention the bot**: Tag `@Mintlify Assistant` followed by your question in any channel where the bot is present.
+- **Direct message**: Send a direct message to the Mintlify Assistant bot.
+
+The assistant responds with information from your documentation and includes source citations when available.
+
+## Manage integrations
+
+### View connection status
+
+The integrations page displays the connection status for each integration:
+
+- **Connected**: The integration is active and the assistant can respond to questions.
+- **Not connected**: The integration is available but not yet configured.
+
+### Configure integrations
+
+Click **Configure** on a connected integration to manage settings, update permissions, or disconnect the integration.
+
+### Disconnect integrations
+
+To disconnect an integration:
+
+1. Navigate to the [integrations page](https://dashboard.mintlify.com/products/assistant/settings/integrations).
+2. Find the integration you want to disconnect in the **Connected apps** section.
+3. Click **Configure**.
+4. Click **Disconnect** and confirm the action.
+
+After disconnecting, the assistant stops responding to questions in that platform and the integration moves to the **All Apps** section.
+
+## Troubleshooting
+
+<Accordion title="Discord bot not responding">
+  If the Discord bot doesn't respond to questions:
+
+  - Verify the bot has permission to read and send messages in the channel.
+  - Check that you're mentioning the bot correctly with `@Mintlify Assistant`.
+  - Ensure your Discord server is still connected in the integrations page.
+  - Verify you haven't exceeded your plan's message allowance.
+</Accordion>
+
+<Accordion title="Slack bot not responding">
+  If the Slack bot doesn't respond to questions:
+
+  - Verify the bot has been invited to the channel with `/invite @Mintlify Assistant`.
+  - Check that you're mentioning the bot correctly with `@Mintlify Assistant`.
+  - Ensure your Slack workspace is still connected in the integrations page.
+  - Verify you haven't exceeded your plan's message allowance.
+</Accordion>
+
+<Accordion title="Authorization failed">
+  If authorization fails when connecting an integration:
+
+  - Verify you have administrator permissions for the Discord server or Slack workspace.
+  - Try disconnecting and reconnecting the integration.
+  - Clear your browser cache and cookies, then try again.
+  - Contact [support](mailto:support@mintlify.com) if the issue persists.
+</Accordion>

--- a/docs.json
+++ b/docs.json
@@ -154,6 +154,7 @@
                 "icon": "wrench",
                 "pages": [
                   "ai/assistant",
+                  "ai/assistant-integrations",
                   "ai/contextual-menu",
                   {
                     "group": "Insights",


### PR DESCRIPTION
Created comprehensive documentation for Discord and Slack assistant integrations. The new page explains how to connect community platforms to enable AI-powered documentation support in Discord servers and Slack workspaces.

## Files changed
- Created `ai/assistant-integrations.mdx` - New documentation page covering Discord and Slack integrations
- Updated `docs.json` - Added new page to navigation under Optimize group

@densumesh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new page documenting Discord and Slack Assistant integrations and links it in navigation.
> 
> - **Documentation**
>   - Add `ai/assistant-integrations.mdx` detailing Discord and Slack integrations (prerequisites, connect steps, channel configuration, usage, management, troubleshooting) with illustrative images.
> - **Navigation**
>   - Update `docs.json` to include `ai/assistant-integrations` under `Optimize` > AI pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7877ee3f20c0ff0adb02ee30084fdfdcc4ffd90a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->