### PR TITLE
Document notification settings for agent suggestions

### DIFF
--- a/ai/suggestions.mdx
+++ b/ai/suggestions.mdx
@@ -81,3 +81,28 @@ If a suggestion doesn't require documentation updates or you've already addresse
 1. Click the **Dismiss** button next any suggestions that you want to dismiss.
 
 The suggestion is immediately removed from your dashboard. You cannot retrieve dismissed suggestions.
+
+## Configure notifications
+
+Receive notifications when the agent creates new suggestions. You can configure email and Slack notifications independently based on your preferences.
+
+### Notification frequency
+
+Both email and Slack notifications support a **per-merge** frequency setting. When enabled, you receive a notification immediately after the agent creates a suggestion from a merged pull request in your monitored repositories.
+
+### Configure email notifications
+
+1. Click the **Ask agent** button in your dashboard to open the agent panel.
+1. Click the **Settings** button.
+1. In the notification settings, set your email digest frequency to **per-merge** to receive email notifications for new suggestions.
+
+### Configure Slack notifications
+
+To receive Slack notifications, you must first connect your Slack workspace to Mintlify.
+
+1. Click the **Ask agent** button in your dashboard to open the agent panel.
+1. Click the **Settings** button.
+1. Connect your Slack account if you haven't already.
+1. Set your Slack digest frequency to **per-merge** to receive Slack notifications for new suggestions.
+
+When a new suggestion is created, you receive a direct message in Slack with details about the pull request and proposed documentation updates.


### PR DESCRIPTION
Added documentation for email and Slack notifications that users receive when new agent suggestions are created. Includes configuration instructions for the per-merge frequency setting that triggers immediate notifications.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents configuring per-merge email and Slack notifications for new agent suggestions.
> 
> - **Docs** (`ai/suggestions.mdx`):
>   - **New section: `Configure notifications`**
>     - Explains notification frequency with **per-merge** option.
>     - Adds steps to configure **email** notifications.
>     - Adds steps to configure **Slack** notifications, including workspace connection requirement and DM details on new suggestions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3fcdbbeedd8145d600e4522772b9e0059d9f455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->