### PR TITLE
Clarify docs for manual API endpoint frontmatter behavior

### DIFF
--- a/api-playground/mdx-setup.mdx
+++ b/api-playground/mdx-setup.mdx
@@ -10,12 +10,13 @@ You can manually define API endpoints in individual MDX pages. This approach is 
 
 <Steps>
   <Step title="Configure your API settings">
+    
     In your `docs.json` file, define your base URL and authentication method.
 
-    ```json
+    ```json Example docs.json
     "api": {
       "mdx": {
-        "server": "https://mintlify.com/api",
+        "server": "https://api.acme.com/",
         "auth": {
           "method": "key",
           "name": "x-api-key"
@@ -43,19 +44,20 @@ You can manually define API endpoints in individual MDX pages. This approach is 
     ```mdx
     ---
     title: 'Create new user'
-    api: 'POST https://api.mintlify.com/user'
+    api: 'POST /v1/users'
     ---
     ```
+
+    The `api` frontmatter field accepts either a full URL or a relative path:
+
+    - **Full URL** like `POST https://api.acme.com/v1/users`. The `server` field in `docs.json` is ignored for that endpoint.
+    - **Relative path** like `POST /v1/users`. Requires a `server` field in `docs.json`. The server URL is prepended to the path.
 
     Specify path parameters by wrapping them in `{}`:
 
     ```bash
     https://api.example.com/v1/endpoint/{userId}
     ```
-
-    <Tip>
-      If you have a `server` field configured in `docs.json`, you can use relative paths like `/v1/endpoint`.
-    </Tip>
 
     To override the global playground display mode for a specific page, add `playground` to the frontmatter:
 

--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -845,7 +845,7 @@ This section contains the full reference for the `docs.json` file.
           </Expandable>
         </ResponseField>
         <ResponseField name="server" type="string or array">
-          Server configuration for API requests.
+          Base URL prepended to relative paths in page-level `api` frontmatter fields. Not used when the frontmatter contains a full URL.
         </ResponseField>
       </Expandable>
     </ResponseField>


### PR DESCRIPTION
## Documentation changes

This PR clarifies the behavior of the `api` field prepending the API URL to manual MDX endpoints.

Closes https://linear.app/mintlify/issue/DOC-212/clarify-docs-for-manual-api-endpoint-frontmatter-behavior

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates and example tweaks; no product logic changes.
> 
> **Overview**
> Clarifies manual MDX API endpoint documentation to explain how page-level `api` frontmatter is resolved: full URLs bypass the global `api.mdx.server`, while relative paths require it and get the base URL prepended.
> 
> Updates examples to use a generic `api.acme.com` base URL and shows relative-path endpoint syntax, and adjusts the `docs.json` settings reference to describe `server` as a base URL for relative paths (ignored for full URLs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3bd465da98559ce27ffd7b558ebd582dda56b42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->