### PR TITLE
Add redirect for /ai/slack-app to /ai/slack-bot

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1778,6 +1778,10 @@
     {
       "source": "/ai/autopilot",
       "destination": "/ai/suggestions"
+    },
+    {
+      "source": "/ai/slack-app",
+      "destination": "/ai/slack-bot"
     }
   ],
   "integrations": {


### PR DESCRIPTION
Added a redirect from the dead link /ai/slack-app to the correct /ai/slack-bot page to fix broken social media links and preserve SEO value. This ensures users clicking the link from the Twitter post will reach the intended documentation.

This link was used on our recent post here: https://x.com/mintlify/status/1999600101468348865

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a redirect mapping `/ai/slack-app` → `/ai/slack-bot` in `docs.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107ba6c07fea7f6a7573fee67c94aac36c4cbe28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->