### PR TITLE
Add tab sync example

### DIFF
--- a/components/tabs.mdx
+++ b/components/tabs.mdx
@@ -54,11 +54,11 @@ Use tabs to organize content into multiple panels that users can switch between.
 </Tabs>
 ````
 
-Tabs automatically synchronize with other tabs and [code groups](/components/code-groups) on the same page when their labels match. When you select a tab, all other tabs and code groups with the same label update to match your selection.
+Tabs with matching titles stay in sync across the page. For example, if you have multiple tab groups that include a `JavaScript` tab title, selecting `JavaScript` in one tab group automatically selects `JavaScript` in the others. This helps users who choose a language or framework once see that choice reflected everywhere. Tabs also sync with [code groups](/components/code-groups) that have matching titles.
 
-Add `sync={false}` to a `<Tabs>` component to disable synchronization.
+To disable tab synchronization, add `sync={false}` to a `<Tabs>` component.
 
-```mdx Disable synchronization example
+```mdx Disable tab sync example
 <Tabs sync={false}>
   <Tab title="First tab">
     This tab group operates independently.
@@ -84,7 +84,7 @@ Add `sync={false}` to a `<Tabs>` component to disable synchronization.
 </ResponseField>
 
 <ResponseField name="sync" type="boolean" default="true">
-  When `true`, tabs synchronize with other tabs and code groups on the page that have matching labels. Set to `false` to make tabs independent.
+  When `true`, tabs synchronize with other tabs and code groups on the page that have matching titles. Set to `false` to make tabs independent.
 </ResponseField>
 
 <ResponseField name="borderBottom" type="boolean">


### PR DESCRIPTION
## Documentation changes

This PR copy edits content about tab sync and adds an example of disabling it.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (copy edits and example snippet) with no runtime code impact; risk is limited to potential confusion if the MDX example is incorrect.
> 
> **Overview**
> Updates the `Tabs` documentation to better explain *cross-page tab synchronization* using matching **titles** (including syncing with `code groups`).
> 
> Adds a concrete MDX example showing how to disable syncing via `sync={false}`, and moves the `sync` property documentation into the main **Properties** section with updated wording ("titles" vs "labels").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68cd421835d6e709742b0b3b247a174ea318ca85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->