### PR TITLE
fix: remove Columns wrapper for the next steps

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -135,14 +135,12 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
 
 ## Next steps
 
-<Columns cols={3}>
-  <Card title="Use the web editor" icon="mouse-pointer-2" horizontal href="/editor/index">
-    Edit documentation in your browser and preview how your pages will look when published.
-  </Card>
-  <Card title="Explore CLI commands" icon="terminal" horizontal href="/installation#additional-commands">
-    Find broken links, check accessibility, validate OpenAPI specs, and more.
-  </Card>
-  <Card title="Add a custom domain" icon="globe" horizontal href="/customize/custom-domain">
-    Use your own domain for your documentation site.
-  </Card>
-</Columns>
+<Card title="Use the web editor" icon="mouse-pointer-2" horizontal href="/editor/index">
+  Edit documentation in your browser and preview how your pages will look when published.
+</Card>
+<Card title="Explore CLI commands" icon="terminal" horizontal href="/installation#additional-commands">
+  Find broken links, check accessibility, validate OpenAPI specs, and more.
+</Card>
+<Card title="Add a custom domain" icon="globe" horizontal href="/customize/custom-domain">
+  Use your own domain for your documentation site.
+</Card>


### PR DESCRIPTION
## Documentation changes

<table>
<thead>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
</thead>
<tbody>
<tr>
<td>

<img width="1740" height="1334" alt="CleanShot 2026-01-09 at 1  21 42@2x" src="https://github.com/user-attachments/assets/bb05eb35-051c-498c-a882-6a069f65a0bc" />


</td>
<td>

<img width="1740" height="1334" alt="CleanShot 2026-01-09 at 1  21 56@2x" src="https://github.com/user-attachments/assets/ce120da1-68b8-47ca-8475-118c52fcba56" />


</td>
</tr>
</tbody>
</table>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs layout in `quickstart.mdx`.
> 
> - Removes `Columns` wrapper from the "Next steps" section and renders three `Card` components directly
> - No content changes; only structure/layout adjustment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a69f222ffabb88b94c5af9991e34024d857c6330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->