### PR TITLE
Update terminology: partial authentication → group-based access control

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -211,7 +211,7 @@ mint validate
 
 Use flags to configure the validation command.
 
-- `--groups [groupname]`: Mock user groups for validation (useful when testing partial authentication)
+- `--groups [groupname]`: Mock user groups for validation (useful when testing group-based access control)
 - `--disable-openapi`: Disable OpenAPI file generation during validation
 
 ### Check OpenAPI spec


### PR DESCRIPTION
Updated the CLI documentation to replace outdated "partial authentication" terminology with "group-based access control" to align with recent backend changes that removed the partial auth concept.

**Files changed:**
- `installation.mdx` - Updated two instances where `--groups` flag documentation referenced "partial authentication"

Generated from [leyland/remove partial auth from model](https://github.com/mintlify/server/pull/3319) @yangleyland

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns CLI docs with current auth model terminology.
> 
> - In `installation.mdx`, updated `--groups [groupname]` descriptions from “partial authentication” to “group-based access control” in the "Preview as a specific group" and "Validate documentation build" sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c2813630381a1e8779f2218b0b1454830294eff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->