### PR TITLE
Document View component duplicate title warning and behavior

### DIFF
--- a/components/view.mdx
+++ b/components/view.mdx
@@ -7,8 +7,17 @@ keywords: ["selector", "language-specific content", "content switching"]
 Use the `View` component to create content that changes based on the selected view in a multi-view dropdown. This is particularly useful for showing code examples or documentation specific to different programming languages or frameworks.
 
 <Tip>
-  Use one view component per language per page. Use [tabs](/components/tabs) for procedures that differ by language and [code groups](/components/code-groups) for code examples that differ by language.
+  Use one View component per title per page. Use [tabs](/components/tabs) for procedures that differ by language and [code groups](/components/code-groups) for code examples that differ by language.
 </Tip>
+
+<Warning>
+  Duplicate View titles on the same page are not allowed. If you use the same `title` value for multiple View components on a page, you'll see this warning and the duplicate Views will be ignored:
+
+  ```
+  ⚠️  Duplicate View title: "JavaScript"
+     Use one View component per title per page. Duplicate Views are ignored.
+  ```
+</Warning>
 
 <View title="JavaScript" icon="js">
   This content is only visible when JavaScript is selected.


### PR DESCRIPTION
Updated View component documentation to clarify title requirements and duplicate title restrictions. Added warning message details for when users have duplicate View titles on the same page.

Files changed:
- components/view.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral code modifications.
> 
> **Overview**
> Updates `View` component docs to clarify the per-page uniqueness requirement by changing guidance from “one per language” to **one per `title` per page**.
> 
> Adds a new **warning section** documenting that duplicate `View` titles on the same page are ignored and shows the exact warning message users will see.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51bd377f30cae4c19b2b7f6f3aa5396438487a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->