### PR TITLE
Simplify quickstart page

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,54 +1,13 @@
 ---
 title: "Quickstart"
 description: "Deploy your documentation site and make your first change."
-keywords: ["quickstart","deploy","get started","first steps"]
 ---
 
-After you complete this guide, you'll have a live documentation site ready to customize and update.
+## Deploy your site
 
-## Before you begin
+Go to [mintlify.com/start](https://mintlify.com/start) to create your documentation site. You'll connect your GitHub account and create a repository for your docs.
 
-Mintlify uses a docs-as-code approach to manage your documentation. Every page on your site has a corresponding file stored in your documentation <Tooltip tip="Your documentation's source code where all files and their history are stored. The web editor connects to your documentation repository to access and modify content, or you can edit files locally in your preferred IDE.">repository</Tooltip>.
-
-When you connect your documentation repository to your Mintlify deployment, you can work on your documentation locally or in the web editor and sync any changes to your remote repository.
-
-## Deploy your documentation site
-
-Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository for your documentation, and install the GitHub App to enable automatic deployments.
-
-After onboarding, your documentation site is deployed and accessible at your `.mintlify.app` URL.
-
-<AccordionGroup>
-  <Accordion title="Optional: Skip connecting GitHub during onboarding">
-    If you want to get started quickly without connecting your own repository, you can skip the GitHub connection during onboarding. Mintlify creates a private repository in a private organization and automatically configures the GitHub App for you.
-
-    This lets you use the web editor immediately and migrate to your own repository later.
-  </Accordion>
-</AccordionGroup>
-
-## View your deployed site
-
-Your documentation site is now deployed at `https://<your-project-name>.mintlify.app`.
-
-Find your exact URL on the **Overview** page of your [dashboard](https://dashboard.mintlify.com/).
-
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-domain-light.png"
-    alt="Overview page of the Mintlify dashboard."
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/mintlify-domain-dark.png"
-    alt="Overview page of the Mintlify dashboard."
-    className="hidden dark:block"
-  />
-</Frame>
-
-<Tip>
-  Your site is ready to view immediately. Use this URL for testing and sharing with your team. Before sharing with your users, you may want to add a [custom domain](/customize/custom-domain).
-</Tip>
+Your site deploys to `https://<your-project-name>.mintlify.app`. Find your URL on the [dashboard](https://dashboard.mintlify.com/).
 
 ## Make your first change
 
@@ -56,28 +15,17 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
   <Tab title="CLI">
     <Steps>
       <Step title="Install the CLI">
-        The CLI requires [Node.js](https://nodejs.org/en) v20.17.0 or higher. Use an LTS version for stability.
-
         <CodeGroup>
-
         ```bash npm
         npm i -g mint
         ```
-
-        
         ```bash pnpm
         pnpm add -g mint
         ```
-
         </CodeGroup>
-
-        See [Install the CLI](/installation) for full details and troubleshooting.
-      </Step>
-      <Step title="Clone your repository">
-        If you haven't already cloned your repository locally, follow the instructions in [Clone your repository](/installation#clone-your-repository).
       </Step>
       <Step title="Edit a page">
-        Open `index.mdx` in your preferred editor and update the description in the frontmatter:
+        Open `index.mdx` and update the description:
 
         ```mdx
         ---
@@ -87,34 +35,27 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
         ```
       </Step>
       <Step title="Preview locally">
-        Run the following command from your documentation directory:
-
         ```bash
         mint dev
         ```
-
-        View your preview at `http://localhost:3000`.
+        View at `http://localhost:3000`.
       </Step>
-      <Step title="Push your changes">
-        Commit and push your changes to trigger a deployment:
-
+      <Step title="Push changes">
         ```bash
         git add .
         git commit -m "Update description"
         git push
         ```
-
-        Mintlify automatically deploys your changes. View your deployment status on the [Overview](https://dashboard.mintlify.com/) page of your dashboard.
       </Step>
     </Steps>
   </Tab>
   <Tab title="Web editor">
     <Steps>
-      <Step title="Open the web editor">
-        Navigate to the [web editor](https://dashboard.mintlify.com/editor) in your dashboard.
+      <Step title="Open the editor">
+        Go to the [web editor](https://dashboard.mintlify.com/editor).
       </Step>
       <Step title="Edit a page">
-        Open `index.mdx` and update the description in the frontmatter:
+        Open `index.mdx` and update the description:
 
         ```mdx
         ---
@@ -124,10 +65,7 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
         ```
       </Step>
       <Step title="Publish">
-        Click the **Publish** button in the top-right of the web editor toolbar.
-      </Step>
-      <Step title="View live">
-        On the [Overview](https://dashboard.mintlify.com/) page of your dashboard, you can see your site's deployment status. When it finishes deploying, refresh your documentation site to see your changes live.
+        Click **Publish** in the toolbar.
       </Step>
     </Steps>
   </Tab>
@@ -137,12 +75,12 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
 
 <Columns cols={3}>
   <Card title="Use the web editor" icon="mouse-pointer-2" horizontal href="/editor/index">
-    Edit documentation in your browser and preview how your pages will look when published.
+    Edit documentation in your browser.
   </Card>
   <Card title="Explore CLI commands" icon="terminal" horizontal href="/installation#additional-commands">
-    Find broken links, check accessibility, validate OpenAPI specs, and more.
+    Find broken links, validate specs, and more.
   </Card>
   <Card title="Add a custom domain" icon="globe" horizontal href="/customize/custom-domain">
-    Use your own domain for your documentation site.
+    Use your own domain.
   </Card>
 </Columns>


### PR DESCRIPTION
Streamlined the quickstart page by removing verbose explanations, condensing deployment instructions, and shortening CLI/web editor steps. Removed unnecessary sections like "Before you begin", accordion content, screenshots, and tip callouts to create a more focused getting started experience.

Files changed:
- quickstart.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `quickstart.mdx` to a shorter, task-focused quickstart.
> 
> - Removes extraneous sections (keywords/frontmatter metadata, “Before you begin”, accordion, screenshots, tip callouts) and viewing/status details
> - Condenses deployment guidance to a single “Deploy your site” section with dashboard URL
> - Shortens CLI flow (install, edit `index.mdx`, preview, push) and web editor steps (open, edit, publish) with tighter copy
> - Trims “Next steps” card descriptions for brevity
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e0f359082d953fb00c2fd85688648aa2696ec8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->