### PR TITLE
Update asDraft default value in agent API documentation

### DIFF
--- a/ai/agent.mdx
+++ b/ai/agent.mdx
@@ -94,7 +94,7 @@ Add any instructions that you want the agent to follow. The agent appends these 
 
 Use the agent endpoints to [create jobs](/api-reference/agent/create-agent-job), [get a specific job](/api-reference/agent/get-agent-job), and [get all jobs](/api-reference/agent/get-all-jobs).
 
-When creating jobs via the API, you can control whether pull requests are created in draft mode using the `asDraft` parameter (defaults to `true`). Set `asDraft: false` to create non-draft pull requests ready for immediate review and merging in automated workflows.
+When creating jobs via the API, you can control whether pull requests are created in draft mode using the `asDraft` parameter (defaults to `false`). Set `asDraft: true` to create draft pull requests for review before merging.
 
 ## Write effective prompts
 


### PR DESCRIPTION
Updated the agent documentation to reflect that the asDraft parameter now defaults to false instead of true. This change aligns the documentation with the recent code changes in PR #2929.

Files changed:
- ai/agent.mdx

---

Created by Mintlify agent