### PR TITLE
Remove docs around snippets config

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -8,22 +8,6 @@ One of the core principles of software development is DRY (Don't Repeat Yourself
 
 Snippets do not render as standalone pages. You must import them into other files.
 
-## Configure snippet folders
-
-By default, any file in a folder named `snippets` is treated as a snippet. You can configure additional custom folders to contain snippets with the `snippets` field in your `docs.json`.
-
-Add [glob patterns](https://code.visualstudio.com/docs/editor/glob-patterns) to the `snippets` array in `docs.json` to specify which folders contain snippets.
-
-```json docs.json
-{
-  "snippets": [
-    "components/**",
-    "shared/reusable/**",
-    "shared/common-component.mdx"
-  ]
-}
-```
-
 ## Create snippets
 
 Create a file in a snippet folder with the content you want to reuse. Snippets can contain all content types supported by Mintlify and they can import other snippets.
@@ -32,7 +16,7 @@ Create a file in a snippet folder with the content you want to reuse. Snippets c
 
 To use snippets, import them into pages using either an absolute or relative path.
 
-- **Absolute imports**: Start with `/snippets/` or your custom snippet location for imports from the root of your project.
+- **Absolute imports**: Start with `/snippets/` for imports from the root of your project.
 - **Relative imports**: Use `./` or `../` to import snippets relative to the current file's location.
 
 <Tip>

--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -92,7 +92,7 @@ The counter renders as an interactive React component.
 
 ## Importing components
 
-To import React components in your MDX files, the component files must be located in a snippet folder. By default, this is the `/snippets/` folder. You can [configure additional directories](/create/reusable-snippets#configure-snippet-folders) to contain snippets in your `docs.json`. Learn more about [reusable snippets](/create/reusable-snippets).
+To import React components in your MDX files, the component files must be located in the `/snippets/` folder. Learn more about [reusable snippets](/create/reusable-snippets).
 
 ### Example
 

--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -643,16 +643,6 @@ This section contains the full reference for the `docs.json` file.
   </Expandable>
 </ResponseField>
 
-<ResponseField name="snippets" type="array of strings">
-  Specify additional folders for reusable snippets using [glob patterns](https://code.visualstudio.com/docs/editor/glob-patterns). Any files in folders matching these patterns are snippets, in addition to the default `/snippets/` folder.
-
-  ```json Example snippets configuration
-  {
-    "snippets": ["components/**", "shared/shared-file.mdx"]
-  }
-  ```
-</ResponseField>
-
 <ResponseField name="contextual" type="object">
   Contextual menu for AI-optimized content and integrations.
 


### PR DESCRIPTION
## Documentation changes
We are refactoring the snippets solution this removes the documentation around it so we don't encourage people to use something that will be deprecated soon.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes docs for custom snippet directories and updates guidance to require components/snippets be imported from `/snippets/` only.
> 
> - **Docs updates (snippets)**:
>   - Remove `snippets` configuration from `docs.json` reference (`organize/settings.mdx`).
>   - `create/reusable-snippets.mdx`:
>     - Delete “Configure snippet folders” section.
>     - Update absolute import guidance to only use `/snippets/`.
>   - `customize/react-components.mdx`:
>     - Clarify React components must live under `/snippets/` and adjust copy accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e7e1d96e869e022dcd967085c9b0ed4a7a80709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->