### PR TITLE
Document branch deletion feature in web editor

### DIFF
--- a/guides/branches.mdx
+++ b/guides/branches.mdx
@@ -123,3 +123,31 @@ Use clear, descriptive names that explain the purpose of a branch.
 ## Merge branches
 
 Once your changes are ready to publish, create a pull request to merge your branch into the deployment branch.
+
+## Delete a branch
+
+After merging a branch, you can delete it to keep your repository organized.
+
+<Tabs>
+  <Tab title="Using web editor">
+    After your pull request is merged, the web editor displays a notification that the branch has been merged. Click **Delete branch** to remove the branch from your repository.
+
+    <Note>
+      You cannot delete the deploy branch or the repository's default branch (usually `main`).
+    </Note>
+  </Tab>
+
+  <Tab title="Using local development">
+    Delete a branch locally and remotely:
+
+    ```bash
+    # Delete the local branch
+    git branch -d branch-name
+
+    # Delete the remote branch
+    git push origin --delete branch-name
+    ```
+
+    Use `-D` instead of `-d` to force delete a branch that hasn't been merged.
+  </Tab>
+</Tabs>


### PR DESCRIPTION
Added documentation for the new branch deletion feature in the web editor. Users can now delete branches after merging PRs, with restrictions preventing deletion of deploy and default branches.

Files changed:
- guides/branches.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new "Delete a branch" section with web editor and CLI instructions, including restrictions on deleting deploy/default branches.
> 
> - **Docs — `guides/branches.mdx`**:
>   - **New section: _Delete a branch_**
>     - **Web editor**: Post-merge UI shows option to click `Delete branch`; includes note that deploy and default (e.g., `main`) branches cannot be deleted.
>     - **Local development**: Commands to delete local (`git branch -d/-D branch-name`) and remote (`git push origin --delete branch-name`) branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a4c78a28f121ff0568ab97db5293f30cb57523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->