### PR TITLE
Update Slack bot name to @mintlify-assistant

### DIFF
--- a/ai/slack-bot.mdx
+++ b/ai/slack-bot.mdx
@@ -27,7 +27,7 @@ Each message sent by the bot counts toward your assistant message usage.
     <img src="/images/assistant/slack-connect-dark.png" alt="The Connect button in the Slack card in dark mode." className="hidden dark:block" />
   </Frame>
 1. Follow the Slack prompts to add the app to your workspace.
-1. Mention the bot to add it to a channel. The bot's default name is `@mintlify`.
+1. Mention the bot to add it to a channel. The bot's default name is `@mintlify-assistant`.
 
 ### Customize the bot's name
 


### PR DESCRIPTION
Updated the Slack bot documentation to reflect the new default bot name `@mintlify-assistant` instead of `@mintlify`. This change aligns the documentation with the updated installation congratulations message.

**Files changed:**
- `ai/slack-bot.mdx` - Updated bot's default name reference

cc @paaatrrrick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Slack bot docs to use the new default handle `@mintlify-assistant`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5be5e915f59574b74c4137fe1a615ab03f37bad1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->