### PR TITLE
Document Tooltip component updates

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,20 @@ rss: true
 noindex: true
 ---
 
+<Update label="December 12, 2025" tags={["Improvements"]} rss={{ title: "Tooltip component updates", description: "Enhanced tooltip styling and new headline prop" }}>
+  ## Tooltip component updates
+
+  The `<Tooltip />` component has been updated with improved styling and new functionality:
+
+  - Added optional `headline` prop for displaying a title above the tooltip content.
+  - Refreshed visual design with updated colors, spacing, and shadows for better readability.
+  - Improved accessibility with enhanced `aria-label` support that combines headline and tip text.
+  - Updated CTA styling with new chevron icon and refined spacing.
+
+  Learn more in the [Tooltip documentation](/components/tooltips).
+
+</Update>
+
 <Update label="December 9, 2025" tags={["New releases"]} rss={{ title: "Preview widget", description: "Track changed files in preview deployments with an interactive widget" }}>
   ## Preview widget
 


### PR DESCRIPTION
Added changelog entry for December 12, 2025 documenting the Tooltip component enhancements. The update covers the new headline prop, refreshed styling, improved accessibility, and updated CTA design.

**Files changed:**
- `changelog.mdx` - Added new update entry for Tooltip component improvements

cc @pqoqubbw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Dec 12, 2025 changelog entry documenting Tooltip updates (new `headline` prop, styling refresh, improved a11y, updated CTA).
> 
> - **Changelog**:
>   - Adds new update in `changelog.mdx` for December 12, 2025 covering `Tooltip` component enhancements:
>     - Optional `headline` prop
>     - Refreshed styling (colors, spacing, shadows)
>     - Improved accessibility via combined `aria-label`
>     - Updated CTA styling with chevron
>     - Links to `/components/tooltips`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b9117f7c3634d52c74df79ab4f513830b7a8ccf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->