### PR TITLE
Document new headline prop for Tooltip

### DIFF
--- a/components/tooltips.mdx
+++ b/components/tooltips.mdx
@@ -12,6 +12,12 @@ Use tooltips to provide additional context or definitions when a user hovers ove
 <Tooltip tip="Application Programming Interface: a set of protocols for software applications to communicate." cta="Read our API guide" href="/api-reference">API</Tooltip> documentation helps developers understand how to integrate with your service.
 ```
 
+**Example with headline**: <Tooltip headline="API Definition" tip="Application Programming Interface: a set of protocols for software applications to communicate." cta="Read our API guide" href="/api-reference">API</Tooltip> documentation helps developers understand how to integrate with your service.
+
+```mdx Tooltip with headline wrap
+<Tooltip headline="API Definition" tip="Application Programming Interface: a set of protocols for software applications to communicate." cta="Read our API guide" href="/api-reference">API</Tooltip> documentation helps developers understand how to integrate with your service.
+```
+
 ## Properties
 
 <ResponseField name="tip" type="string" required>

--- a/components/tooltips.mdx
+++ b/components/tooltips.mdx
@@ -24,6 +24,10 @@ Use tooltips to provide additional context or definitions when a user hovers ove
   The text displayed in the tooltip.
 </ResponseField>
 
+<ResponseField name="headline" type="string">
+  Optional headline text displayed above the tooltip content.
+</ResponseField>
+
 <ResponseField name="cta" type="string">
   The call-to-action text for a link within the tooltip.
 </ResponseField>


### PR DESCRIPTION
Added documentation for the new optional `headline` prop in the Tooltip component. The documentation includes usage examples and property descriptions for the headline feature.

## Files changed
- `components/tooltips.mdx` - Added headline prop documentation with examples and property definition

@pqoqubbw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for the optional `headline` prop in Tooltip, including a new example and property description in `components/tooltips.mdx`.
> 
> - **Docs**:
>   - Update `components/tooltips.mdx` to document Tooltip `headline` prop.
>     - Add usage example demonstrating `headline` with `tip`, `cta`, and `href`.
>     - Add `headline` to Properties with description as optional headline above tooltip content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1289311e512f10fedcc717be28a37e371c8c294. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->