### PR TITLE
Re-add CLI instructions to quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -10,21 +10,19 @@ After you complete this guide, you'll have a live documentation site ready to cu
 
 Mintlify uses a docs-as-code approach to manage your documentation. Every page on your site has a corresponding file stored in your documentation <Tooltip headline="Repository" tip="Your documentation's source code where all files and their history are stored. The web editor connects to your documentation repository to access and modify content, or you can edit files locally in your preferred IDE.">repository</Tooltip>.
 
-You'll connect your own GitHub repository to your Mintlify deployment. This allows you to work locally, sync to your remote repository, and keep your documentation under your own GitHub organization.
+When you connect your documentation repository to your Mintlify deployment, you can work on your documentation locally or in the web editor and sync any changes to your remote repository.
 
 ## Deploy your documentation site
 
-Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository, and install the GitHub App to enable automatic deployments.
+Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository for your documentation, and install the GitHub App to enable automatic deployments.
 
 After onboarding, your documentation site is deployed and accessible at your `.mintlify.app` URL.
 
 <AccordionGroup>
-  <Accordion title="Skip connecting GitHub for now">
-    If you want to get started quickly without connecting your own repository, you can skip the GitHub connection during onboarding. Mintlify will create a private repository in the `mintlify-community` organization and automatically configure the GitHub App for you.
+  <Accordion title="Optional: Skip connecting GitHub during onboarding">
+    If you want to get started quickly without connecting your own repository, you can skip the GitHub connection during onboarding. Mintlify creates a private repository in the `mintlify-community` organization and automatically configures the GitHub App for you.
 
-    This is a temporary option that allows you to use the web editor immediately. You can migrate to your own repository later if needed.
-
-    To skip: When prompted to connect GitHub during onboarding, click **Skip**.
+    This lets you use the web editor immediately and migrate to your own repository later.
   </Accordion>
 </AccordionGroup>
 
@@ -56,10 +54,6 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
 
 <Tabs>
   <Tab title="CLI">
-    <Note>
-      The GitHub App must be installed to enable automatic deployments when you push changes. If you completed onboarding, the app is already installed. See [GitHub](/deploy/github) for details.
-    </Note>
-
     <Steps>
       <Step title="Install the CLI">
         The CLI requires [Node.js](https://nodejs.org/en) v20.17.0 or higher. Use an LTS version for stability.


### PR DESCRIPTION
## Documentation changes

This PR adds the CLI workflow back to the quickstart.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **docs/quickstart.mdx** simplified and expanded to cover both CLI and web editor workflows.
> 
> - Reintroduces a full **CLI** path with steps to install `mint`, clone repo, edit `index.mdx`, run `mint dev`, and push to deploy
> - Streamlines **deployment/onboarding** into a single flow, clarifying GitHub connection, repo selection, and app install
> - Adds an **Accordion** explaining how to skip GitHub during onboarding (Mintlify-hosted repo is auto-created)
> - Keeps **View your deployed site** guidance and adds concise **Next steps** cards (editor, installation, custom domain)
> - Removes prior split tabs/cards for “Mintlify-hosted” vs “Your own repository” in favor of a unified path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc6b2079b9547a9809f2511a7743d4b508496643. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->