### PR TITLE
Simplify quickstart page

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,18 +1,15 @@
 ---
 title: "Quickstart"
 description: "Deploy your documentation site and make your first changes."
-keywords: ["quickstart","deploy","get started","first steps"]
 ---
 
-After completing this guide, you will have a live documentation site ready to customize and expand.
-
 <Info>
-  **Prerequisites**: Before you begin, [create an account](https://mintlify.com/start) and complete onboarding.
+  **Prerequisites**: [Create an account](https://mintlify.com/start) and complete onboarding.
 </Info>
 
-## Getting started
+## Deploy your site
 
-After you complete the onboarding process, your documentation site automatically deploys to a unique URL with this format:
+After onboarding, your documentation site deploys automatically to:
 
 ```
 https://<your-project-name>.mintlify.app
@@ -20,295 +17,71 @@ https://<your-project-name>.mintlify.app
 
 Find your URL on the Overview page of your [dashboard](https://dashboard.mintlify.com/).
 
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-domain-light.png"
-    alt="Mintlify Domain"
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/mintlify-domain-dark.png"
-    alt="Mintlify Domain"
-    className="hidden dark:block"
-  />
-</Frame>
-
-Your site's URL is available immediately. Use this URL for testing and sharing with your team while you are setting up your docs site.
-
-### Install the GitHub App
-
-Mintlify provides a GitHub App that automates deployment when you push changes to your repository.
-
-Install the GitHub App by following the instructions from the onboarding checklist or your dashboard.
+## Install the GitHub App
 
 1. Navigate to **Settings** in your Mintlify dashboard.
 2. Select **GitHub App** from the sidebar.
-3. Select **Install GitHub App**. This opens a new tab to the GitHub App installation page.
-4. Select the organization or user account where you want to install the app.
-5. Select the repositories that you want to connect.
+3. Select **Install GitHub App**.
+4. Choose your organization and repositories.
 
-<Frame>
-  <img
-    src="/images/quickstart/github-app-installation-light.png"
-    alt="GitHub App Installation"
-    className="block dark:hidden"
-  />
+## Make your first edit
 
-  <img
-    src="/images/quickstart/github-app-installation-dark.png"
-    alt="GitHub App Installation"
-    className="hidden dark:block"
-  />
-</Frame>
+Choose your preferred workflow:
 
-<Info>
-  Update the GitHub App permissions if you move your documentation to a different repository.
-</Info>
+### Code-based workflow
 
-### Authorize your GitHub account
+1. Install the CLI:
 
-1. Navigate to **Settings** in your Mintlify dashboard.
-2. Select **My Profile** from the sidebar.
-3. Select **Authorize GitHub account**. This opens a new tab to the GitHub authorization page.
-
-<Info>
-  An admin for your GitHub organization may need to authorize your account depending on your organization settings.
-</Info>
-
-## Editing workflows
-
-Mintlify offers two workflows for creating and maintaining your documentation:
-
-<Card title="Code-based workflow" icon="terminal" horizontal href="#code-based-workflow">
-  For users who prefer working with existing tools in their local environment. Click to jump to this section.
-</Card>
-
-<Card title="Web editor workflow" icon="mouse-pointer-2" horizontal href="#web-editor-workflow">
-  For users who prefer a visual interface in their web browser. Click to jump to this section.
-</Card>
-
-## Code-based workflow
-
-The code-based workflow integrates with your existing development environment and Git repositories. This workflow is best for technical teams who want to manage documentation alongside code.
-
-### Install the CLI
-
-<Info>
-  **Prerequisite**: The CLI requires [Node.js](https://nodejs.org/en) v20.17.0 or higher through v24. LTS versions are preferred.
-</Info>
-
-To work locally with your documentation, install the Command Line Interface (CLI), called [mint](https://www.npmjs.com/package/mint), by running this command in your terminal:
-
-<CodeGroup>
-
-```bash npm
+```bash
 npm i -g mint
 ```
 
+2. Create a new project:
 
-```bash pnpm
-pnpm add -g mint
+```bash
+mint new
 ```
 
-</CodeGroup>
+3. Edit `index.mdx` and change the title to "Hello World".
 
-### Create a new project
-
-Run `mint new` to create a new documentation project. See the [CLI installation guide](/installation#create-a-new-project) for details on the command and flags.
-
-### Edit the documentation
-
-After setting up your project, you can start editing your documentation files. For example, update the title of the introduction page:
-
-1. Navigate to your documentation repository.
-2. Open `index.mdx` and locate the top of the file:
-
-```mdx index.mdx
----
-title: "Introduction"
-description: "This is the introduction to the documentation"
----
-```
-
-3. Update the `title` field to `"Hello World"`.
-
-```mdx index.mdx {2}
----
-title: "Hello World"
-description: "This is the introduction to the documentation"
----
-```
-
-### Preview the changes
-
-To preview the changes locally, run the following command:
+4. Preview locally:
 
 ```bash
 mint dev
 ```
 
-Your preview is available at `localhost:3000`.
+5. Push your changes to deploy.
 
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-dev-light.png"
-    alt="Mintlify Dev"
-    className="block dark:hidden"
-  />
+### Web editor workflow
 
-  <img
-    src="/images/quickstart/mintlify-dev-dark.png"
-    alt="Mintlify Dev"
-    className="hidden dark:block"
-  />
-</Frame>
+1. Open the [Editor](https://dashboard.mintlify.com) in your dashboard.
+2. Select `index.mdx` in the file explorer.
+3. Change the title to "Hello World".
+4. Select **Publish** to deploy.
 
-### Push the changes
+## Add a custom domain
 
-When you are ready to publish your changes, push them to your repository.
+Navigate to [Domain Setup](https://dashboard.mintlify.com/settings/deployment/custom-domain) and add your domain (e.g., `docs.yourcompany.com`).
 
-Mintlify automatically detects the changes, builds your documentation, and deploys the updates to your site. Monitor the deployment status in your GitHub repository commit history or the [dashboard](https://dashboard.mintlify.com).
+Configure your DNS with a CNAME record:
 
-After the deployment completes, your latest update will be available at `<your-project-name>.mintlify.app`.
-
-<Card title="Jump to adding a custom domain" icon="arrow-down" horizontal href="#adding-a-custom-domain">
-  Optionally, skip the web editor workflow and jump to adding a custom domain.
-</Card>
-
-## Web editor workflow
-
-The web editor workflow provides a what-you-see-is-what-you-get (WYSIWYG) interface for creating and editing documentation. This workflow is best for people who want to work in their web browser without additional local development tools.
-
-### Access the web editor
-
-1. Log in to your [dashboard](https://dashboard.mintlify.com).
-2. Select **Editor** on the left sidebar.
-
-<Info>
-  If you have not installed the GitHub App, you will be prompted to install the app when you open the web editor.
-</Info>
-
-<Frame>
-  <img
-    alt="The Mintlify web editor in the visual editor mode"
-    src="/images/quickstart/web-editor-light.png"
-    className="block dark:hidden"
-  />
-
-  <img
-    alt="The Mintlify web editor in the visual editor mode"
-    src="/images/quickstart/web-editor-dark.png"
-    className="hidden dark:block"
-  />
-</Frame>
-
-### Edit the documentation
-
-In the web editor, you can navigate through your documentation files in the sidebar. Let's update the introduction page:
-
-Find and select `index.mdx` in the file explorer.
-
-Then, in the editor, update the title field to "Hello World".
-
-<Frame>
-  <img
-    alt="Editing in Web Editor"
-    src="/images/quickstart/web-editor-editing-light.png"
-    className="block dark:hidden"
-  />
-
-  <img
-    alt="Editing in Web Editor"
-    src="/images/quickstart/web-editor-editing-dark.png"
-    className="hidden dark:block"
-  />
-</Frame>
-
-<Tip>
-  The editor provides a rich set of formatting tools and components. Type <kbd>/</kbd>
-
-   in the editor to open the command menu and access these tools.
-</Tip>
-
-### Publish your changes
-
-When you're satisfied with your edits, select the **Publish** button in the top-right corner. Your changes are immediately deployed to your documentation site.
-
-<Tip>
-  Use branches to preview and review changes through pull requests before deploying to your live site.
-</Tip>
-
-For more details about using the web editor, including using branches and pull requests to collaborate and preview changes, see our [web editor documentation](/editor).
-
-## Adding a custom domain
-
-While your `<your-project-name>.mintlify.app` subdomain works well for testing and development, most teams prefer using a custom domain for production documentation.
-
-To add a custom domain, navigate to the [Domain Setup](https://dashboard.mintlify.com/settings/deployment/custom-domain) page in your dashboard.
-
-<Frame>
-  <img
-    src="/images/quickstart/custom-domain-light.png"
-    alt="Custom Domain"
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/custom-domain-dark.png"
-    alt="Custom Domain"
-    className="hidden dark:block"
-  />
-</Frame>
-
-Enter your domain (for example, `docs.yourcompany.com`) and follow the provided instructions to configure DNS settings with your domain provider.
-
-<Table>
-  | Record Type | Name                | Value                | TTL  |
-  | ----------- | ------------------- | -------------------- | ---- |
-  | CNAME       | docs (or subdomain) | cname.vercel-dns.com | 3600 |
-</Table>
-
-<Info>
-  DNS changes can take up to 48 hours to propagate, though changes often complete much sooner.
-</Info>
+| Record Type | Name | Value                | TTL  |
+| ----------- | ---- | -------------------- | ---- |
+| CNAME       | docs | cname.vercel-dns.com | 3600 |
 
 ## Next steps
 
-Congratulations! You have successfully deployed your documentation site with Mintlify. Here are suggested next steps to enhance your documentation:
-
-<Card title="Configure your global settings" icon="settings" horizontal href="organize/settings">
-  Configure site-wide styling, navigation, integrations, and more with the `docs.json` file.
-</Card>
-
-<Card title="Customize your theme" icon="paintbrush" horizontal href="customize/themes">
-  Learn how to customize colors, fonts, and the overall appearance of your documentation site.
-</Card>
-
-<Card title="Organize navigation" icon="map" horizontal href="organize/navigation">
-  Structure your documentation with intuitive navigation to help users find what they need.
-</Card>
-
-<Card title="Add interactive components" icon="puzzle" horizontal href="/components/accordions">
-  Enhance your documentation with interactive components like accordions, tabs, and code samples.
-</Card>
-
-<Card title="Set up API references" icon="code" horizontal href="/api-playground/overview">
-  Create interactive API references with OpenAPI and AsyncAPI specifications.
-</Card>
-
-## Troubleshooting
-
-If you encounter issues during the setup process, check these common troubleshooting solutions:
-
-<AccordionGroup>
-  <Accordion title="Local preview not working">
-    Make sure you have Node.js v20.17.0 or higher installed and that you run the `mint dev` command from the directory containing your `docs.json` file.
-  </Accordion>
-  <Accordion title="Changes not reflecting on live site">
-    Deployment can take up to a few minutes. Check your GitHub Actions (for code-based workflow) or deployment logs in the Mintlify dashboard to ensure there are no build errors.
-  </Accordion>
-  <Accordion title="Custom domain not connecting">
-    Verify that your DNS records are set up correctly and allow sufficient time for DNS propagation (up to 48 hours). You can use tools like [DNSChecker](https://dnschecker.org) to verify your CNAME record.
-  </Accordion>
-</AccordionGroup>
+<CardGroup cols={2}>
+  <Card title="Configure settings" icon="settings" href="organize/settings">
+    Customize your site with `docs.json`
+  </Card>
+  <Card title="Customize theme" icon="paintbrush" href="customize/themes">
+    Update colors and fonts
+  </Card>
+  <Card title="Organize navigation" icon="map" href="organize/navigation">
+    Structure your documentation
+  </Card>
+  <Card title="Add components" icon="puzzle" href="/components/accordions">
+    Use interactive elements
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Streamlined the quickstart guide by removing verbose explanations and consolidating sections. The page now focuses on essential steps to get users up and running quickly.

**Files changed:**
- `quickstart.mdx` - Condensed content from ~400 lines to ~80 lines, removed images, troubleshooting section, and detailed explanations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Condenses `quickstart.mdx` to a streamlined guide focusing on deployment, GitHub App setup, first edits (CLI and web editor), custom domain setup, and concise next steps; removes images and verbose sections.
> 
> - **Quickstart rework (`quickstart.mdx`)**:
>   - **Structure**: Renames and condenses sections to focus on essentials: deploy site, install GitHub App, make first edit (code-based and web editor), add custom domain, next steps.
>   - **Workflows**:
>     - Code-based: minimal steps with `npm i -g mint`, `mint new`, `mint dev`, and push to deploy.
>     - Web editor: simple 4-step edit-and-publish flow.
>   - **Custom domain**: Replaces verbose instructions with a single CNAME record table.
>   - **Next steps**: Adds concise `CardGroup` linking to settings, theme, navigation, and components.
>   - **Removals**: Strips images, frames, tips, accordion-based troubleshooting, and lengthy explanations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8595e97a8c50e86061fc8db7c92ab5ed5814013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->