### PR TITLE
Document MCP search filtering parameters

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -12,28 +12,28 @@ The Model Context Protocol (MCP) is an open protocol that creates standardized c
 
 Your MCP server exposes a search tool for AI applications to query your documentation. Your users must connect your MCP server to their tools.
 
-### Search filtering parameters
-
-The MCP search tool supports optional filtering parameters that AI tools can use to narrow search results:
-
-- **`version`**: Filter results to a specific documentation version (e.g., `'v0.7'`). Only returns content tagged with the specified version or content available across all versions.
-- **`language`**: Filter results to a specific language code (e.g., `'en'`, `'zh'`, `'es'`). Only returns content in the specified language or content available across all languages.
-- **`apiReferenceOnly`**: When set to `true`, only returns API reference documentation pages.
-- **`codeOnly`**: When set to `true`, only returns code snippets and examples.
-
-AI tools determine when to apply these filters based on the context of the user's query. For example, if a user asks about a specific API version or requests code examples, the AI may automatically apply the appropriate filters to provide more relevant results.
-
 ### How MCP servers work
 
-When an AI tool has your documentation MCP server connected, the AI tool can search your documentation directly instead of making a generic web search in response to a user's prompt. Your MCP server provides access to all indexed content on your documentation site.
+When an AI application connects to your documentation MCP server, it can search your documentation directly instead of making a generic web search in response to a user's prompt. Your MCP server provides access to all indexed content on your documentation site.
 
-- The LLM can proactively search your documentation while generating a response, not just when explicitly asked.
-- The LLM determines when to use the search tool based on the context of the conversation and the relevance of your documentation.
-- Each tool call happens during the generation process, so the LLM searches up-to-date information from your documentation to generate its response.
+- The AI application can proactively search your documentation while generating a response, not just when explicitly asked.
+- The AI application determines when to use the search tool based on the context of the conversation and the relevance of your documentation.
+- Each search (tool call) happens during the generation process, so the AI application searches up-to-date information from your documentation to generate its response.
 
 <Tip>
   Some AI tools like Claude support both MCP and Skills. MCP gives the AI access to your documentation content, while Skills instruct the AI how to use that content effectively. They're complementary. MCP provides the data and Skills provide the instructions.
 </Tip>
+
+### Search filtering parameters
+
+The MCP search tool supports optional filtering parameters that AI applications can use to narrow search results.
+
+- **`version`**: Filter results to a specific documentation version. For example, `'v0.7'`. Only returns content tagged with the specified version or content available across all versions.
+- **`language`**: Filter results to a specific language code. For example, `'en'`, `'zh'`, or `'es'`. Only returns content in the specified language or content available across all languages.
+- **`apiReferenceOnly`**: When set to `true`, only returns API reference documentation pages.
+- **`codeOnly`**: When set to `true`, only returns code snippets and examples.
+
+AI applications determine when to apply these filters based on the context of the user's query. For example, if a user asks about a specific API version or requests code examples, the AI application may automatically apply the appropriate filters to provide more relevant results.
 
 ### MCP compared to web search
 


### PR DESCRIPTION
Added documentation for the new MCP server search filtering parameters introduced in PR #5628. The documentation explains how AI tools can use `version`, `language`, `apiReferenceOnly`, and `codeOnly` parameters to filter search results.

## Files changed
- `ai/model-context-protocol.mdx` - Added "Search filtering parameters" section describing the four new optional filter parameters

Generated from [feature: add filtering to mcp server](https://github.com/mintlify/mint/pull/5628) @densumesh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds documentation for MCP search filtering.
> 
> - New "Search filtering parameters" section describing optional `version`, `language`, `apiReferenceOnly`, and `codeOnly` filters and when AI apps may apply them
> - Clarifies phrasing in "How MCP servers work" (uses "AI application", refines proactive search and tool-call wording)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ef90d4e604ee67d6b2e30cd356b5370c2df6f3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->