### PR TITLE
Editor page links

### DIFF
--- a/editor/collaborate.mdx
+++ b/editor/collaborate.mdx
@@ -40,7 +40,7 @@ Use pull requests to propose changes and collaborate with your team before mergi
 
 ## Preview deployments
 
-Preview deployments create temporary URLs where you can see your changes before they go live.
+Preview deployments create temporary URLs where you can see your rendered changes before they go live. Use preview deployments to gather feedback on how changes.
 
 ### Access preview deployments
 
@@ -63,7 +63,7 @@ Preview URLs are publicly accessible by default. Enable preview authentication i
 
 ## Share editor links
 
-Share a direct link to a specific page in the editor to quickly share a page with your teammates. Editor links require organization access and are used to collaborate on updates.
+Share a direct link to a specific page in the editor with your teammates. Use editor links to collaborate on updates and make changes to pages.
 
 When you open a page, the editor saves the path in the URL. Copy the URL from your browser's address bar to share it with teammates who have access to the editor.
 


### PR DESCRIPTION
## Documentation changes

Document that you can share links to specific pages in the editor

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; main risk is minor confusion if the editor URL format or behavior differs from what’s described.
> 
> **Overview**
> Updates `editor/collaborate.mdx` metadata to mention/share keywords for shareable editor links.
> 
> Adds a new **Share editor links** section documenting URL deep links to open a specific file/branch in the web editor (with an example and tip), and tweaks the preview deployment description to emphasize rendered previews.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7631c892b40a1832bd74b308d49a1d92cf3fa14f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->