### PR TITLE
Revert "Update redirect documentation to reflect 308/307 status codes"

### DIFF
--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Redirects"
 description: "Configure redirects for moved, renamed, or deleted pages."
-keywords: ["308", "307", "redirects"]
+keywords: ["301", "redirects"]
 ---
 
 When you change the path of a file in your docs folder, it also changes the URL path to that page. This may happen when restructuring your docs or changing the sidebar title.
 
 ## Redirects
 
-Set up redirects by adding the `redirects` field to your `docs.json` file. By default, all redirects are permanent (308).
+Set up 301 redirects by adding the `redirects` field to your `docs.json` file.
 
 ```json
 "redirects": [
@@ -20,20 +20,6 @@ Set up redirects by adding the `redirects` field to your `docs.json` file. By de
 ```
 
 This permanently redirects `/source/path` to `/destination/path` so that you don't lose any previous SEO for the original page.
-
-### Temporary redirects
-
-To create a temporary redirect (307), set `permanent` to `false`:
-
-```json
-"redirects": [
-  {
-    "source": "/source/path",
-    "destination": "/destination/path",
-    "permanent": false
-  }
-]
-```
 
 ### Wildcard redirects
 

--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -640,7 +640,7 @@ This section contains the full reference for the `docs.json` file.
       Destination path to redirect to. Example: `/new-page`
     </ResponseField>
     <ResponseField name="permanent" type="boolean">
-      Whether to use a permanent redirect (308). Defaults to `true`. Set to `false` for a temporary redirect (307).
+      Whether to use a permanent redirect (301). Defaults to `true`.
     </ResponseField>
   </Expandable>
 </ResponseField>


### PR DESCRIPTION
Reverts mintlify/docs#2674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts redirect documentation to use 301 permanent redirects only.
> 
> - Updates `create/redirects.mdx` to say "Set up 301 redirects" and changes SEO `keywords` to `"301"`; removes the "Temporary redirects (307)" section
> - Updates `organize/settings.mdx` `redirects.permanent` description to reference 301 (default true), removing prior mention of 308/307
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa461897395cbd38930363c7f4d5cd50c6ba366f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->