### PR TITLE
Rename "custom" to "enterprise"

### DIFF
--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -7,11 +7,11 @@ keywords: ["support", "CSM", "enterprise"]
 ## Support options
 
 - All customers receive support via dashboard or support@mintlify.com (24-48 hour response)
-- Custom plan customers can add Advanced Slack support (24-hour response) or a dedicated CSM (4-hour response + strategic partnership)
+- Enterprise plan customers can add Advanced Slack support (24-hour response) or a dedicated CSM (4-hour response + strategic partnership)
 
 ### Standard support (included)
 
-Included with all Pro and Custom plans. Submit tickets through the dashboard or email support@mintlify.com. First response within 24-48 hours.
+Included with all Pro and Enterprise plans. Submit tickets through the dashboard or email support@mintlify.com. First response within 24-48 hours.
 
 ### Advanced Slack support (Add-on)
 
@@ -82,7 +82,7 @@ Get an assigned Customer Success Manager who knows your team, setup, and goals.
 
 <AccordionGroup>
   <Accordion title="What's the difference between advanced Slack support and standard support?">
-    Standard support (included with Pro and Custom plans) is delivered via the dashboard or support@mintlify.com with a 24-48 hour response SLA. Advanced Slack support includes:
+    Standard support (included with Pro and Enterprise plans) is delivered via the dashboard or support@mintlify.com with a 24-48 hour response SLA. Advanced Slack support includes:
 
     - Dedicated Slack channel versus email/dashboard support
     - 24-hour response SLA versus 24-48 hours for standard support

--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -5,7 +5,7 @@ keywords: ["automation", "automate", "AI", "autoupdate", "maintenance"]
 ---
 
 <Info>
-  The agent is available on [Pro and Custom plans](https://mintlify.com/pricing?ref=agent) for anyone with access to your dashboard.
+  The agent is available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=agent) for anyone with access to your dashboard.
 </Info>
 
 The agent creates pull requests with proposed changes to your documentation based on your prompts. When you send a request to the agent, it references your documentation, connected repositories, and Slack messages to create content that follows technical writing best practices and adheres to the Mintlify schema.

--- a/agent/suggestions.mdx
+++ b/agent/suggestions.mdx
@@ -5,7 +5,7 @@ keywords: ["automation", "documentation gaps", "self updating", "self-updating",
 ---
 
 <Note>
-  Agent suggestions are available on [Custom plans](https://mintlify.com/pricing?ref=autopilot). To enable suggestions for your organization, [contact our sales team](mailto:gtm@mintlify.com). 
+  Agent suggestions are available on [Enterprise plans](https://mintlify.com/pricing?ref=autopilot). To enable suggestions for your organization, [contact our sales team](mailto:gtm@mintlify.com). 
 </Note>
 
 You can allow the agent to suggest documentation updates from two sources.

--- a/ai/assistant.mdx
+++ b/ai/assistant.mdx
@@ -5,7 +5,7 @@ keywords: ["chat", "RAG", "user support"]
 ---
 
 <Info>
-  The assistant is automatically enabled on [Pro and Custom plans](https://mintlify.com/pricing?ref=assistant).
+  The assistant is automatically enabled on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=assistant).
 </Info>
 
 ## About the assistant
@@ -38,7 +38,7 @@ You can [set a deflection email](/ai/assistant#set-deflection-email) so that the
 
 ## Configure the assistant
 
-The assistant is active on Pro and Custom plans by default.
+The assistant is active on Pro and Enterprise plans by default.
 
 Manage the assistant from the [Assistant Configurations](https://dashboard.mintlify.com/products/assistant/settings) page of your dashboard. Enable or disable the assistant, configure response handling, add default questions, and manage your message allowance.
 

--- a/ai/discord.mdx
+++ b/ai/discord.mdx
@@ -5,7 +5,7 @@ keywords: ["Discord", "bot", "Q&A", "customer support"]
 ---
 
 <Info>
-  Discord integrations are available on [Pro and Custom plans](https://mintlify.com/pricing?ref=discord) with access to the assistant.
+  Discord integrations are available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=discord) with access to the assistant.
 </Info>
 
 The Discord bot supports your community with real-time answers from your documentation. The bot uses the Mintlify assistant to search your docs and provide accurate, cited responses, so it is always up-to-date.

--- a/create/files.mdx
+++ b/create/files.mdx
@@ -25,7 +25,7 @@ Supported file types for all plans:
 - **Scripts**: `.js`
 - **Fonts**: `.woff`, `.woff2`, `.ttf`, `.eot`
 
-Supported file types for Custom plans:
+Supported file types for Enterprise plans:
 - **Documents**: `.pdf`, `.txt`
 - **Data**: `.xml`, `.csv`
 - **Archives**: `.zip`

--- a/dashboard/audit-logs.mdx
+++ b/dashboard/audit-logs.mdx
@@ -5,7 +5,7 @@ keywords: ["monitoring", "activity tracking", "security", "compliance"]
 ---
 
 <Info>
-  Audit logs are available on [Custom plans](https://mintlify.com/pricing?ref=audit-logs).
+  Audit logs are available on [Enterprise plans](https://mintlify.com/pricing?ref=audit-logs).
 </Info>
 
 Use audit logs to monitor and track actions performed by members of your organization. Audit logs provide a record of activities for security, compliance, and troubleshooting purposes.

--- a/dashboard/roles.mdx
+++ b/dashboard/roles.mdx
@@ -5,7 +5,7 @@ keywords: ["RBAC", "role-based access control", "Admin", "permissions"]
 ---
 
 <Info>
-  RBAC functionality is available on [Custom plans](https://mintlify.com/pricing?ref=rbac).
+  Role based access control (RBAC) is available on [Enterprise plans](https://mintlify.com/pricing?ref=rbac).
 </Info>
 
 Mintlify provides two dashboard access levels: Editor and Admin.

--- a/dashboard/sso.mdx
+++ b/dashboard/sso.mdx
@@ -5,7 +5,7 @@ keywords: ["SAML authentication", "OIDC", "Okta integration", "identity provider
 ---
 
 <Info>
-  SSO functionality is available on [Custom plans](https://mintlify.com/pricing?ref=sso).
+  SSO is available on [Enterprise plans](https://mintlify.com/pricing?ref=sso).
 </Info>
 
 Use single sign-on to your dashboard via SAML and OIDC. If you use Okta, Google Workspace, or Microsoft Entra, we have provider-specific documentation for setting up SSO. If you use another provider, please [contact us](mailto:support@mintlify.com).

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -7,7 +7,7 @@ keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 <Info>
   [Pro plans](https://mintlify.com/pricing?ref=authentication) include password authentication.
 
-  [Custom plans](https://mintlify.com/pricing?ref=authentication) include all authentication methods.
+  [Enterprise plans](https://mintlify.com/pricing?ref=authentication) include all authentication methods.
 </Info>
 
 Authentication requires users to log in before accessing your documentation.

--- a/deploy/ci.mdx
+++ b/deploy/ci.mdx
@@ -5,7 +5,7 @@ keywords: ["continuous integration", "CI/CD", "checks", "Vale", "linter"]
 ---
 
 <Info>
-  [Pro and Custom plans](https://mintlify.com/pricing?ref=docs-ci) include CI checks for GitHub repositories.
+  [Pro and Enterprise plans](https://mintlify.com/pricing?ref=docs-ci) include CI checks for GitHub repositories.
 </Info>
 
 Use CI checks to lint your docs for errors and provide warnings before you deploy. Mintlify CI checks run on pull requests against a configured deployment branch.

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -5,7 +5,7 @@ keywords: ["preview URLs", "pull request previews", "branch previews", "staging 
 ---
 
 <Info>
-  Preview deployments are available on [Pro and Custom plans](https://mintlify.com/pricing?ref=preview-deployments).
+  Preview deployments are available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=preview-deployments).
 </Info>
 
 Preview deployments let you see how changes to your docs will look before merging to production. Each preview creates a shareable URL that updates automatically as you push new changes. 

--- a/deploy/reverse-proxy.mdx
+++ b/deploy/reverse-proxy.mdx
@@ -5,7 +5,7 @@ keywords: ["reverse proxy configuration","nginx","proxy routing","header forward
 ---
 
 <Note>
-  Reverse proxy configurations are only supported for [Custom plans](https://mintlify.com/pricing?ref=reverse-proxy).
+  Reverse proxy configurations are only supported for [Enterprise plans](https://mintlify.com/pricing?ref=reverse-proxy).
 </Note>
 
 To serve your documentation through a custom reverse proxy, you must configure routing rules, caching policies, and header forwarding.

--- a/guides/assistant-embed.mdx
+++ b/guides/assistant-embed.mdx
@@ -21,7 +21,7 @@ Users can use the widget to get help with your product without leaving your appl
 
 ## Prerequisites
 
-- [Mintlify Pro or Custom plan](https://mintlify.com/pricing)
+- [Mintlify Pro or Enterprise plan](https://mintlify.com/pricing)
 - Your domain name, which appears at the end of your dashboard URL. For example, if your dashboard URL is `https://dashboard.mintlify.com/org-name/domain-name`, your domain name is `domain-name`
 - An [assistant API key](https://dashboard.mintlify.com/settings/organization/api-keys)
 - Node.js v18 or higher and npm installed

--- a/guides/automate-agent.mdx
+++ b/guides/automate-agent.mdx
@@ -36,7 +36,7 @@ GitHub Actions is the simplest option if your code is already on GitHub. No addi
 - [Mintlify GitHub App](/deploy/github) installed in both your code and documentation repositories
 - [Mintlify admin API key](https://dashboard.mintlify.com/settings/organization/api-keys)
 - [Mintlify project ID](https://dashboard.mintlify.com/settings/organization/api-keys)
-- [Mintlify Pro or Custom plan](https://mintlify.com/pricing)
+- [Mintlify Pro or Enterprise plan](https://mintlify.com/pricing)
 - Admin access to the GitHub repositories for your code and documentation
 
 ### Install the Mintlify app on your code repository
@@ -202,7 +202,7 @@ n8n provides a visual workflow editor and can integrate with multiple services.
 ## Prerequisites
 
 - n8n workspace
-- [Mintlify Pro or Custom plan](https://mintlify.com/pricing)
+- [Mintlify Pro or Enterprise plan](https://mintlify.com/pricing)
 - Mintlify app installed on your code repository
 - Mintlify admin API key
 - Admin access to the GitHub repositories for your code and documentation

--- a/guides/knowledge-base.mdx
+++ b/guides/knowledge-base.mdx
@@ -173,7 +173,7 @@ Move your exported content into a folder structure that matches the navigation s
 
 ## Set up the assistant
 
-The assistant is automatically enabled for Pro and Custom plans. The assistant lets your team ask questions and get answers with cited sources from your knowledge base.
+The assistant is automatically enabled for Pro and Enterprise plans. The assistant lets your team ask questions and get answers with cited sources from your knowledge base.
 
 Configure the assistant from your [dashboard](https://dashboard.mintlify.com/products/assistant/settings):
 

--- a/optimize/pdf-exports.mdx
+++ b/optimize/pdf-exports.mdx
@@ -14,7 +14,7 @@ export const DownloadPDFButton = () => {
 }
 
 <Info>
-PDF exports are available on [Custom plans](https://mintlify.com/pricing).
+PDF exports are available on [Enterprise plans](https://mintlify.com/pricing).
 </Info>
 
 You can export your docs as a single PDF file for offline viewing. The PDF will contain all the content in the docs, including images and links, and a navigable table of contents.


### PR DESCRIPTION
## Documentation changes

This PR updates `Custom plan` to `Enterprise plan`

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates; primary risk is incorrect plan entitlement messaging or missed occurrences.
> 
> **Overview**
> Updates docs plan/tier references to reflect a rename from **Custom** to **Enterprise** across support and product feature pages.
> 
> This changes availability/prerequisite copy for the agent (including suggestions), assistant (including Discord integration and embed guide), audit logs, RBAC, SSO, authentication methods, CI checks, preview deployments, reverse proxy support, PDF exports, and supported file types, aligning all affected pages to the new plan naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be73f347989c9dd2bf2532690a3e10e90f79e80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->