### PR TITLE
Document markdown support in Frame captions

### DIFF
--- a/components/frames.mdx
+++ b/components/frames.mdx
@@ -62,6 +62,18 @@ Add text that precedes the frame using the optional `hint` prop. Hints appear ab
 </Frame>
 ```
 
+```mdx Frame with markdown in caption
+<Frame caption="Visit the [documentation](/docs) for more details">
+  <img src="/path/image.jpg" alt="Descriptive alt text" />
+</Frame>
+```
+
+```mdx Frame with bold text and links in caption
+<Frame caption="**Note:** See the [official guide](https://example.com) for setup instructions">
+  <img src="/path/image.jpg" alt="Descriptive alt text" />
+</Frame>
+```
+
 ```mdx Frame with a hint
 <Frame hint="Hint text">
   <img src="/path/image.jpg" alt="Descriptive alt text" />


### PR DESCRIPTION
Added documentation for the new markdown formatting support in Frame component captions. This includes examples of using links and bold text in captions, updated property descriptions, and additional code examples.

**Files changed:**
- `components/frames.mdx` - Added markdown support section with examples and updated property documentation

Generated from [added md support for captions](https://github.com/mintlify/mint/pull/5585) @ruhanponnada

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Updates docs for `Frame` captions with markdown support.**
> 
> - Adds a new "Markdown in captions" section with examples (links, bold text)
> - Updates `caption` property description to state it supports markdown formatting
> - Adds new `CodeGroup` examples demonstrating markdown usage in captions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01c92e1967f681421c640b2df04d79af35399afc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->