### PR TITLE
docs: improve agent api docs to clarify you don't need to specify a system message

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -48,7 +48,7 @@
                   },
                   "messages": {
                     "type": "array",
-                    "description": "A list of previous messages to provide to the agent.",
+                    "description": "A list of messages to provide to the agent. A default system prompt is always prepended automatically, so you typically only need to include user messages.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -59,7 +59,7 @@
                         "role": {
                           "type": "string",
                           "enum": ["system", "user"],
-                          "description": "The role of the message sender."
+                          "description": "The role of the message sender. Use `user` for task instructions. Use `system` to add supplementary instructions that are appended after the default system prompt (does not replace it)."
                         },
                         "content": {
                           "type": "string",

--- a/es/admin-openapi.json
+++ b/es/admin-openapi.json
@@ -48,7 +48,7 @@
                   },
                   "messages": {
                     "type": "array",
-                    "description": "Una lista de mensajes anteriores para proporcionar al agente.",
+                    "description": "Una lista de mensajes para proporcionar al agente. Un system prompt predeterminado siempre se antepone automáticamente, por lo que normalmente solo necesitas incluir mensajes de usuario.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -62,7 +62,7 @@
                             "system",
                             "user"
                           ],
-                          "description": "La función del remitente del mensaje."
+                          "description": "El rol del remitente del mensaje. Usa `user` para instrucciones de tareas. Usa `system` para añadir instrucciones complementarias que se agregan después del system prompt predeterminado (no lo reemplaza)."
                         },
                         "content": {
                           "type": "string",

--- a/fr/admin-openapi.json
+++ b/fr/admin-openapi.json
@@ -48,7 +48,7 @@
                   },
                   "messages": {
                     "type": "array",
-                    "description": "Une liste de messages précédents à fournir à l’agent.",
+                    "description": "Une liste de messages à fournir à l'agent. Un system prompt par défaut est toujours ajouté automatiquement au début, donc vous n'avez généralement besoin d'inclure que des messages utilisateur.",
                     "items": {
                       "type": "object",
                       "required": [
@@ -62,7 +62,7 @@
                             "system",
                             "user"
                           ],
-                          "description": "Le rôle de l’expéditeur du message."
+                          "description": "Le rôle de l'expéditeur du message. Utilisez `user` pour les instructions de tâche. Utilisez `system` pour ajouter des instructions supplémentaires qui sont ajoutées après le system prompt par défaut (ne le remplace pas)."
                         },
                         "content": {
                           "type": "string",

--- a/zh/admin-openapi.json
+++ b/zh/admin-openapi.json
@@ -48,7 +48,7 @@
                   },
                   "messages": {
                     "type": "array",
-                    "description": "要提供给代理的历史消息列表。",
+                    "description": "要提供给代理的消息列表。默认系统提示会自动添加到消息开头，因此通常只需包含用户消息。",
                     "items": {
                       "type": "object",
                       "required": [
@@ -62,7 +62,7 @@
                             "system",
                             "user"
                           ],
-                          "description": "消息发送方的角色。"
+                          "description": "消息发送方的角色。使用 `user` 发送任务指令。使用 `system` 添加补充说明，这些说明会附加在默认系统提示之后（不会替换默认提示）。"
                         },
                         "content": {
                           "type": "string",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies default system prompt behavior and `user` vs `system` role guidance for `messages` in the agent job API across en/es/fr/zh OpenAPI specs.
> 
> - **API docs (OpenAPI)**:
>   - Updates `admin-openapi.json`, `es/admin-openapi.json`, `fr/admin-openapi.json`, `zh/admin-openapi.json`.
>   - `POST /agent/{projectId}/job` request body:
>     - `messages.description`: notes a default system prompt is auto-prepended; typically only include user messages.
>     - `messages.items.properties.role.description`: clarifies using `user` for task instructions and `system` for supplementary instructions appended after the default prompt.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42fe60f3c7d562bab5a6283b743383b1ee73f727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->