### PR TITLE
Clarify API key requirements on endpoint pages

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -317,7 +317,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Create an [Admin API Key](https://dashboard.mintlify.com/settings/organization/api-keys) here."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://dashboard.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     }
   }

--- a/analytics.openapi.json
+++ b/analytics.openapi.json
@@ -16,7 +16,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. See the [API authentication](/api/introduction#authentication) documentation for details on how to get your API key."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://dashboard.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     },
     "schemas": {

--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -28,7 +28,7 @@ function MyComponent({ domain }) {
   const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
     api: `https://api.mintlify.com/discovery/v1/assistant/${domain}/message`,
     headers: {
-      'Authorization': `Bearer ${process.env.MINTLIFY_TOKEN}`,
+      'Authorization': `Bearer ${process.env.PUBLIC_MINTLIFY_ASSISTANT_KEY}`,
     },
     body: {
       fp: 'anonymous',

--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -34,11 +34,11 @@ You can create up to 10 API keys per hour per organization.
 
 ### Admin API key
 
-Use the admin API key to authenticate requests to [Trigger update](/api-reference/update/trigger), [Get update status](/api-reference/update/status), and all agent endpoints.
+Use the admin API key to authenticate requests to [Trigger update](/api-reference/update/trigger), [Get update status](/api-reference/update/status), [Create agent job](/api-reference/agent/create-agent-job), [Get agent job](/api-reference/agent/get-agent-job), [Get all agent jobs](/api-reference/agent/get-all-jobs), [Get user feedback](/api-reference/analytics/feedback), and [Get assistant conversations](/api-reference/analytics/assistant-conversations).
 
-Admin API keys begin with the `mint_` prefix. Keep your admin API keys secret.
+Admin API keys begin with the `mint_` prefix. 
 
-The admin API key is a server-side token. Keep it secret.
+The admin API key is a server-side secret. Do not expose it in client-side code.
 
 ### Assistant API key
 

--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -510,7 +510,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. See the [API authentication](/api/introduction#authentication) documentation for details on how to get your API key."
+        "description": "The Authorization header expects a Bearer token. Use an assistant API key (prefixed with `mint_dsc_`). This is a public key safe for use in client-side code. Generate one on the [API keys page](https://dashboard.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -198,7 +198,8 @@
     "securitySchemes": {
       "bearerAuth": {
         "type": "http",
-        "scheme": "bearer"
+        "scheme": "bearer",
+        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://dashboard.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     }
   }


### PR DESCRIPTION
## Documentation changes

This PR includes more information on API keys in the API spec descriptions so that users don't need to navigate to another page when learning about endpoints.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (OpenAPI descriptions and MDX examples) with no runtime behavior impact; main risk is confusing users if key guidance is inaccurate.
> 
> **Overview**
> Clarifies authentication requirements across the OpenAPI specs by adding/expanding `bearerAuth` descriptions, explicitly calling out **admin** keys (`mint_`, server-side secret) for admin/analytics endpoints and **assistant** keys (`mint_dsc_`, public) for discovery endpoints.
> 
> Updates API docs to better map endpoints to the correct key type (including analytics export and agent endpoints) and adjusts the `useChat` assistant integration example to use `PUBLIC_MINTLIFY_ASSISTANT_KEY` instead of a generic token env var.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48d86e71423fd2080a263842d7d37d7b5a74029d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->