### PR TITLE
Add note that anchors aren't supported in redirects

### DIFF
--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -8,6 +8,10 @@ When you change the path of a file in your docs folder, it also changes the URL 
 
 ## Redirects
 
+<Note>
+  Redirects **cannot** include URL anchors like `path#anchor` or query parameters like `path?query=value`.
+</Note>
+
 Set up 301 redirects by adding the `redirects` field to your `docs.json` file.
 
 ```json


### PR DESCRIPTION
## Documentation changes

See title

Closes https://linear.app/mintlify/issue/DOC-208/document-limitation-docsjson-redirects-dont-support-anchor-fragments

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Updates the `Redirects` documentation to explicitly call out a limitation: redirect `source`/`destination` values **cannot** include URL fragments (anchors) or query parameters.
> 
> Adds a short `<Note>` near the top of `create/redirects.mdx` to prevent users from attempting unsupported redirect formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d02884baafc42fd760ff06a588e9350b79a8ce79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->