### PR TITLE
Use native MDX support in Vale setup

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,7 +9,7 @@ Packages = Google, MDX
 
 Vocab = Mintlify
 
-# MDX files use native mdx2vast parser
+# MDX files use native mdx2vast parser (requires Vale >= 3.10.0)
 [*.mdx]
 BasedOnStyles = Vale, Google
 Google.Colons = NO # We allow for capital words after colons


### PR DESCRIPTION
## Documentation changes

See title. Works locally

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adopts native MDX parsing in Vale to simplify and improve MDX linting.
> 
> - Add `MDX` to `Packages` and use mdx2vast for `*.mdx`
> - Remove legacy `formats`, MDX-specific `TokenIgnores`/`BlockIgnores`, and `CommentDelimiters`
> - Retain existing style overrides for `changelog.mdx` and locale folders (`es`, `fr`, `zh`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95e785d5c6e5438f3b6b443f8bcdae8a7e1306de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->