### PR TITLE
Update roles documentation to include deployment deletion permission

### DIFF
--- a/dashboard/roles.mdx
+++ b/dashboard/roles.mdx
@@ -21,6 +21,7 @@ The following describes actions that are limited to the Admin role:
 | Update custom domain    |   ❌   |  ✅   |
 | Update Git source       |   ❌   |  ✅   |
 | Delete org              |   ❌   |  ✅   |
+| Delete deployment       |   ❌   |  ✅   |
 
 Other actions on the dashboard are available to both roles.
 


### PR DESCRIPTION
Added "Delete deployment" permission to the roles table in dashboard/roles.mdx, marking it as Admin-only based on the authorization middleware configuration in PR #2465. This ensures the documentation accurately reflects the new deployment deletion feature's access controls.

Files changed:
- dashboard/roles.mdx

---

Created by Mintlify agent