### PR TITLE
Document new `mint validate` CLI command

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -170,6 +170,37 @@ If this `mint update` command is not available on your local version, re-install
 
 ## Additional commands
 
+### Validate documentation build
+
+Validate your documentation build in strict mode, which exits with an error if any warnings or errors are detected. This command is designed for CI/CD pipelines to prevent broken documentation from being deployed.
+
+```bash
+mint validate
+```
+
+The command runs a full documentation build and exits with a non-zero status code if validation fails, making it ideal for automated workflows.
+
+#### Available flags
+
+- `--groups [groupname]`: Mock user groups for validation (useful when testing partial authentication)
+- `--disable-openapi`: Disable OpenAPI file generation during validation
+
+#### Example: Using in CI workflows
+
+Add the validate command to your CI pipeline to catch documentation issues before deployment:
+
+```yaml
+# GitHub Actions example
+- name: Validate documentation
+  run: npx mint validate
+```
+
+```yaml
+# With specific group validation
+- name: Validate documentation for admin group
+  run: npx mint validate --groups admin
+```
+
 ### Find broken links
 
 Identify any broken internal links with the following command:


### PR DESCRIPTION
Added documentation for the new `mint validate` command in the installation guide. This command validates documentation builds in strict mode and is designed for CI/CD pipelines to prevent broken documentation from being deployed.

## Changes
- Updated `installation.mdx` to add a new "Validate documentation build" section under "Additional commands"
- Documented available flags: `--groups` and `--disable-openapi`
- Added GitHub Actions workflow examples showing how to use the command in CI/CD pipelines

Generated from [feat: add new validate-build cli command](https://github.com/mintlify/mint/pull/5473) @rtbarnes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `mint validate` for strict documentation builds, intended for CI usage.
> 
> - Adds **Validate documentation build** section in `installation.mdx` with `mint validate` usage
> - Documents flags: `--groups [groupname]` and `--disable-openapi`
> - Provides GitHub Actions examples using `npx mint validate`, including group-specific validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ef27d425457a6161d20cfc67b9b03cdc10300c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->