### PR TITLE
Remove hreflang tag section in internationalization guide

### DIFF
--- a/guides/internationalization.mdx
+++ b/guides/internationalization.mdx
@@ -181,10 +181,6 @@ keywords: ["démarrage", "tutoriel", "guide"]
 ---
 ```
 
-### hreflang tags
-
-Mintlify automatically generates hreflang tags for each language version of your documentation to help search engines understand the relationships between translated pages.
-
 ## Best practices
 
 ### Date and number formats


### PR DESCRIPTION
## Documentation changes

This PR removes an inaccurate section.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an inaccurate SEO subsection from the internationalization guide.
> 
> - Deletes the `### hreflang tags` section and its description from `guides/internationalization.mdx`
> - Retains other SEO guidance (e.g., translated frontmatter metadata) and best practices
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 513d94b7bb641e18dca29eb05f94f3e192672589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->