### PR TITLE
Update assistant documentation for always-on placement

### DIFF
--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -109,7 +109,7 @@ Add the assistant as a bot to your [Slack workspace](/ai/slack-bot) or [Discord 
 
 ### UI placement
 
-Depending on how you configure your assistant placement, the assistant appears as either a button next to the search bar or a bar at the bottom of the page.
+When the assistant is enabled, it appears in two locations: as a button next to the search bar and as a bar at the bottom of the page.
 
 <Columns cols={2}>
   <Frame caption="Assistant button next to the search bar.">


### PR DESCRIPTION
Removed the "Control placement" configuration section from the assistant documentation since placement options are no longer configurable. Updated the "UI placement" section to clarify that both entry points (search bar button and bottom bar) are always present when the assistant is enabled.

## Files changed
- `ai/assistant.mdx` - Removed placement configuration section and updated UI placement description

Generated from [Experiment: Remove configuration for assistant on locations](https://github.com/mintlify/mint/pull/5306) @handotdev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Assistant docs update**
> 
> - Removes `Control placement` configuration section from `ai/assistant.mdx`
> - Updates the **UI placement** description to clarify the assistant is always shown in two places: a button by the search bar and a bottom-of-page bar
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdfcee6c212091c1157c7e91086637f715114d9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->