### PR TITLE
Document notification settings for agent suggestions

### DIFF
--- a/ai/suggestions.mdx
+++ b/ai/suggestions.mdx
@@ -81,3 +81,27 @@ If a suggestion doesn't require documentation updates or you've already addresse
 1. Click the **Dismiss** button next any suggestions that you want to dismiss.
 
 The suggestion is immediately removed from your dashboard. You cannot retrieve dismissed suggestions.
+
+## Notifications
+
+Receive notifications when the agent creates new suggestions. You can configure email and Slack notifications to stay informed about documentation updates without checking the dashboard.
+
+### Configure notification preferences
+
+Configure your notification preferences in the agent settings.
+
+1. Click the **Ask agent** button in your dashboard to open the agent panel.
+1. Click the **Settings** button.
+1. In the notification settings, select your preferred frequency for email and Slack notifications.
+
+Set the frequency to **per-merge** to receive a notification each time the agent creates a suggestion from a merged pull request. This ensures you're immediately notified when new documentation updates are needed.
+
+### Email notifications
+
+When email notifications are enabled with the per-merge frequency, you receive an email each time the agent creates a suggestion. The email includes the suggestion title, the pull request that triggered it, and a link to review the suggested changes in your dashboard.
+
+### Slack notifications
+
+When Slack notifications are enabled with the per-merge frequency, you receive a Slack message each time the agent creates a suggestion. To receive Slack notifications, you must connect your Slack account to Mintlify.
+
+The Slack notification includes the suggestion details and a link to your dashboard where you can review and act on the suggestion.


### PR DESCRIPTION
Added comprehensive documentation for email and Slack notification settings for agent suggestions. Users can now understand how to configure notification preferences and the "per-merge" frequency setting for both notification types.

Files changed:
- ai/suggestions.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents email and Slack notifications (including per-merge frequency) for agent suggestions in `ai/suggestions.mdx`.
> 
> - **Docs**:
>   - **Notifications for agent suggestions** in `ai/suggestions.mdx`:
>     - Add configuration instructions for email and Slack notifications, including choosing per-merge frequency.
>     - Describe email content and Slack requirements (connect account) with links to review suggestions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a367e0383bfdece2872415d2c1422597fc6aaaa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->