### PR TITLE
Pull request for mintlify/sync-mintlify-mint-repo-discrepancies-32754

### DIFF
--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -948,17 +948,6 @@ This section contains the full reference for the `docs.json` file.
         </ResponseField>
       </Expandable>
     </ResponseField>
-    <ResponseField name="koala" type="object">
-      Koala integration.
-
-      <Expandable title="Koala">
-        <ResponseField name="publicApiKey" type="string" required>
-          Your Koala public API key.
-
-          Minimum length: 2
-        </ResponseField>
-      </Expandable>
-    </ResponseField>
     <ResponseField name="logrocket" type="object">
       LogRocket integration.
 


### PR DESCRIPTION
The mintlify agent's changes for pull request mintlify/sync-mintlify-mint-repo-discrepancies-32754

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Contextual menu:** `options` now supports custom option objects with `title`, `description`, `icon`, and `href` (with `$page`, `$path`, `$mcp` placeholders).
> - **Integrations:** Added `clarity.projectId` and `hightouch` (`writeKey`, optional `apiHost`); removed PostHog `sessionRecording` field.
> - **Banner:** `content` is now required and limited to basic MDX; `dismissible` clarified as showing a right-side dismiss button.
> - **Appearance:** `strict` default updated to `false` (hide light/dark toggle when true).
> - **Errors (404):** `redirect` docs now note default `true`; `description` formatting clarified to basic MDX.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c49db4ddb4b02e34e185d52b2e18b713f54a914. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->