### PR TITLE
Document partial wildcard redirect support

### DIFF
--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -21,6 +21,8 @@ Set up 301 redirects by adding the `redirects` field to your `docs.json` file.
 
 This permanently redirects `/source/path` to `/destination/path` so that you don't lose any previous SEO for the original page.
 
+### Wildcard paths
+
 To match a wildcard path, use `*` after a parameter. In this example, `/beta/:slug*` matches `/beta/introduction` and redirects it to `/v2/introduction`.
 
 ```json
@@ -31,6 +33,36 @@ To match a wildcard path, use `*` after a parameter. In this example, `/beta/:sl
   }
 ]
 ```
+
+### Partial wildcard patterns
+
+Use partial wildcards to match URL segments that start with a specific prefix. Add `*` at the end of a prefix to match any content that follows.
+
+For example, `/en/articles/9140627-*` matches any path where the segment starts with `9140627-`:
+
+```json
+"redirects": [
+  {
+    "source": "/en/articles/9140627-*",
+    "destination": "/collections/overview"
+  }
+]
+```
+
+This redirects paths like `/en/articles/9140627-how-do-i-create-collections` and `/en/articles/9140627-what-is-a-collection` to `/collections/overview`.
+
+You can also substitute the captured portion in the destination by using the same partial wildcard pattern:
+
+```json
+"redirects": [
+  {
+    "source": "/old/article-*",
+    "destination": "/new/article-*"
+  }
+]
+```
+
+This redirects `/old/article-123` to `/new/article-123`, preserving the `123` portion after the prefix.
 
 ## Broken links
 


### PR DESCRIPTION
Added documentation for the new partial wildcard redirect feature that allows matching URL segments with specific prefixes. This enables more flexible redirect patterns like `/en/articles/9140627-*` where only the portion after the prefix is captured and can be substituted in the destination URL.

Files changed:
- create/redirects.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds docs for partial wildcard redirects, including prefix-matching and captured-segment substitution examples.
> 
> - **Docs (`create/redirects.mdx`)**:
>   - Add section on **partial wildcard patterns** for redirects:
>     - Explain prefix-based matching using `*` (e.g., `/en/articles/9140627-*`).
>     - Provide examples for redirecting to a fixed destination and for substituting the captured suffix (e.g., `/old/article-*` -> `/new/article-*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f0226dddd4b2645cc8f84b0278f4046b4ce026e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->