### PR TITLE
Fix french documentation warning component

### DIFF
--- a/fr/api-playground/complex-data-types.mdx
+++ b/fr/api-playground/complex-data-types.mdx
@@ -16,7 +16,7 @@ Pour les types de données complexes, OpenAPI propose des mots-clés pour combin
 - `anyOf` : Accepte des données correspondant à l’un des schémas fournis. Fonctionne comme un opérateur « or ».
 - `oneOf` : Accepte des données correspondant exactement à un seul des schémas fournis. Fonctionne comme un opérateur « exclusive-or ».
 
-<Avertissement>Mintlify traite `oneOf` et `anyOf` de la même manière, car la différence pratique influe rarement sur l’utilisation de l’API.</Avertissement>
+<Warning>Mintlify traite `oneOf` et `anyOf` de la même manière, car la différence pratique influe rarement sur l’utilisation de l’API.</Warning>
 
 Pour des spécifications détaillées de ces mots-clés, consultez la [documentation OpenAPI](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/).
 


### PR DESCRIPTION
## Documentation changes
Somehow this component got translated when it shouldn't have been, this fixes <Avertissement> to <Warning>.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation-only component tag change with no runtime or data/security impact.
> 
> **Overview**
> Fixes the French `complex-data-types.mdx` doc to use the correct Mintlify admonition component by changing the translated `<Avertissement>` tag to the expected `<Warning>` tag, ensuring the warning renders properly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a9079fce50fff225e3d71e63838fb4e385cfcf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->