### PR TITLE
feat: add yellow color for the Badge component

### DIFF
--- a/components/badge.mdx
+++ b/components/badge.mdx
@@ -23,6 +23,7 @@ Badges support multiple color variants to convey different meanings.
 <Badge color="gray">Badge</Badge>
 <Badge color="blue">Badge</Badge>
 <Badge color="green">Badge</Badge>
+<Badge color="yellow">Badge</Badge>
 <Badge color="orange">Badge</Badge>
 <Badge color="red">Badge</Badge>
 <Badge color="purple">Badge</Badge>
@@ -35,6 +36,7 @@ Badges support multiple color variants to convey different meanings.
 <Badge color="gray">Badge</Badge>
 <Badge color="blue">Badge</Badge>
 <Badge color="green">Badge</Badge>
+<Badge color="yellow">Badge</Badge>
 <Badge color="orange">Badge</Badge>
 <Badge color="red">Badge</Badge>
 <Badge color="purple">Badge</Badge>
@@ -141,7 +143,7 @@ Combine multiple properties for custom badge styles.
 <ResponseField name="color" type="string" default="gray">
   Badge color variant.
   
-  Options: `gray`, `blue`, `green`, `orange`, `red`,
+  Options: `gray`, `blue`, `green`, `yellow`, `orange`, `red`,
   `purple`, `white`, `surface`, `white-destructive`, `surface-destructive`.
 </ResponseField>
 


### PR DESCRIPTION
## Documentation changes

added `yellow` color for the `Badge` component

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Document the new `yellow` color variant for `Badge` in examples and props.
> 
> - **Docs**:
>   - Update `components/badge.mdx` to include `yellow` in color examples and in the `color` property options list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c070abb9132c70ca39fed46b9a663593d075961. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->