### PR TITLE
Add hello card with library icon to quickstart page

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -135,6 +135,9 @@ Find your exact URL on the **Overview** page of your [dashboard](https://dashboa
 
 ## Next steps
 
+<Card title="Hello" icon="library">
+</Card>
+
 <Card title="Use the web editor" icon="mouse-pointer-2" horizontal href="/editor/index">
   Edit documentation in your browser and preview how your pages will look when published.
 </Card>


### PR DESCRIPTION
Added a new card component to the quickstart page with "Hello" title and library icon from Lucide. The card was placed in the "Next steps" section alongside existing cards.

Files changed:
- quickstart.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an additional callout in the Quickstart guide’s Next steps.
> 
> - Adds a new `Card` titled `"Hello"` with `icon="library"` to `quickstart.mdx` under **Next steps**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c91db068a7704dd618f86df1f0fbc67287c732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->