### PR TITLE
Document assistant dashboard filtering by resolution status

### DIFF
--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -238,6 +238,16 @@ You can explore queries from your [dashboard](https://dashboard.mintlify.com/pro
 ## Assistant insights
 Use assistant insights to understand how users interact with your documentation through two views: categories and chat history.
 
+### Filter by resolution status
+
+Filter assistant queries by resolution status to focus on specific types of interactions. Use the filter buttons above the bar chart to switch between:
+
+- **All responses**: View all assistant queries regardless of outcome.
+- **Answered properly**: View only queries where the assistant successfully answered the user's question.
+- **Not answered**: View only queries where the assistant could not provide an answer.
+
+The resolution status filter applies across the bar chart, chat history, and top questions views, allowing you to analyze patterns in answered versus unanswered queries.
+
 ### Categories
 
 The categories tab uses LLMs to automatically categorize conversations. Categories show a summary of the topic or theme, when a question was last asked about the category, and how many questions have been asked about the category over time.


### PR DESCRIPTION
Added documentation for the new resolution status filter in the assistant dashboard. This filter allows users to view all responses, only answered queries, or only unanswered queries across the bar chart, chat history, and top questions views.

Files changed:
- ai/assistant.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents the new resolution status filter in Assistant insights, including All/Answered properly/Not answered, applied across bar chart, chat history, and top questions.
> 
> - **Docs**: Update `ai/assistant.mdx` to add "Filter by resolution status" section under Assistant insights, detailing `All responses`, `Answered properly`, and `Not answered`, and noting the filter applies across the bar chart, chat history, and top questions views.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c88e5181064b987f5763ac6df83d8df1446091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->