### PR TITLE
Document per-page locale links feature

### DIFF
--- a/guides/internationalization.mdx
+++ b/guides/internationalization.mdx
@@ -129,6 +129,62 @@ To add global navigation elements that appear across all languages, configure th
 }
 ```
 
+### External URLs for language switcher
+
+For multi-domain documentation setups where different locales are hosted on separate domains, you can configure external URLs in the language switcher. This is useful when not all pages exist in all locales or when you maintain separate documentation sites per region.
+
+Configure default external URLs in your `docs.json`:
+
+```json docs.json
+{
+  "navigation": {
+    "global": {
+      "languages": [
+        {
+          "language": "en",
+          "default": true,
+          "href": "https://developers.example.com/docs"
+        },
+        {
+          "language": "de",
+          "href": "https://developers.example.de/docs"
+        },
+        {
+          "language": "fr",
+          "href": "https://developers.example.fr/docs"
+        },
+        {
+          "language": "es",
+          "href": "https://developers.example.es/docs"
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Per-page locale links
+
+Override the default language switcher URLs for specific pages using frontmatter. This allows you to link directly to the translated version of the current page instead of the homepage.
+
+Add locale-specific links to your page frontmatter using the pattern `{language_code}_link`:
+
+```mdx api-reference/introduction.mdx
+---
+title: "API Introduction"
+description: "Get started with our API"
+de_link: "https://developers.example.de/docs/api-reference/introduction"
+fr_link: "https://developers.example.fr/docs/api-reference/introduction"
+es_link: "https://developers.example.es/docs/api-reference/introduction"
+---
+```
+
+When a user switches languages on this page, they will be directed to the specific translated page URL instead of the default `href` configured in `docs.json`. This is particularly useful for:
+
+- Multi-domain documentation where each locale has its own domain
+- Documentation sites where not all pages are translated
+- Linking to equivalent pages across different documentation systems
+
 ## Maintain translations
 
 Keep translations accurate and synchronized with your source content.


### PR DESCRIPTION
Added documentation for the new per-page locale links feature that allows users to override language switcher URLs using frontmatter. This enables multi-domain documentation setups where different locales are hosted on separate domains.

## Files changed
- `guides/internationalization.mdx` - Added section on external URLs for language switcher and per-page locale links configuration

Generated from [feat: support local-based external urls for language switcher](https://github.com/mintlify/mint/pull/5480) @rtbarnes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates internationalization guide with new language switcher configuration options.
> 
> - **External URLs:** Documents `navigation.global.languages` in `docs.json` with `href` and `default` to point languages to external domains
> - **Per-page overrides:** Introduces `{language_code}_link` frontmatter to route the switcher to specific translated page URLs
> - Clarifies use cases like multi-domain locales and partial translations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c347e461aae28d22cb2df1eeb474d7ba7c3ad28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->