### PR TITLE
Shorten quickstart page

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -4,311 +4,73 @@ description: "Deploy your documentation site and make your first changes."
 keywords: ["quickstart","deploy","get started","first steps"]
 ---
 
-After completing this guide, you will have a live documentation site ready to customize and expand.
-
 <Info>
-  **Prerequisites**: Before you begin, [create an account](https://mintlify.com/start) and complete onboarding.
+  **Prerequisites**: [Create an account](https://mintlify.com/start) and complete onboarding.
 </Info>
 
-## Getting started
+## Your documentation URL
 
-After you complete the onboarding process, your documentation site automatically deploys to a unique URL with this format:
+After onboarding, your site deploys to `https://<your-project-name>.mintlify.app`. Find your URL on the [dashboard](https://dashboard.mintlify.com/) Overview page.
 
-```
-https://<your-project-name>.mintlify.app
-```
+## Connect GitHub
 
-Find your URL on the Overview page of your [dashboard](https://dashboard.mintlify.com/).
+Install the GitHub App to automate deployments:
 
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-domain-light.png"
-    alt="Mintlify Domain"
-    className="block dark:hidden"
-  />
+1. Go to **Settings** > **GitHub App** in your dashboard.
+2. Select **Install GitHub App** and choose your organization and repositories.
 
-  <img
-    src="/images/quickstart/mintlify-domain-dark.png"
-    alt="Mintlify Domain"
-    className="hidden dark:block"
-  />
-</Frame>
+Authorize your account under **Settings** > **My Profile** > **Authorize GitHub account**.
 
-Your site's URL is available immediately. Use this URL for testing and sharing with your team while you are setting up your docs site.
+## Edit your docs
 
-### Install the GitHub App
+Choose your preferred workflow:
 
-Mintlify provides a GitHub App that automates deployment when you push changes to your repository.
+<Tabs>
+  <Tab title="Code-based">
+    Install the CLI ([Node.js](https://nodejs.org/en) v20.17.0+ required):
 
-Install the GitHub App by following the instructions from the onboarding checklist or your dashboard.
+    ```bash
+    npm i -g mint
+    ```
 
-1. Navigate to **Settings** in your Mintlify dashboard.
-2. Select **GitHub App** from the sidebar.
-3. Select **Install GitHub App**. This opens a new tab to the GitHub App installation page.
-4. Select the organization or user account where you want to install the app.
-5. Select the repositories that you want to connect.
+    Create a project with `mint new`, then preview locally:
 
-<Frame>
-  <img
-    src="/images/quickstart/github-app-installation-light.png"
-    alt="GitHub App Installation"
-    className="block dark:hidden"
-  />
+    ```bash
+    mint dev
+    ```
 
-  <img
-    src="/images/quickstart/github-app-installation-dark.png"
-    alt="GitHub App Installation"
-    className="hidden dark:block"
-  />
-</Frame>
+    Push changes to your repository to deploy automatically.
+  </Tab>
+  <Tab title="Web editor">
+    1. Go to **Editor** in your [dashboard](https://dashboard.mintlify.com).
+    2. Select a file and make your edits.
+    3. Select **Publish** to deploy.
 
-<Info>
-  Update the GitHub App permissions if you move your documentation to a different repository.
-</Info>
+    Type <kbd>/</kbd> in the editor to access formatting tools and components.
+  </Tab>
+</Tabs>
 
-### Authorize your GitHub account
+## Add a custom domain
 
-1. Navigate to **Settings** in your Mintlify dashboard.
-2. Select **My Profile** from the sidebar.
-3. Select **Authorize GitHub account**. This opens a new tab to the GitHub authorization page.
+Navigate to [Domain Setup](https://dashboard.mintlify.com/settings/deployment/custom-domain) and add a CNAME record:
 
-<Info>
-  An admin for your GitHub organization may need to authorize your account depending on your organization settings.
-</Info>
-
-## Editing workflows
-
-Mintlify offers two workflows for creating and maintaining your documentation:
-
-<Card title="Code-based workflow" icon="terminal" horizontal href="#code-based-workflow">
-  For users who prefer working with existing tools in their local environment. Click to jump to this section.
-</Card>
-
-<Card title="Web editor workflow" icon="mouse-pointer-2" horizontal href="#web-editor-workflow">
-  For users who prefer a visual interface in their web browser. Click to jump to this section.
-</Card>
-
-## Code-based workflow
-
-The code-based workflow integrates with your existing development environment and Git repositories. This workflow is best for technical teams who want to manage documentation alongside code.
-
-### Install the CLI
-
-<Info>
-  **Prerequisite**: The CLI requires [Node.js](https://nodejs.org/en) v20.17.0 or higher through v24. LTS versions are preferred.
-</Info>
-
-To work locally with your documentation, install the Command Line Interface (CLI), called [mint](https://www.npmjs.com/package/mint), by running this command in your terminal:
-
-<CodeGroup>
-
-```bash npm
-npm i -g mint
-```
-
-
-```bash pnpm
-pnpm add -g mint
-```
-
-</CodeGroup>
-
-### Create a new project
-
-Run `mint new` to create a new documentation project. See the [CLI installation guide](/installation#create-a-new-project) for details on the command and flags.
-
-### Edit the documentation
-
-After setting up your project, you can start editing your documentation files. For example, update the title of the introduction page:
-
-1. Navigate to your documentation repository.
-2. Open `index.mdx` and locate the top of the file:
-
-```mdx index.mdx
----
-title: "Introduction"
-description: "This is the introduction to the documentation"
----
-```
-
-3. Update the `title` field to `"Hello World"`.
-
-```mdx index.mdx {2}
----
-title: "Hello World"
-description: "This is the introduction to the documentation"
----
-```
-
-### Preview the changes
-
-To preview the changes locally, run the following command:
-
-```bash
-mint dev
-```
-
-Your preview is available at `localhost:3000`.
-
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-dev-light.png"
-    alt="Mintlify Dev"
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/mintlify-dev-dark.png"
-    alt="Mintlify Dev"
-    className="hidden dark:block"
-  />
-</Frame>
-
-### Push the changes
-
-When you are ready to publish your changes, push them to your repository.
-
-Mintlify automatically detects the changes, builds your documentation, and deploys the updates to your site. Monitor the deployment status in your GitHub repository commit history or the [dashboard](https://dashboard.mintlify.com).
-
-After the deployment completes, your latest update will be available at `<your-project-name>.mintlify.app`.
-
-<Card title="Jump to adding a custom domain" icon="arrow-down" horizontal href="#adding-a-custom-domain">
-  Optionally, skip the web editor workflow and jump to adding a custom domain.
-</Card>
-
-## Web editor workflow
-
-The web editor workflow provides a what-you-see-is-what-you-get (WYSIWYG) interface for creating and editing documentation. This workflow is best for people who want to work in their web browser without additional local development tools.
-
-### Access the web editor
-
-1. Log in to your [dashboard](https://dashboard.mintlify.com).
-2. Select **Editor** on the left sidebar.
-
-<Info>
-  If you have not installed the GitHub App, you will be prompted to install the app when you open the web editor.
-</Info>
-
-<Frame>
-  <img
-    alt="The Mintlify web editor in the visual editor mode"
-    src="/images/quickstart/web-editor-light.png"
-    className="block dark:hidden"
-  />
-
-  <img
-    alt="The Mintlify web editor in the visual editor mode"
-    src="/images/quickstart/web-editor-dark.png"
-    className="hidden dark:block"
-  />
-</Frame>
-
-### Edit the documentation
-
-In the web editor, you can navigate through your documentation files in the sidebar. Let's update the introduction page:
-
-Find and select `index.mdx` in the file explorer.
-
-Then, in the editor, update the title field to "Hello World".
-
-<Frame>
-  <img
-    alt="Editing in Web Editor"
-    src="/images/quickstart/web-editor-editing-light.png"
-    className="block dark:hidden"
-  />
-
-  <img
-    alt="Editing in Web Editor"
-    src="/images/quickstart/web-editor-editing-dark.png"
-    className="hidden dark:block"
-  />
-</Frame>
-
-<Tip>
-  The editor provides a rich set of formatting tools and components. Type <kbd>/</kbd>
-
-   in the editor to open the command menu and access these tools.
-</Tip>
-
-### Publish your changes
-
-When you're satisfied with your edits, select the **Publish** button in the top-right corner. Your changes are immediately deployed to your documentation site.
-
-<Tip>
-  Use branches to preview and review changes through pull requests before deploying to your live site.
-</Tip>
-
-For more details about using the web editor, including using branches and pull requests to collaborate and preview changes, see our [web editor documentation](/editor).
-
-## Adding a custom domain
-
-While your `<your-project-name>.mintlify.app` subdomain works well for testing and development, most teams prefer using a custom domain for production documentation.
-
-To add a custom domain, navigate to the [Domain Setup](https://dashboard.mintlify.com/settings/deployment/custom-domain) page in your dashboard.
-
-<Frame>
-  <img
-    src="/images/quickstart/custom-domain-light.png"
-    alt="Custom Domain"
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/custom-domain-dark.png"
-    alt="Custom Domain"
-    className="hidden dark:block"
-  />
-</Frame>
-
-Enter your domain (for example, `docs.yourcompany.com`) and follow the provided instructions to configure DNS settings with your domain provider.
-
-<Table>
-  | Record Type | Name                | Value                | TTL  |
-  | ----------- | ------------------- | -------------------- | ---- |
-  | CNAME       | docs (or subdomain) | cname.vercel-dns.com | 3600 |
-</Table>
-
-<Info>
-  DNS changes can take up to 48 hours to propagate, though changes often complete much sooner.
-</Info>
+| Record Type | Name                | Value                | TTL  |
+| ----------- | ------------------- | -------------------- | ---- |
+| CNAME       | docs (or subdomain) | cname.vercel-dns.com | 3600 |
 
 ## Next steps
 
-Congratulations! You have successfully deployed your documentation site with Mintlify. Here are suggested next steps to enhance your documentation:
-
-<Card title="Configure your global settings" icon="settings" horizontal href="organize/settings">
-  Configure site-wide styling, navigation, integrations, and more with the `docs.json` file.
-</Card>
-
-<Card title="Customize your theme" icon="paintbrush" horizontal href="customize/themes">
-  Learn how to customize colors, fonts, and the overall appearance of your documentation site.
-</Card>
-
-<Card title="Organize navigation" icon="map" horizontal href="organize/navigation">
-  Structure your documentation with intuitive navigation to help users find what they need.
-</Card>
-
-<Card title="Add interactive components" icon="puzzle" horizontal href="/components/accordions">
-  Enhance your documentation with interactive components like accordions, tabs, and code samples.
-</Card>
-
-<Card title="Set up API references" icon="code" horizontal href="/api-playground/overview">
-  Create interactive API references with OpenAPI and AsyncAPI specifications.
-</Card>
-
-## Troubleshooting
-
-If you encounter issues during the setup process, check these common troubleshooting solutions:
-
-<AccordionGroup>
-  <Accordion title="Local preview not working">
-    Make sure you have Node.js v20.17.0 or higher installed and that you run the `mint dev` command from the directory containing your `docs.json` file.
-  </Accordion>
-  <Accordion title="Changes not reflecting on live site">
-    Deployment can take up to a few minutes. Check your GitHub Actions (for code-based workflow) or deployment logs in the Mintlify dashboard to ensure there are no build errors.
-  </Accordion>
-  <Accordion title="Custom domain not connecting">
-    Verify that your DNS records are set up correctly and allow sufficient time for DNS propagation (up to 48 hours). You can use tools like [DNSChecker](https://dnschecker.org) to verify your CNAME record.
-  </Accordion>
-</AccordionGroup>
+<CardGroup cols={2}>
+  <Card title="Configure settings" icon="settings" href="organize/settings">
+    Set up styling, navigation, and integrations.
+  </Card>
+  <Card title="Customize theme" icon="paintbrush" href="customize/themes">
+    Customize colors, fonts, and appearance.
+  </Card>
+  <Card title="Organize navigation" icon="map" href="organize/navigation">
+    Structure your documentation.
+  </Card>
+  <Card title="Set up API references" icon="code" href="/api-playground/overview">
+    Create interactive API documentation.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Condensed the quickstart page from ~280 lines to ~70 lines by consolidating workflow sections, removing redundant content, and simplifying instructions. This makes the page more concise and easier to follow for new users.

Files changed:
- quickstart.mdx

---

Created by Mintlify agent