### PR TITLE
Document mint validate CLI command

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -211,21 +211,6 @@ Use flags to configure the validation command.
 - `--groups [groupname]`: Mock user groups for validation (useful when testing partial authentication)
 - `--disable-openapi`: Disable OpenAPI file generation during validation
 
-<CodeGroup>
-
-```yaml GitHub Actions example
-- name: Validate documentation
-  run: npx mint validate
-```
-
-```yaml GitLab CI example
-validate-docs:
-  script:
-    - npx mint validate
-```
-
-</CodeGroup>
-
 ### Check OpenAPI spec
 
 Check your OpenAPI file for errors with the following command:


### PR DESCRIPTION
Added documentation for the new `mint validate` CLI command to the installation guide. This command validates documentation builds in strict mode and is designed for CI/CD pipelines to prevent broken documentation from being deployed.

## Files changed
- `installation.mdx` - Added new "Validate documentation build" section with command usage, available flags, and CI/CD integration examples

Generated from [feat: add new validate-build cli command](https://github.com/mintlify/mint/pull/5473) @rtbarnes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces documentation for validating builds in strict mode, intended for CI/CD.
> 
> - Adds a new "Validate documentation build" section in `installation.mdx` describing `mint validate`
> - Documents flags: `--groups [groupname]` and `--disable-openapi`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3156ac6ea52c24fb5f979d4b3d68ef5c21bee3c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->