### PR TITLE
Document custom Slack bot avatar feature

### DIFF
--- a/ai/slack-bot.mdx
+++ b/ai/slack-bot.mdx
@@ -36,6 +36,21 @@ Each message sent by the bot counts toward your assistant message usage.
 1. Click **Configuration**. This opens the app configuration page in a web browser.
 1. In the **Bot User** section, edit the bot name.
 
+### Customize the bot's profile picture
+
+You can upload a custom avatar for your Slack bot through the Mintlify dashboard.
+
+1. Navigate to the [Integrations](https://dashboard.mintlify.com/products/assistant/settings/integrations) tab of the **Assistant Configurations** page in your dashboard.
+1. In the Slack card, click **Configure**.
+1. Click **Upload** to select an image from your computer, or click **Change** to replace an existing avatar.
+1. Click **Save changes** to apply the new avatar.
+
+#### Image requirements
+
+- **Format**: PNG or JPEG
+- **Dimensions**: Minimum 256x256 pixels, maximum 2048x2048 pixels
+- **File size**: Under 8MB
+
 ## Create an `#ask-ai` channel
 
 To help your users quickly get answers to their questions, create a channel named `#ask-ai`. The bot will respond to every message in that channel. See [Create a channel](https://slack.com/help/articles/201402297-Create-a-channel) in the Slack Help Center for more information.


### PR DESCRIPTION
Added documentation for the new custom avatar feature for Slack bots. Users can now upload custom profile pictures through the Mintlify dashboard with specific image requirements (PNG/JPEG, 256-2048px, under 8MB).

## Files changed
- `ai/slack-bot.mdx` - Added new section "Customize the bot's profile picture" with upload instructions and image requirements

Generated from [Custom pfp on slack assistant](https://github.com/mintlify/mint/pull/5059) @paaatrrrick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds instructions to upload a custom Slack bot avatar via the dashboard, including image requirements.
> 
> - **Docs (`ai/slack-bot.mdx`)**:
>   - **New section**: `Customize the bot's profile picture` with step-by-step upload instructions via the dashboard.
>   - **Image requirements**: Specifies allowed formats (PNG/JPEG), dimensions (256–2048 px), and file size (<8MB).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2df0795608b9b2706ba75c05f0473e3866d20ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->