### PR TITLE
Add timestamp metadata callout to pages documentation

### DIFF
--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -173,14 +173,10 @@ keywords: ['configuration', 'setup', 'getting started']
 
 ## Last modified timestamp
 
-<Tip>
-  Display a "Last modified" timestamp at the bottom of all pages by enabling `metadata.timestamp` in your [global settings](/organize/settings#metadata).
-  
-  ```json docs.json
-  {
-    "metadata": {
-      "timestamp": true
-    }
-  }
-  ```
-</Tip>
+Add a "Last modified on [date]" timestamp to all pages by enabling `metadata.timestamp` in your [global settings](/organize/settings#metadata).
+
+```json docs.json
+"metadata": {
+  "timestamp": true
+}
+```


### PR DESCRIPTION
Added a callout to the pages documentation explaining the metadata.timestamp feature that displays last modified dates on pages. This helps users discover this useful feature when learning about page organization.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents the new page-level timestamp option.
> 
> - Adds a "Last modified timestamp" section to `organize/pages.mdx`, explaining and exemplifying enabling `metadata.timestamp` in global settings (via `docs.json`) to show "Last modified on [date]" on all pages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3356e0058bd6a511a35bd39704477370d8b97a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->