### PR TITLE
Update analytics events table

### DIFF
--- a/integrations/analytics/overview.mdx
+++ b/integrations/analytics/overview.mdx
@@ -618,8 +618,11 @@ We send the following events to your analytics provider. All events use the `doc
 | `docs.code_block.copy`                  | When a user copies code from a code block.                                                                |
 | `docs.code_block.ask_ai`                | When a user asks the assistant to explain a code block.                                                   |
 | `docs.content.view`                     | When a user views a page. Only available for analytics providers that do not track page views by default. |
-| `docs.feedback.thumbs_up`               | When a user clicks the positive feedback button.                                                          |
-| `docs.feedback.thumbs_down`             | When a user clicks the negative feedback button.                                                          |
+| `docs.assistant.thumbs_up`              | When a user clicks the positive feedback button.                                                          |
+| `docs.assistant.thumbs_down`            | When a user clicks the negative feedback button.                                                          |
+| `docs.assistant.spam_detected`          | When spam is detected in an assistant conversation.                                                       |
+| `docs.autopilot.suggestion.created`     | When an autopilot suggestion is created.                                                                  |
+| `docs.autopilot.suggestion.no_suggestion` | When autopilot determines no suggestion is needed.                                                      |
 | `docs.navitem.cta_click`                | When a user clicks a call to action.                                                                      |
 | `docs.expandable.close`                 | When a user closes an expandable.                                                                         |
 | `docs.expandable.open`                  | When a user opens an expandable.                                                                          |


### PR DESCRIPTION
Updated the analytics events table to reflect the standardized event names from PR #3039. Renamed feedback events to use the `docs.assistant` prefix and added new events for spam detection and autopilot suggestions.

**Files changed:**
- `integrations/analytics/overview.mdx` - Updated analytics events table with renamed and new events

Generated from [[ENG-5136]: Validate analytics events](https://github.com/mintlify/server/pull/3039) @IHSten

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames feedback events to `docs.assistant.*` and adds `docs.assistant.spam_detected` plus autopilot suggestion events in `integrations/analytics/overview.mdx`.
> 
> - **Docs (Analytics)**
>   - **Events table update** in `integrations/analytics/overview.mdx`:
>     - Rename `docs.feedback.thumbs_up/down` to `docs.assistant.thumbs_up/down`.
>     - Add `docs.assistant.spam_detected`.
>     - Add `docs.autopilot.suggestion.created` and `docs.autopilot.suggestion.no_suggestion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8586697eeddfe40e615cab2d59e7e59065ff88cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->