### PR TITLE
Document API key creation rate limit

### DIFF
--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -18,27 +18,25 @@ The Mintlify REST API enables you to programmatically interact with your documen
 
 ## Authentication
 
-You can generate an API key through [the dashboard](https://dashboard.mintlify.com/settings/organization/api-keys). API keys are associated with an entire organization and can be used across multiple deployments.
+Generate API keys on the [API keys page](https://dashboard.mintlify.com/settings/organization/api-keys) in your dashboard. Each API key belongs to an organization--you can use keys across multiple deployments within the same organization.
 
-<Note>
-  API key creation through the dashboard is limited to 10 requests per hour per organization to prevent abuse.
-</Note>
+You can create up to 10 API keys per hour per organization.
 
 ### Admin API key
 
-The admin API key is used for the [Trigger update](/api-reference/update/trigger), [Get update status](/api-reference/update/status), and all agent endpoints.
+Use the admin API key to authenticate requests to [Trigger update](/api-reference/update/trigger), [Get update status](/api-reference/update/status), and all agent endpoints.
 
 Admin API keys begin with the `mint_` prefix. Keep your admin API keys secret.
 
 ### Assistant API key
 
-The assistant API key is used for the [Generate assistant message](/api-reference/assistant/create-assistant-message) and [Search documentation](/api-reference/assistant/search) endpoints.
+Use the assistant API key to authenticate requests to [Generate assistant message](/api-reference/assistant/create-assistant-message) and [Search documentation](/api-reference/assistant/search) endpoints.
 
 Assistant API keys begin with the `mint_dsc_` prefix.
 
-The assistant API **key** is a server-side token that should be kept secret.
+The assistant API **key** is a server-side token. Keep it secret.
 
-The assistant API **token** is a public token that can be referenced in your frontend code.
+The assistant API **token** is a public token that you can reference in frontend code.
 
 <Note>
   Calls using the assistant API token can incur costs: either using your AI assistant credits or incurring overages.


### PR DESCRIPTION
Added documentation for the new rate limiting on API key creation through the dashboard. This informs users that API key creation is limited to 10 requests per hour per organization to prevent abuse.

## Files changed
- `api/introduction.mdx` - Added note about rate limiting in the Authentication section

Generated from [feat: dashboard admin API key creation rate limiting](https://github.com/mintlify/server/pull/3119) @lucaspunz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `api/introduction.mdx` Authentication docs.
> 
> - Adds rate limit: you can create up to `10` API keys per hour per organization
> - Clarifies where to generate API keys and that keys are org-scoped and reusable across deployments
> - Rewords admin/assistant key usage and prefixes; clarifies assistant key vs public token
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e245af336ce6f87ec46d824a16fdac63a9ca9b3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->