### PR TITLE
Document OAuth logout redirect validation

### DIFF
--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -101,7 +101,7 @@ Your host your documentation at `docs.foo.com` and your entire team has access t
       * **Additional authorization parameters** (optional): Additional query parameters to add to the initial authorization request.
       * **Token URL**: Your OAuth token exchange endpoint.
       * **Info API URL** (optional): Endpoint on your server that Mintlify calls to retrieve user info. Required for group-based access control. If omitted, the OAuth flow only verifies identity.
-      * **Logout URL** (optional): The native logout URL for your OAuth provider. When users log out, Mintlify validates the logout redirect against this configured URL for security. The redirect only succeeds if it exactly matches the configured `logoutUrl`—otherwise, users are redirected to `/login`. Mintlify redirects users with a `GET` request and does not append query parameters, so include any parameters (for example, `returnTo`) directly in the URL.
+      * **Logout URL** (optional): The native logout URL for your OAuth provider. When users log out, Mintlify validates the logout redirect against this configured URL for security. The redirect only succeeds if it exactly matches the configured `logoutUrl`. If you do not configure a logout URL, users redirect to `/login`. Mintlify redirects users with a `GET` request and does not append query parameters, so include any parameters (for example, `returnTo`) directly in the URL.
       * **Redirect URL** (optional): The URL to redirect users to after authentication.
     5. Click **Save changes**.
 


### PR DESCRIPTION
## Summary

Updated the OAuth authentication documentation to reflect the new logout redirect security validation feature. The Logout URL field now validates redirects against the configured URL to prevent open redirect vulnerabilities.

## Changes

- Updated `deploy/authentication-setup.mdx` to document that logout redirects are validated against the configured `logoutUrl` and only succeed on exact match, otherwise redirecting to `/login`

Generated from [fix: resolve open redirect in client auth /logout](https://github.com/mintlify/server/pull/3345) @mayankshouche

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates OAuth docs in `deploy/authentication-setup.mdx`:
> 
> - Clarifies `Logout URL` behavior: logout redirects are validated to exactly match the configured `logoutUrl`; if not configured, users are redirected to `/login`. Notes that redirects use `GET` and no query params are appended (include any needed params directly in the URL).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9218d2f870ba75153bc4c2dd2871373ed55cad6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->