### PR TITLE
Add deprecated label to v1 create assistant message

### DIFF
--- a/api/assistant/create-assistant-message.mdx
+++ b/api/assistant/create-assistant-message.mdx
@@ -1,7 +1,9 @@
 ---
 openapi: /discovery-openapi.json POST /v1/assistant/{domain}/message
+tag: "Deprecated"
 keywords: [ "assistant message", "embed", "chat", "integrate", "ai sdk v4" ]
 ---
+<Badge color="orange">Deprecated</Badge>
 
 <Info>
   The assistant message v1 endpoint is compatible with **AI SDK v4**. If you use AI SDK v5 or later, use the [assistant message v2 endpoint](/api-reference/assistant/create-assistant-message-v2) instead.


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a deprecation label and guidance, with no runtime or API behavior impact.
> 
> **Overview**
> Marks the `POST /v1/assistant/{domain}/message` documentation as **Deprecated** by adding frontmatter `tag: "Deprecated"` and a visible `Deprecated` badge, while directing readers to the v2 endpoint for AI SDK v5+ usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c37c721f258f58a21f7b1b92ca6e04caf39f37fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->