### PR TITLE
Revert "Add banner for live preview"

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,10 +11,6 @@
   "icons": {
     "library": "lucide"
   },
-  "banner": {
-    "content": "[Live preview](/editor/live-preview) now available in the web editor.",
-    "dismissible": true
-  },
   "interaction": {
     "drilldown": false
   },


### PR DESCRIPTION
Reverts mintlify/docs#2695

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the previously added site banner configuration from `docs.json`, reverting the Live preview announcement.
> 
> - Deletes the `banner` block (content and dismissible fields) from the docs configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd13c030f12f9005a73ac285bfc28c2e277b7599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->