### PR TITLE
Document context parameter for assistant API

### DIFF
--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -33,6 +33,13 @@ function MyComponent({ domain }) {
     body: {
       fp: 'anonymous',
       retrievalPageSize: 5,
+      context: [
+        {
+          type: 'code',
+          value: 'const example = "code snippet";',
+          elementId: 'code-block-1',
+        },
+      ],
     },
     streamProtocol: 'data',
     sendExtraMessageFields: true,
@@ -60,6 +67,12 @@ function MyComponent({ domain }) {
 - `sendExtraMessageFields: true` - Required to send message metadata.
 - `body.fp` - Fingerprint identifier (use 'anonymous' or a user identifier).
 - `body.retrievalPageSize` - Number of search results to use (recommended: 5).
+
+**Optional configuration:**
+- `body.context` - Array of contextual information to provide to the assistant. Each context object contains:
+  - `type` - Either `'code'` or `'textSelection'`.
+  - `value` - The code snippet or selected text content.
+  - `elementId` (optional) - Identifier for the UI element containing the context.
 
 </Step>
 </Steps>


### PR DESCRIPTION
Added documentation for the new optional `context` parameter in the assistant message API. This parameter allows passing code snippets or text selections to provide additional context to the assistant.

## Files changed
- `api/assistant/create-assistant-message.mdx` - Added example usage and documentation for the `context` parameter

Generated from [feat: add context payloads to assistant messages](https://github.com/mintlify/server/pull/2788) @dks333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs and example for an optional `context` payload (code/text selections) in the assistant message API `useChat` integration.
> 
> - **Docs (`api/assistant/create-assistant-message.mdx`)**:
>   - **Example update**: Adds `body.context` to `useChat` configuration with a code snippet example (`type`, `value`, `elementId`).
>   - **New section – Optional configuration**: Documents `body.context` structure and supported types (`code`, `textSelection`) and optional `elementId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 070119fce5d4a2b9e9ec53bac224eea5554adc91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->