### PR TITLE
Add relative import examples to snippets documentation

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -175,6 +175,8 @@ export const MyJSXSnippet = () => {
 
 2. Import the snippet from your destination file and use the component:
 
+**Absolute import**:
+
 ```typescript destination-file.mdx
 ---
 title: My title
@@ -182,6 +184,19 @@ description: My Description
 ---
 
 import { MyJSXSnippet } from '/snippets/my-jsx-snippet.jsx';
+
+<MyJSXSnippet />
+```
+
+**Relative import**:
+
+```typescript docs/destination-file.mdx
+---
+title: My title
+description: My Description
+---
+
+import { MyJSXSnippet } from '../snippets/my-jsx-snippet.jsx';
 
 <MyJSXSnippet />
 ```


### PR DESCRIPTION
Updated the reusable snippets documentation to include examples of both absolute and relative import paths. This reflects the new relative imports feature added in PR #5011, showing users they can now use `../snippets/...` syntax in addition to `/snippets/...`.

## Files changed
- `create/reusable-snippets.mdx` - Added relative import examples alongside absolute imports for default exports, variables, reusable variables, and JSX snippets

Generated from [[ENG-4680] - Add relative imports support for snippets](https://github.com/mintlify/mint/pull/5011) @k-finken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds relative import examples and guidance alongside existing absolute imports in `create/reusable-snippets.mdx` across default exports, props, variables, and JSX snippets.
> 
> - **Documentation**
>   - Update `create/reusable-snippets.mdx` to include relative import examples (`../snippets/...`) alongside absolute imports (`/snippets/...`).
>     - Default export usage.
>     - Exporting with variables (props).
>     - Reusable exported variables.
>     - JSX snippet components.
>   - Add a tip clarifying support for both absolute and relative imports.
>   - Clarify step text to mention using absolute or relative paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1419a6d0c1e737af9127a303a3911595bb51c29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->