### PR TITLE
Document v2 assistant endpoint for AI SDK v5

### DIFF
--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -157,8 +157,20 @@ function MyComponent({ domain }) {
   - `value` - The code snippet or selected text content.
   - `elementId` (optional) - Identifier for the UI element containing the context.
 
+**Message format:**
+The v1 endpoint uses a custom message format with `prompt` and `response` fields:
+```typescript
+{
+  prompt: string,
+  response?: string
+}
+```
+
 </Step>
 </Steps>
+
+</Tab>
+</Tabs>
 
 See [useChat](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) in the AI SDK documentation for more details.
 


### PR DESCRIPTION
Added documentation for the new v2 assistant endpoint that natively supports AI SDK v5. Updated the integration guide with tabbed examples showing both v1 (AI SDK v4) and v2 (AI SDK v5) endpoints with their respective message formats.

## Files changed
- `api/assistant/create-assistant-message.mdx` - Added v2 endpoint documentation, tabbed code examples for both SDK versions, and clarified message format differences

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no production code or API behavior is modified.
> 
> **Overview**
> Documents the new **v2** assistant message endpoint (`/discovery/v2/assistant/:domain/message`) with a `useChat` example targeting **AI SDK v5**, including required config (`streamProtocol: 'data'`) and the v5 `role`/`content` message format.
> 
> Updates the existing **v1** guidance by splitting the page into tabs for AI SDK v4 vs v5, clarifying that v1 needs a custom transport for AI SDK v5 and explicitly documenting the v1 `prompt`/`response` message shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a4fe986dcb394965d41f063d385494d227d104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->