### PR TITLE
Add layout shift warnings

### DIFF
--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -22,6 +22,10 @@ Tailwind CSS arbitrary values are not supported. For custom values, use the `sty
 <img style={{ width: '350px', margin: '12px auto' }} src="/path/image.jpg" />
 ```
 
+<Warning>
+  Using the `style` prop can cause a layout shift on page load, especially on custom mode pages. Use Tailwind CSS classes or custom CSS files instead to avoid shifts or flickering.
+</Warning>
+
 ## Custom CSS
 
 Add CSS files to your repository and their defined class names will be applied and available in all of your MDX files.

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -100,6 +100,10 @@ mode: "custom"
 ---
 ```
 
+<Warning>
+  Using the `style` property on custom mode pages can cause a layout shift on page load. Use [Tailwind CSS or custom CSS](/customize/custom-scripts) instead to avoid this issue.
+</Warning>
+
 ### Frame
 
 Frame mode provides a layout similar to custom mode, but preserves the sidebar navigation. This page mode allows for custom HTML and components while maintaining the default navigation experience. Frame mode is only available for Aspen and Almond themes.


### PR DESCRIPTION
## Documentation changes

This PR adds warnings to help people avoid layout shifts.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds warning callouts to documentation to caution against using inline `style` due to potential layout shifts, recommending Tailwind classes or custom CSS instead.
> 
> - Inserted `<Warning>` in `customize/custom-scripts.mdx` about `style` causing shifts/flicker, advising Tailwind/custom CSS
> - Added `<Warning>` in `organize/pages.mdx` for custom mode pages, linking to styling guidance
> 
> Docs-only change; no code or API modifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d60d9ae1310fa565fedda8fb8497441099f5c438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->