### PR TITLE
Remove custom subpaths callout

### DIFF
--- a/deploy/docs-subpath.mdx
+++ b/deploy/docs-subpath.mdx
@@ -17,4 +17,4 @@ Setting up a `/docs` subpath varies depending on your hosting provider. Choose y
 
 ### Additional configuration for strict security policies
 
-If you proxy all traffic on your custom domain, you may need to configure [headers](/deploy/csp-configuration) added by your proxy or firewalls to ensure that your documentation is served correctly.
+If you proxy all traffic on your custom domain, you may need to configure your proxy or firewall rules to add the correct [headers](/deploy/csp-configuration) so your documentation displays properly.


### PR DESCRIPTION
## Documentation changes

Custom subpaths aren't available out of the box, so this PR removes information implying that they are.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs update: `/deploy/docs-subpath.mdx`**
> 
> - Removes the "Custom subpaths" section implying arbitrary subpaths are supported
> - Rewrites the strict security policies note to clarify configuring proxy/firewall rules to add correct headers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fbe7e0806237f09be27ddb7f977b759ba044a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->