### PR TITLE
Document file and folder duplication feature

### DIFF
--- a/editor.mdx
+++ b/editor.mdx
@@ -186,6 +186,17 @@ To delete a page, click the kebab menu icon for the file you want to delete. Sel
   />
 </Frame>
 
+### Duplicate files and folders
+
+To duplicate a file or folder, click the kebab menu icon for the item you want to duplicate. Select **Duplicate** from the dropdown menu.
+
+When you duplicate a file or folder:
+
+- **Files**: The duplicated file is created with a `-copied-N` suffix (for example, `quickstart-copied-1.mdx`). The number increments if you duplicate the same file multiple times.
+- **Folders**: The duplication behavior depends on the folder structure:
+  - If all files in the folder share a common folder path, the entire folder structure is preserved and duplicated with the `-copied-N` suffix.
+  - If files don't share a common folder, each file is duplicated individually with the `-copied-N` suffix.
+
 ### Organize your navigation
 
 Edit your `docs.json` file to add new pages and remove deleted pages from your site navigation. See [Navigation](/organize/navigation) for more information on how to organize pages.


### PR DESCRIPTION
Added documentation for the new duplicate functionality in the visual editor. This explains how users can duplicate files and folders, including the naming convention and folder structure behavior.

## Files changed
- `editor.mdx` - Added "Duplicate files and folders" section explaining the duplication feature

Generated from [feat: implement duplication logic for file tree](https://github.com/mintlify/mint/pull/5070) @ricardonunez-io