### PR TITLE
Add feedback element identifiers to docs

### DIFF
--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -63,6 +63,12 @@ Mintlify has a set of common identifiers and selectors to help you tag important
     - ContentArea: `content-area`
     - ContentContainer: `content-container`
     - ContentSideLayout: `content-side-layout`
+    - FeedbackForm: `feedback-form`
+    - FeedbackFormCancel: `feedback-form-cancel`
+    - FeedbackFormInput: `feedback-form-input`
+    - FeedbackFormSubmit: `feedback-form-submit`
+    - FeedbackThumbsDown: `feedback-thumbs-down`
+    - FeedbackThumbsUp: `feedback-thumbs-up`
     - Footer: `footer`
     - Header: `header`
     - NavBarTransition: `navbar-transition`


### PR DESCRIPTION
Updated the custom scripts documentation to include six new feedback element identifiers. These identifiers allow users to customize the styling of feedback form components including thumbs up/down buttons and form controls.

**Files changed:**
- `customize/custom-scripts.mdx` - Added FeedbackForm, FeedbackFormCancel, FeedbackFormInput, FeedbackFormSubmit, FeedbackThumbsDown, and FeedbackThumbsUp identifiers

cc @pqoqubbw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds six feedback-related element identifiers to the custom scripts identifiers list.
> 
> - **Docs**:
>   - Update `customize/custom-scripts.mdx` Identifiers list with:
>     - `feedback-form`, `feedback-form-cancel`, `feedback-form-input`, `feedback-form-submit`, `feedback-thumbs-down`, `feedback-thumbs-up`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a2c81aeccc04a044ed37640ef91f76823aac9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->