### PR TITLE
Add relative import examples to reusable snippets documentation

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -165,7 +165,8 @@ export const MyJSXSnippet = () => {
 
 2. Import the snippet from your destination file and use the component:
 
-```typescript destination-file.mdx
+<CodeGroup>
+```typescript Absolute import
 ---
 title: My title
 description: My Description
@@ -175,3 +176,15 @@ import { MyJSXSnippet } from '/snippets/my-jsx-snippet.jsx';
 
 <MyJSXSnippet />
 ```
+
+```typescript Relative import
+---
+title: My title
+description: My Description
+---
+
+import { MyJSXSnippet } from '../snippets/my-jsx-snippet.jsx';
+
+<MyJSXSnippet />
+```
+</CodeGroup>

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -75,21 +75,37 @@ My keyword of the day is {word}.
 
 2. Import the snippet into your destination file with the variable. The property will fill in based on your specification.
 
-```typescript destination-file.mdx
+<CodeGroup>
+```typescript Absolute import
 ---
 title: My title
 description: My Description
 ---
 
-import MySnippet from '/snippets/path/to/my-snippet.mdx';
+import MySnippet from '/snippets/my-snippet.mdx';
 
 ## Header
 
 Lorem impsum dolor sit amet.
 
 <MySnippet word="bananas" />
-
 ```
+
+```typescript Relative import
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from '../snippets/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet word="bananas" />
+```
+</CodeGroup>
 
 ### Reusable variables
 

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -31,23 +31,39 @@ component.
 Hello world! This is my content I want to reuse across pages.
 ```
 
-2. Import the snippet into your destination file.
+2. Import the snippet into your destination file using either an absolute or relative path.
 
-```typescript destination-file.mdx
+<CodeGroup>
+```typescript Absolute import
 ---
 title: My title
 description: My Description
 ---
 
-import MySnippet from '/snippets/path/to/my-snippet.mdx';
+import MySnippet from '/snippets/my-snippet.mdx';
 
 ## Header
 
 Lorem impsum dolor sit amet.
 
 <MySnippet/>
-
 ```
+
+```typescript Relative import
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from '../snippets/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet/>
+```
+</CodeGroup>
 
 ### Exporting with variables
 

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -119,16 +119,29 @@ export const myObject = { fruit: "strawberries" };
 
 2. Import the snippet from your destination file and use the variable:
 
-```typescript destination-file.mdx
+<CodeGroup>
+```typescript Absolute import
 ---
 title: My title
 description: My Description
 ---
 
-import { myName, myObject } from '/snippets/path/to/custom-variables.mdx';
+import { myName, myObject } from '/snippets/custom-variables.mdx';
 
 Hello, my name is {myName} and I like {myObject.fruit}.
 ```
+
+```typescript Relative import
+---
+title: My title
+description: My Description
+---
+
+import { myName, myObject } from '../snippets/custom-variables.mdx';
+
+Hello, my name is {myName} and I like {myObject.fruit}.
+```
+</CodeGroup>
 
 ### JSX snippets
 


### PR DESCRIPTION
Added comprehensive examples showing how to use relative imports for snippets alongside existing absolute import examples. Enhanced documentation with CodeGroup components demonstrating both `../snippets/` and `/snippets/` syntax for all snippet types.

Files changed:
- create/reusable-snippets.mdx

---

Created by Mintlify agent