### PR TITLE
chore: Vale vocab

### DIFF
--- a/.vale/styles/Google/WordList.yml
+++ b/.vale/styles/Google/WordList.yml
@@ -23,7 +23,6 @@ swap:
   above: preceding
   account name: username
   action bar: app bar
-  admin: administrator
   Ajax: AJAX
   a\.k\.a|aka: or|also known as
   Android device: Android-powered device
@@ -38,7 +37,6 @@ swap:
   cellular network: mobile network
   chapter: documents|pages|sections
   check box: checkbox
-  CLI: command-line tool
   click on: click|click in
   Cloud: Google Cloud Platform|GCP
   Container Engine: Kubernetes Engine

--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -26,7 +26,6 @@ repo
 Ronan
 topbar
 (?i)tooltips?
-url
 
 # =============================================================================
 # NAMES OF THINGS
@@ -57,7 +56,6 @@ GCP
 (?i)git
 GitHub
 GitLab
-Go
 Golang
 GraphQL
 Heroku
@@ -101,6 +99,7 @@ Redis
 Ruby
 RubyGems
 Rust
+Slack
 Spring
 Storybook
 subpath
@@ -140,7 +139,7 @@ boolean
 Blockquote
 Blockquotes
 cdn
-cli
+CLI
 CNAME
 cpu
 config
@@ -174,7 +173,7 @@ ingestible
 init
 instanceof
 jvm
-jwt
+JWT
 lang
 len
 localhost
@@ -185,11 +184,10 @@ Multiline
 mvc
 monorepo
 nav
-next
 nodejs
 npm
 num
-oauth
+OIDC
 obj
 orm
 params


### PR DESCRIPTION
## Documentation changes

Reduce false positives

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Vale configuration to tighten terminology and casing, aiming to reduce false positives in docs linting.
> 
> - Updates Google `WordList.yml`: removes substitutions like `admin → administrator` and `CLI → command-line tool`; keeps standardized mappings (e.g., `url → URL`)
> - Refines Mintlify `accept.txt`: adds `Slack` and `OIDC`; enforces capitalization for `CLI` and `JWT`; removes or replaces generic/problematic entries (`Go`, `oauth`, `url`, `next`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2b5eb0a5b54aff9a401bd20e838f349c7d9aba1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->