### PR TITLE
Document partial wildcard redirect support

### DIFF
--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -32,6 +32,34 @@ To match a wildcard path, use `*` after a parameter. In this example, `/beta/:sl
 ]
 ```
 
+### Partial wildcard patterns
+
+Use partial wildcards to match URL segments that start with a specific prefix. Add `*` at the end of a prefix to capture the remaining portion of that segment.
+
+```json
+"redirects": [
+  {
+    "source": "/en/articles/9140627-*",
+    "destination": "/collections/overview"
+  }
+]
+```
+
+This redirects any path like `/en/articles/9140627-how-to-create-collections` or `/en/articles/9140627-getting-started` to `/collections/overview`.
+
+To preserve the captured portion in the destination, use the same partial wildcard pattern:
+
+```json
+"redirects": [
+  {
+    "source": "/old/article-*",
+    "destination": "/new/article-*"
+  }
+]
+```
+
+This redirects `/old/article-123` to `/new/article-123`, substituting the captured value (`123`) into the destination.
+
 ## Broken links
 
 Catch broken links with our CLI. [Install the CLI](/installation) and run the command:


### PR DESCRIPTION
Added documentation for the new partial wildcard redirect feature that allows matching URL segments with specific prefixes. Updated the redirects documentation to include examples of prefix-* patterns and how to use captured portions in destinations.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs for partial wildcard redirect patterns, including prefix-* matching and capturing for use in destinations.
> 
> - **Docs**:
>   - **Redirects guide** (`create/redirects.mdx`):
>     - Add section on partial wildcard patterns (`prefix-*`).
>     - Examples for redirecting to a fixed destination and for preserving the captured segment in the destination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fed33bf2a5fcdc5ac1a6c887c884bc251859c561. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->