### PR TITLE
Banners can be configured on a per-language basis

### DIFF
--- a/components/banner.mdx
+++ b/components/banner.mdx
@@ -31,6 +31,10 @@ To add a banner, use the `banner` property in your `docs.json`:
   ```
 </CodeGroup>
 
+<Note>
+  Banners can also be configured on a per-language basis by setting the banner property in `navigation.languages`.
+</Note>
+
 ## Properties
 
 <ResponseField name="content" type="string" required>


### PR DESCRIPTION
## Documentation changes

Documenting that banners can be configured on a per-language basis. Mint PR: https://github.com/mintlify/mint/pull/5287.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a clarification to `components/banner.mdx` documenting per-language banner configuration.
> 
> - New note explains setting the `banner` property within `navigation.languages` to localize banners per language
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c49900c806a4b249756a79d79b6b2f752f8777f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->