### PR TITLE
Add redirect from /changelog/overview to /changelog

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1784,6 +1784,10 @@
     {
       "source": "/ai/slack-app",
       "destination": "/ai/slack-bot"
+    },
+    {
+      "source": "/changelog/overview",
+      "destination": "/changelog"
     }
   ],
   "integrations": {


### PR DESCRIPTION
Added a redirect in docs.json to route users from the old changelog overview URL to the main changelog page. This ensures users accessing the legacy URL are automatically redirected to the correct location.

Files changed:
- docs.json

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Adds redirect in `docs.json` mapping `/changelog/overview` to `/changelog` within the `redirects` array
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5cf734cb51665aa59f1c396e89f859ba8abe21d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->