### PR TITLE
Add relative import examples to snippets documentation

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -134,6 +134,19 @@ import { myName, myObject } from '/snippets/path/to/custom-variables.mdx';
 Hello, my name is {myName} and I like {myObject.fruit}.
 ```
 
+Or with a relative path:
+
+```typescript destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import { myName, myObject } from '../snippets/path/to/custom-variables.mdx';
+
+Hello, my name is {myName} and I like {myObject.fruit}.
+```
+
 ### JSX snippets
 
 1. Export a JSX component from your snippet file. (See [React components](/customize/react-components) for more information):

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -179,3 +179,16 @@ import { MyJSXSnippet } from '/snippets/my-jsx-snippet.jsx';
 
 <MyJSXSnippet />
 ```
+
+Or with a relative path:
+
+```typescript destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import { MyJSXSnippet } from '../snippets/my-jsx-snippet.jsx';
+
+<MyJSXSnippet />
+```

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -31,7 +31,7 @@ component.
 Hello world! This is my content I want to reuse across pages.
 ```
 
-2. Import the snippet into your destination file.
+2. Import the snippet into your destination file using an absolute path.
 
 ```typescript destination-file.mdx
 ---
@@ -40,6 +40,24 @@ description: My Description
 ---
 
 import MySnippet from '/snippets/path/to/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet/>
+
+```
+
+Alternatively, you can use a relative path:
+
+```typescript destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from '../snippets/path/to/my-snippet.mdx';
 
 ## Header
 

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -93,6 +93,24 @@ Lorem impsum dolor sit amet.
 
 ```
 
+You can also use relative imports:
+
+```typescript destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from './snippets/path/to/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet word="bananas" />
+
+```
+
 ### Reusable variables
 
 1. Export a variable from your snippet file:


### PR DESCRIPTION
Updated the reusable snippets documentation to include examples of relative import paths alongside existing absolute path examples. This reflects the new relative imports feature added in PR #5011, showing users they can now use `./` or `../` syntax when importing snippets.

## Files changed
- `create/reusable-snippets.mdx` - Added relative import examples for default exports, variables, and JSX snippets

Generated from [[ENG-4680] - Add relative imports support for snippets](https://github.com/mintlify/mint/pull/5011) @k-finken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds relative import examples and clarifies absolute import usage in `create/reusable-snippets.mdx`.
> 
> - **Documentation**:
>   - Update `create/reusable-snippets.mdx` to illustrate both absolute (`/snippets/...`) and relative (`./`, `../`) imports.
>     - Default export: add relative path example alongside absolute.
>     - Exporting with variables: add relative import example.
>     - JSX snippets: add relative import example.
>   - Clarify instruction text to specify “using an absolute path” where shown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88524d1384eb81aee96e361c27128357428fbc89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->