### PR TITLE
fix: remove lines wrap from code blocks for mobile scroll

### DIFF
--- a/es/organize/settings.mdx
+++ b/es/organize/settings.mdx
@@ -1240,7 +1240,7 @@ Esta sección contiene la referencia completa del archivo `docs.json`.
 
 <Tabs>
   <Tab title="Ejemplo básico">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1387,7 +1387,7 @@ Esta sección contiene la referencia completa del archivo `docs.json`.
   </Tab>
 
   <Tab title="Ejemplo de API interactivo">
-    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} lines wrap
+    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1561,7 +1561,7 @@ Esta sección contiene la referencia completa del archivo `docs.json`.
   </Tab>
 
   <Tab title="Ejemplo multilingüe">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",

--- a/fr/organize/settings.mdx
+++ b/fr/organize/settings.mdx
@@ -1232,7 +1232,7 @@ Cette section présente la référence complète du fichier `docs.json`.
 
 <Tabs>
   <Tab title="Exemple de base">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1379,7 +1379,7 @@ Cette section présente la référence complète du fichier `docs.json`.
   </Tab>
 
   <Tab title="Exemple d’API interactif">
-    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} lines wrap
+    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1553,7 +1553,7 @@ Cette section présente la référence complète du fichier `docs.json`.
   </Tab>
 
   <Tab title="Exemple multilingue">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",

--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -1118,7 +1118,7 @@ This section contains the full reference for the `docs.json` file.
 
 <Tabs>
   <Tab title="Basic example">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1264,7 +1264,7 @@ This section contains the full reference for the `docs.json` file.
     ```
   </Tab>
   <Tab title="Interactive API example">
-    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} lines wrap
+    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1437,7 +1437,7 @@ This section contains the full reference for the `docs.json` file.
     ```
   </Tab>
   <Tab title="Multi-language example">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",

--- a/zh/organize/settings.mdx
+++ b/zh/organize/settings.mdx
@@ -1224,7 +1224,7 @@ import IconsOptional from "/snippets/zh/icons-optional.mdx";
 
 <Tabs>
   <Tab title="基础示例">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1371,7 +1371,7 @@ import IconsOptional from "/snippets/zh/icons-optional.mdx";
   </Tab>
 
   <Tab title="交互式 API 示例">
-    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} lines wrap
+    ```json docs.json {43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,72,73,74,75,76,77,78,79} 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",
@@ -1545,7 +1545,7 @@ import IconsOptional from "/snippets/zh/icons-optional.mdx";
   </Tab>
 
   <Tab title="多语言示例">
-    ```json docs.json lines wrap
+    ```json docs.json 
     {
       "$schema": "https://mintlify.com/docs.json",
       "theme": "maple",


### PR DESCRIPTION
## Summary
Removed `lines wrap` attribute from code fence declarations to enable proper horizontal scrolling on mobile devices.

## Problem
Code blocks with `lines wrap` were forcing text to wrap instead of showing a horizontal scrollbar, breaking mobile UX.

## Solution
- Removed `lines wrap` from all code blocks in `/organize/settings.mdx`
- Enables proper overflow-x scrolling on small screens
- Consistent behavior across all documentation code samples

## Screenshots

| Before | After |
|--------|-------|
| <img width="527" alt="Before - text wrapping" src="https://github.com/user-attachments/assets/f08f6d34-9f79-4300-aa34-34497a1557c3" /> | <img width="515" alt="After - horizontal scroll" src="https://github.com/user-attachments/assets/7b841bd3-8f58-436f-a1c8-adcd9ff65065" /> |

**Before:** Code wraps to new lines, making it hard to read  
**After:** Code maintains formatting with horizontal scroll

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes forced line wrapping from code fences to fix mobile code block scrolling.
> 
> - Strips `lines wrap` from fenced code blocks in `organize/settings.mdx` and localized `es/`, `fr/`, `zh/` versions, including interactive API example blocks
> - Visual/formatting-only change; no content or schema updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 503747e5439b673f2c467fb008d2d10ff1c9521b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->