### PR TITLE
Document API key creation rate limit

### DIFF
--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -20,6 +20,10 @@ The Mintlify REST API enables you to programmatically interact with your documen
 
 You can generate an API key through [the dashboard](https://dashboard.mintlify.com/settings/organization/api-keys). API keys are associated with an entire organization and can be used across multiple deployments.
 
+<Note>
+  API key creation through the dashboard is limited to 10 requests per hour per organization to prevent abuse.
+</Note>
+
 ### Admin API key
 
 The admin API key is used for the [Trigger update](/api-reference/update/trigger), [Get update status](/api-reference/update/status), and all agent endpoints.


### PR DESCRIPTION
Added documentation for the new rate limiting on API key creation through the dashboard. This informs users that API key creation is limited to 10 requests per hour per organization to prevent abuse.

## Files changed
- `api/introduction.mdx` - Added note about rate limiting in the Authentication section

Generated from [feat: dashboard admin API key creation rate limiting](https://github.com/mintlify/server/pull/3119) @lucaspunz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates authentication docs to reflect new rate limiting for API key creation via the dashboard.
> 
> - In `api/introduction.mdx`, adds a `Note` indicating API key creation is capped at 10 requests per hour per organization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce699dcf58f7e95fb59f23a73b85a5c451ffe329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->