### PR TITLE
Add relative import examples to snippets documentation

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -79,6 +79,8 @@ My keyword of the day is {word}.
 
 2. Import the snippet into your destination file with the variable. The property will fill in based on your specification.
 
+**Absolute import**:
+
 ```typescript destination-file.mdx
 ---
 title: My title
@@ -86,6 +88,24 @@ description: My Description
 ---
 
 import MySnippet from '/snippets/path/to/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet word="bananas" />
+
+```
+
+**Relative import**:
+
+```typescript docs/destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from '../snippets/path/to/my-snippet.mdx';
 
 ## Header
 

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -175,6 +175,8 @@ export const MyJSXSnippet = () => {
 
 2. Import the snippet from your destination file and use the component:
 
+**Absolute import**:
+
 ```typescript destination-file.mdx
 ---
 title: My title
@@ -182,6 +184,19 @@ description: My Description
 ---
 
 import { MyJSXSnippet } from '/snippets/my-jsx-snippet.jsx';
+
+<MyJSXSnippet />
+```
+
+**Relative import**:
+
+```typescript docs/destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import { MyJSXSnippet } from '../snippets/my-jsx-snippet.jsx';
 
 <MyJSXSnippet />
 ```

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -127,6 +127,8 @@ export const myObject = { fruit: "strawberries" };
 
 2. Import the snippet from your destination file and use the variable:
 
+**Absolute import**:
+
 ```typescript destination-file.mdx
 ---
 title: My title
@@ -134,6 +136,19 @@ description: My Description
 ---
 
 import { myName, myObject } from '/snippets/path/to/custom-variables.mdx';
+
+Hello, my name is {myName} and I like {myObject.fruit}.
+```
+
+**Relative import**:
+
+```typescript docs/destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import { myName, myObject } from '../snippets/path/to/custom-variables.mdx';
 
 Hello, my name is {myName} and I like {myObject.fruit}.
 ```

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -31,7 +31,9 @@ component.
 Hello world! This is my content I want to reuse across pages.
 ```
 
-2. Import the snippet into your destination file.
+2. Import the snippet into your destination file using either absolute or relative paths.
+
+**Absolute import** (from root):
 
 ```typescript destination-file.mdx
 ---
@@ -40,6 +42,24 @@ description: My Description
 ---
 
 import MySnippet from '/snippets/path/to/my-snippet.mdx';
+
+## Header
+
+Lorem impsum dolor sit amet.
+
+<MySnippet/>
+
+```
+
+**Relative import** (from current directory):
+
+```typescript docs/destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import MySnippet from '../snippets/path/to/my-snippet.mdx';
 
 ## Header
 


### PR DESCRIPTION
Updated the reusable snippets documentation to include examples of both absolute and relative import paths. This reflects the new relative imports feature added in PR #5011, showing users they can now use `../snippets/...` syntax in addition to `/snippets/...`.

## Files changed
- `create/reusable-snippets.mdx` - Added relative import examples alongside absolute imports for all snippet types (default export, variables, reusable variables, and JSX snippets)

Generated from [[ENG-4680] - Add relative imports support for snippets](https://github.com/mintlify/mint/pull/5011) @k-finken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds relative import examples alongside absolute imports across snippet docs and clarifies supported import paths.
> 
> - **Docs** (`create/reusable-snippets.mdx`):
>   - Add relative import examples alongside absolute imports for `default export`, `exporting with variables`, `reusable variables`, and `JSX snippets`.
>   - Introduce a Tip noting support for absolute (`/snippets/...`) and relative (`./`, `../`) imports.
>   - Clarify import step text to mention absolute or relative paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2550d71ec065734efa3badf150492c306face87b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->