### PR TITLE
Document automatic backfill behavior for AI suggestions

### DIFF
--- a/ai/suggestions.mdx
+++ b/ai/suggestions.mdx
@@ -38,7 +38,7 @@ After installing the Mintlify GitHub App on your organizations, select which rep
 The agent monitors the default branch (typically `main`) for each repository. When a pull request merges to this branch, the agent analyzes the changes and creates suggestions.
 
 <Note>
-  When you first enable monitoring for a repository, the agent automatically creates suggestions for pull requests merged in the last 7 days. This backfill only occurs if no suggestions already exist for that repository. You may see multiple suggestions appear immediately after enabling monitoring.
+  When you first enable monitoring for a repository, the agent creates suggestions for pull requests merged in the last seven days. This backfill only occurs if no suggestions already exist for that repository. You may see multiple suggestions appear immediately after enabling monitoring.
 </Note>
 
 ### Stop monitoring a repository


### PR DESCRIPTION
Added documentation explaining that when users first enable repository monitoring, the system automatically creates suggestions for merged pull requests from the last 7 days. This helps users understand why they may see multiple suggestions appear immediately after enabling monitoring.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents that enabling monitoring backfills suggestions for PRs merged in the last 7 days (if none exist), which may create multiple suggestions immediately.
> 
> - **Documentation**:
>   - Add a `Note` in `ai/suggestions.mdx` describing initial backfill when monitoring is first enabled:
>     - Creates suggestions for pull requests merged in the last 7 days.
>     - Runs only if no suggestions exist for the repository.
>     - May result in multiple suggestions appearing immediately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27343c80b00e188b79bf83a29f2d03719f28be06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->