### PR TITLE
Add docs.content.md.view analytics event

### DIFF
--- a/integrations/analytics/overview.mdx
+++ b/integrations/analytics/overview.mdx
@@ -636,7 +636,7 @@ All tracked events use the `docs.` prefix.
 | Event name                              | Description                                                                                               |
 | :-------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
 | `docs.content.view`                     | User views a page. Only sent to providers that don't track page views by default. |
-| `docs.content.md.view`                  | User views markdown content specifically.                                                          |
+| `docs.content.md.view`                  | User views Markdown version of a page.                                                          |
 | `docs.navitem.click`                    | User clicks a header navigation item.                                                              |
 | `docs.navitem.cta_click`                | User clicks a call to action button.                                                                      |
 | `docs.footer.powered_by_mintlify_click` | User clicks the "Powered by Mintlify" link.                                                        |


### PR DESCRIPTION
Added the new `docs.content.md.view` analytics event to the tracked events documentation. This event tracks when users view markdown content specifically.

## Files changed
- `integrations/analytics/overview.mdx` - Added `docs.content.md.view` event to the Navigation and page views section

Generated from [feature: add new content markdown view request](https://github.com/mintlify/mint/pull/5750) @densumesh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or data-handling impact.
> 
> **Overview**
> Adds `docs.content.md.view` to the analytics *Tracked events* documentation, describing a new event emitted when users view the Markdown version of a page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6468803bdb0aaf886759cc1827f93cccee22cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->