### PR TITLE
Update assistant embed guide for Next.js example

### DIFF
--- a/.vale/styles/Google/WordList.yml
+++ b/.vale/styles/Google/WordList.yml
@@ -28,7 +28,6 @@ swap:
   Android device: Android-powered device
   android: Android
   API explorer: APIs Explorer
-  application: app
   approx\.: approximately
   authN: authentication
   authZ: authorization

--- a/guides/assistant-embed.mdx
+++ b/guides/assistant-embed.mdx
@@ -34,7 +34,7 @@ Users can use the widget to get help with your product without leaving your appl
 3. Copy the assistant API key (starts with `mint_dsc_`) and save it securely.
 
 <Note>
-  The assistant API key is a public token that can be used in frontend code. Calls using this token count toward your plan's message allowance and can incur overages.
+  The assistant API key is a public token that you can use in frontend code. Calls using this token count toward your plan's message allowance and can incur overages.
 </Note>
 
 ## Set up the example


### PR DESCRIPTION
## Documentation changes

Dependent on https://github.com/mintlify/assistant-embed-example/pull/5

Closes https://linear.app/mintlify/issue/DOC-250/create-nextjs-version-of-assistant-embed-tutorial

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to setup instructions and linter configuration; no runtime or API behavior changes.
> 
> **Overview**
> Updates the `assistant-embed` guide to better match the example repo by splitting setup into clearer steps and explicitly supporting both **Next.js** and **Vite** via a `CodeGroup`, plus minor wording/formatting tweaks.
> 
> Adjusts Vale’s Google wordlist to stop suggesting `app` in place of `application` by removing that substitution entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a378624c14ce7338394e13613621e20a03467392. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->