### PR TITLE
Add Polish, Uzbek, and Hebrew languages to navigation docs

### DIFF
--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -540,6 +540,7 @@ We currently support the following languages for localization:
   <Card title="Swedish (sv)" icon="/images/navigation/languages/sv.png" horizontal />
   <Card title="Turkish (tr)" icon="/images/navigation/languages/tr.png" horizontal />
   <Card title="Ukrainian (ua)" icon="/images/navigation/languages/ua.png" horizontal />
+  <Card title="Uzbek (uz)" icon="/images/navigation/languages/uz.png" horizontal />
   <Card title="Vietnamese (vi)" icon="/images/navigation/languages/vi.png" horizontal />
 </CardGroup>
 

--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -524,6 +524,7 @@ We currently support the following languages for localization:
   <Card title="English (en)" icon="/images/navigation/languages/en.png" horizontal />
   <Card title="French (fr)" icon="/images/navigation/languages/fr.png" horizontal />
   <Card title="German (de)" icon="/images/navigation/languages/de.png" horizontal />
+  <Card title="Hebrew (he)" icon="/images/navigation/languages/he.png" horizontal />
   <Card title="Hindi (hi)" icon="/images/navigation/languages/hi.png" horizontal />
   <Card title="Indonesian (id)" icon="/images/navigation/languages/id.png" horizontal />
   <Card title="Italian (it)" icon="/images/navigation/languages/it.png" horizontal />
@@ -531,6 +532,7 @@ We currently support the following languages for localization:
   <Card title="Korean (ko)" icon="/images/navigation/languages/ko.png" horizontal />
   <Card title="Latvian (lv)" icon="/images/navigation/languages/lv.png" horizontal />
   <Card title="Norwegian (no)" icon="/images/navigation/languages/no.png" horizontal />
+  <Card title="Polish (pl)" icon="/images/navigation/languages/pl.png" horizontal />
   <Card title="Portuguese (pt-BR)" icon="/images/navigation/languages/pt-br.png" horizontal />
   <Card title="Romanian (ro)" icon="/images/navigation/languages/ro.png" horizontal />
   <Card title="Russian (ru)" icon="/images/navigation/languages/ru.png" horizontal />


### PR DESCRIPTION
Updated the navigation documentation to include three newly supported languages: Polish (pl), Uzbek (uz), and Hebrew (he). These languages were added to the supported languages list in alphabetical order with their corresponding flag icons.

## Files changed
- `organize/navigation.mdx` - Added Card components for Hebrew, Polish, and Uzbek languages in the Languages section

Generated from [added pl, uz, and he langs](https://github.com/mintlify/mint/pull/5172) @ruhanponnada

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Hebrew (he), Polish (pl), and Uzbek (uz) to the supported languages list in navigation docs.
> 
> - **Documentation**:
>   - **Languages**: Add `Hebrew (he)`, `Polish (pl)`, and `Uzbek (uz)` cards with icons in `organize/navigation.mdx` under supported languages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9663c81f23a6c7c17056541f0ab139cdbaf963b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->