### PR TITLE
Add Slack Assistant removal documentation

### DIFF
--- a/ai/slack-bot.mdx
+++ b/ai/slack-bot.mdx
@@ -47,3 +47,20 @@ If you want the bot to reply to messages in a different channel, select a channe
 After you add the app to your workspace, you can manage or remove the app from the [Integrations](https://dashboard.mintlify.com/products/assistant/settings/integrations) tab.
 
 In the Slack bot configuration menu, customize the bot by changing its avatar or name, and choose which channel it automatically replies to all messages in.
+
+## Remove the Slack app
+
+You can remove the Slack Assistant installation from your workspace through the dashboard:
+
+1. Navigate to the [Integrations](https://dashboard.mintlify.com/products/assistant/settings/integrations) tab of the **Assistant Configurations** page in your dashboard.
+1. In the Slack card, click **Configure** to open the configuration menu.
+1. Click **Remove** to delete the installation.
+
+When you remove a Slack Assistant installation:
+
+- The Mintlify app is automatically uninstalled from your Slack workspace
+- All installation data associated with your workspace is permanently deleted from Mintlify's database
+- The bot will no longer respond to messages in your workspace
+- This action cannot be undone
+
+If you want to use the Slack Assistant again after removing it, you'll need to reinstall it by following the setup steps above.


### PR DESCRIPTION
Added documentation for removing Slack Assistant installations from workspaces. The new section explains the removal process through the dashboard and clarifies what happens when an installation is removed (automatic app uninstallation, permanent data deletion, and irreversibility).

## Files changed
- `ai/slack-bot.mdx` - Added "Remove the Slack app" section with step-by-step removal instructions and consequences

Generated from [feat: add ability to remove slack assistant integration](https://github.com/mintlify/server/pull/2989) @rtbarnes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds clear removal guidance to Slack bot docs.
> 
> - New "Remove the Slack app" section in `ai/slack-bot.mdx` with step-by-step instructions via the dashboard
> - Clarifies effects of removal: Slack app uninstalled, installation data permanently deleted, bot stops responding, action is irreversible
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd3acc2a215974926a838658b4f429b0f35f5cbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->