### PR TITLE
Include link to icon library param in icon snippets

### DIFF
--- a/snippets/icons-optional.mdx
+++ b/snippets/icons-optional.mdx
@@ -2,8 +2,8 @@
   The icon to display.
 
   Options:
-  - [Font Awesome](https://fontawesome.com/icons) icon name (for example, `github`)
-  - [Lucide](https://lucide.dev/icons) icon name (for example, `rocket`)
+  - [Font Awesome](https://fontawesome.com/icons) icon name, if you have the `icons.library` [property](/organize/settings#param-icons) set to `fontawesome` in your `docs.json`
+  - [Lucide](https://lucide.dev/icons) icon name, if you have the `icons.library` [property](/organize/settings#param-icons) set to `lucide` in your `docs.json`
   - URL to an externally hosted icon
   - Path to an icon file in your project
   - SVG code wrapped in curly braces

--- a/snippets/icons-required.mdx
+++ b/snippets/icons-required.mdx
@@ -2,18 +2,10 @@
   The icon to display.
   
   Options:
-  - [Font Awesome icon](https://fontawesome.com/icons) name
-  - [Lucide icon](https://lucide.dev/icons) name
-  - JSX-compatible SVG code wrapped in curly braces
+  - [Font Awesome icon](https://fontawesome.com/icons) name, if you have the `icons.library` [property](/organize/settings#param-icons) set to `fontawesome` in your `docs.json`
+  - [Lucide icon](https://lucide.dev/icons) name, if you have the `icons.library` [property](/organize/settings#param-icons) set to `lucide` in your `docs.json`
   - URL to an externally hosted icon
   - Path to an icon file in your project
-  
-  For custom SVG icons:
-  1. Convert your SVG using the [SVGR converter](https://react-svgr.com/playground/).
-  1. Paste your SVG code into the SVG input field.
-  2. Copy the complete `<svg>...</svg>` element from the JSX output field.
-  3. Wrap the JSX-compatible SVG code in curly braces: `icon={<svg ...> ... </svg>}`.
-  4. Adjust `height` and `width` as needed.
 </ResponseField>
 
 <ResponseField name="iconType" type="string">


### PR DESCRIPTION
## Documentation changes

This PR includes info in icon snippets that you need to set which icon library you use in response to user feedback.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates icon snippet docs to clarify library configuration and streamline options.
> 
> - In `icons-optional.mdx` and `icons-required.mdx`, specify that Font Awesome/Lucide icon names require the `icons.library` property set in `docs.json` (with link)
> - In `icons-required.mdx`, remove the SVG option and the custom SVG instructions, keeping only URL/path options alongside library names
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abf6ea8ee06f444fe05aa93df09404427a82c3aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->