### PR TITLE
Add Slack bot and Discord bot to changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,19 @@ rss: true
 noindex: true
 ---
 
+<Update label="December 18, 2025" tags={["New releases"]} rss={{ title: "Slack bot and Discord bot" }}>
+  ## Slack bot and Discord bot
+
+  Add AI-powered bots to your [Slack workspace](/ai/slack-bot) and [Discord server](/ai/discord) that answer questions based on your documentation. The bots use the Mintlify assistant to provide accurate, cited responses in real-time.
+
+  Key features:
+  - Responds to `@` mentions and all messages in `#ask-ai` channels
+  - Customizable bot name and profile picture
+  - Always up-to-date with your latest documentation
+
+  Available on Pro and Custom plans with assistant access.
+</Update>
+
 <Update label="December 12, 2025" tags={["New releases", "Improvements"]} rss={{  title: "Agent suggestions and Q&A bots" }}>
   ## Agent suggestions
   


### PR DESCRIPTION
Added a new changelog entry for December 18, 2025 featuring the Slack bot and Discord bot integration. This entry includes documentation links, key features, and availability information for both AI-powered bots.

Files changed:
- changelog.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Dec 18, 2025 changelog entry announcing AI-powered Slack and Discord bots with links, key features, and plan availability.
> 
> - **Changelog**:
>   - Add `Update` for "December 18, 2025" in `changelog.mdx` announcing AI-powered Slack and Discord bots, including docs links, key features (responds to mentions/`#ask-ai`, customizable name/avatar, auto-updated from docs), and availability (Pro/Custom with assistant).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3bb90e4a5dbee19d3adeb6b46bec7d8b6420ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->