### PR TITLE
Updated quickstart page branding from Mintlify to Mint-ify

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -10,7 +10,7 @@ After you complete this guide, you'll have a live documentation site ready to cu
 
 Mint-ify uses a docs-as-code approach to manage your documentation. Every page on your site has a corresponding file stored in your documentation <Tooltip tip="Your documentation's source code where all files and their history are stored. The web editor connects to your documentation repository to access and modify content, or you can edit files locally in your preferred IDE.">repository</Tooltip>.
 
-When you connect your documentation repository to your Mintlify deployment, you can work on your documentation locally or in the web editor and sync any changes to your remote repository.
+When you connect your documentation repository to your Mint-ify deployment, you can work on your documentation locally or in the web editor and sync any changes to your remote repository.
 
 ## Deploy your documentation site
 


### PR DESCRIPTION
Updated all text references to "Mintlify" to use "Mint-ify" branding on the quickstart page. URLs and links were preserved to maintain functionality.

Files changed:
- quickstart.mdx

Changes include:
- Product name references throughout the content
- Alt text for dashboard screenshots
- All user-facing text mentions of the company name

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates branding on `quickstart.mdx`.
> 
> - Replaces user-facing references to "Mintlify" with "Mint-ify" across body text and deployment messaging
> - Updates image alt text to use "Mint-ify"
> - Preserves existing URLs (`mintlify.com`, `.mintlify.app`) and image paths/assets
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe473783215c2a7f849bc90c5f342f2eff9d8919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->