### PR TITLE
Add changelog entry for December 23, 2025 releases

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -8,7 +8,7 @@ noindex: true
 <Update label="December 23, 2025" tags={["New releases", "Improvements"]} rss={{ title: "Web editor improvements and assistant insights" }}>
   ## Web editor improvements
 
-  The [web editor](/editor/index) has been redesigned with a more intuitive interface and new capabilities.
+  The [web editor](/editor/index) now has a more intuitive interface and new capabilities.
 
   - **Visual navigation editing**: Configure your navigation structure in the web editor and see how your site's navigation sidebar looks in the editor. All changes map to your `docs.json` automatically.
   - **Configuration options**: Adjust all site configuration options from the editor without manually editing your `docs.json`.
@@ -36,7 +36,7 @@ noindex: true
   ## Bug fixes
 
   - Fixed missing request examples in API playground for certain endpoints.
-  - Fixed MDX examples not displaying correctly when prefill is enabled in API playground.
+  - Fixed MDX examples not displaying correctly when using prefilled examples in the API playground.
   - Fixed links in assistant opening in new windows instead of the same window.
   - Fixed Markdown link rendering in assistant responses.
   - Fixed header slug character handling for special characters.


### PR DESCRIPTION
Added comprehensive changelog entry covering web editor improvements, assistant insights, Slack bot customization, mobile navigation updates, and various bug fixes from merged PRs since December 19.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new dated entry to `changelog.mdx` detailing recent releases and fixes.
> 
> - **Web editor**: Visual navigation editing mapped to `docs.json`, configuration controls, drag-and-drop asset uploads, and stability/mobile responsiveness improvements
> - **Agent suggestions**: New insights source from assistant conversations alongside repo monitoring
> - **Slack bot customization**: Choose reply channel (default `#ask-ai`) and customize bot avatar/name from dashboard
> - **Mobile navigation**: Theme switcher and logo display added
> - **Bug fixes**: Request examples and MDX prefill display in `API playground`; assistant links open in same window; Markdown link rendering; header slug handling for special characters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a0018afb4c21efd06fafd823a1ab5e1ec4f6bff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->