### PR TITLE
Remove deprecated feedback events from analytics docs

### DIFF
--- a/integrations/analytics/overview.mdx
+++ b/integrations/analytics/overview.mdx
@@ -664,13 +664,6 @@ All tracked events use the `docs.` prefix.
 | `docs.expandable.open`                  | User opens an expandable.                                                                          |
 | `docs.expandable.close`                 | User closes an expandable.                                                                         |
 
-### Feedback
-
-| Event name                              | Description                                                                                               |
-| :-------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
-| `docs.feedback.thumbs_up`               | User clicks the positive feedback button.                                                          |
-| `docs.feedback.thumbs_down`             | User clicks the negative feedback button.                                                          |
-
 ### Assistant and agent
 
 | Event name                              | Description                                                                                               |


### PR DESCRIPTION
Removed the deprecated `docs.feedback.thumbs_up` and `docs.feedback.thumbs_down` events from the analytics integrations documentation. These events are no longer tracked and have been replaced by assistant-specific feedback events.

## Files changed
- `integrations/analytics/overview.mdx` - Removed the "Feedback" section containing the deprecated thumbs up/down events

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes deprecated `docs.feedback.thumbs_up` and `docs.feedback.thumbs_down` events from the analytics docs.
> 
> - **Docs**:
>   - Remove deprecated "Feedback" events from `integrations/analytics/overview.mdx`:
>     - Deleted `docs.feedback.thumbs_up` and `docs.feedback.thumbs_down` entries and their section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a92040a0bd5f1cac8ff27f006134687e7ca05a64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->