### PR TITLE
Simplify quickstart page by 50%

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,146 +1,42 @@
 ---
 title: "Quickstart"
 description: "Deploy your documentation site and make your first change."
-keywords: ["quickstart","deploy","get started","first steps"]
 ---
 
-After you complete this guide, you'll have a live documentation site ready to customize and update.
+## Deploy your site
 
-## Before you begin
+Go to [mintlify.com/start](https://mintlify.com/start) to create your documentation site. You'll connect your GitHub account and select a repository.
 
-Mintlify uses a docs-as-code approach to manage your documentation. Every page on your site has a corresponding file stored in your documentation <Tooltip tip="Your documentation's source code where all files and their history are stored. The web editor connects to your documentation repository to access and modify content, or you can edit files locally in your preferred IDE.">repository</Tooltip>.
-
-When you connect your documentation repository to your Mintlify deployment, you can work on your documentation locally or in the web editor and sync any changes to your remote repository.
-
-## Deploy your documentation site
-
-Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository for your documentation, and install the GitHub App to enable automatic deployments.
-
-After onboarding, your documentation site is deployed and accessible at your `.mintlify.app` URL.
-
-<AccordionGroup>
-  <Accordion title="Optional: Skip connecting GitHub during onboarding">
-    If you want to get started quickly without connecting your own repository, you can skip the GitHub connection during onboarding. Mintlify creates a private repository in a private organization and automatically configures the GitHub App for you.
-
-    This lets you use the web editor immediately and migrate to your own repository later.
-  </Accordion>
-</AccordionGroup>
-
-## View your deployed site
-
-Your documentation site is now deployed at `https://<your-project-name>.mintlify.app`.
-
-Find your exact URL on the **Overview** page of your [dashboard](https://dashboard.mintlify.com/).
-
-<Frame>
-  <img
-    src="/images/quickstart/mintlify-domain-light.png"
-    alt="Overview page of the Mintlify dashboard."
-    className="block dark:hidden"
-  />
-
-  <img
-    src="/images/quickstart/mintlify-domain-dark.png"
-    alt="Overview page of the Mintlify dashboard."
-    className="hidden dark:block"
-  />
-</Frame>
-
-<Tip>
-  Your site is ready to view immediately. Use this URL for testing and sharing with your team. Before sharing with your users, you may want to add a [custom domain](/customize/custom-domain).
-</Tip>
+After onboarding, your site is live at `https://<your-project-name>.mintlify.app`. Find your URL on the [dashboard](https://dashboard.mintlify.com/).
 
 ## Make your first change
 
 <Tabs>
-  <Tab title="CLI">
-    <Steps>
-      <Step title="Install the CLI">
-        The CLI requires [Node.js](https://nodejs.org/en) v20.17.0 or higher. Use an LTS version for stability.
-
-        <CodeGroup>
-
-        ```bash npm
-        npm i -g mint
-        ```
-
-        
-        ```bash pnpm
-        pnpm add -g mint
-        ```
-
-        </CodeGroup>
-
-        See [Install the CLI](/installation) for full details and troubleshooting.
-      </Step>
-      <Step title="Clone your repository">
-        If you haven't already cloned your repository locally, follow the instructions in [Clone your repository](/installation#clone-your-repository).
-      </Step>
-      <Step title="Edit a page">
-        Open `index.mdx` in your preferred editor and update the description in the frontmatter:
-
-        ```mdx
-        ---
-        title: "Introduction"
-        description: "Your custom description here"
-        ---
-        ```
-      </Step>
-      <Step title="Preview locally">
-        Run the following command from your documentation directory:
-
-        ```bash
-        mint dev
-        ```
-
-        View your preview at `http://localhost:3000`.
-      </Step>
-      <Step title="Push your changes">
-        Commit and push your changes to trigger a deployment:
-
-        ```bash
-        git add .
-        git commit -m "Update description"
-        git push
-        ```
-
-        Mintlify automatically deploys your changes. View your deployment status on the [Overview](https://dashboard.mintlify.com/) page of your dashboard.
-      </Step>
-    </Steps>
-  </Tab>
   <Tab title="Web editor">
-    <Steps>
-      <Step title="Open the web editor">
-        Navigate to the [web editor](https://dashboard.mintlify.com/editor) in your dashboard.
-      </Step>
-      <Step title="Edit a page">
-        Open `index.mdx` and update the description in the frontmatter:
+    1. Open the [web editor](https://dashboard.mintlify.com/editor)
+    2. Edit `index.mdx` and update the description
+    3. Click **Publish**
+  </Tab>
+  <Tab title="CLI">
+    Install the CLI and run locally:
 
-        ```mdx
-        ---
-        title: "Introduction"
-        description: "Your custom description here"
-        ---
-        ```
-      </Step>
-      <Step title="Publish">
-        Click the **Publish** button in the top-right of the web editor toolbar.
-      </Step>
-      <Step title="View live">
-        On the [Overview](https://dashboard.mintlify.com/) page of your dashboard, you can see your site's deployment status. When it finishes deploying, refresh your documentation site to see your changes live.
-      </Step>
-    </Steps>
+    ```bash
+    npm i -g mint
+    mint dev
+    ```
+
+    Push changes to deploy:
+
+    ```bash
+    git add . && git commit -m "Update docs" && git push
+    ```
   </Tab>
 </Tabs>
 
 ## Next steps
 
-<Card title="Use the web editor" icon="mouse-pointer-2" horizontal href="/editor/index">
-  Edit documentation in your browser and preview how your pages will look when published.
-</Card>
-<Card title="Explore CLI commands" icon="terminal" horizontal href="/installation#additional-commands">
-  Find broken links, check accessibility, validate OpenAPI specs, and more.
-</Card>
-<Card title="Add a custom domain" icon="globe" horizontal href="/customize/custom-domain">
-  Use your own domain for your documentation site.
-</Card>
+<CardGroup cols={3}>
+  <Card title="Web editor" icon="mouse-pointer-2" href="/editor/index" />
+  <Card title="CLI commands" icon="terminal" href="/installation" />
+  <Card title="Custom domain" icon="globe" href="/customize/custom-domain" />
+</CardGroup>


### PR DESCRIPTION
Streamlined the quickstart guide by removing verbose sections and condensing deployment instructions. Reduced page length from ~140 lines to ~45 lines while maintaining essential information.

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Significantly streamlines the quickstart for faster onboarding.
> 
> - Rewrites `quickstart.mdx` to a shorter flow: **Deploy your site**, **Make your first change**, and **Next steps**
> - Adds concise Web editor steps and a minimal CLI snippet (`npm i -g mint`, `mint dev`, and git push to deploy)
> - Replaces detailed accordions, frames, tips, and multi-step instructions with a brief summary of deployment and live URL discovery
> - Consolidates resources into a `CardGroup` with links to Web editor, CLI commands, and Custom domain
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69e9d7619ee3b63ffccc29f16ee275657084cae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->