### PR TITLE
Clarify React component import limitations in MDX

### DIFF
--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -95,7 +95,7 @@ The counter renders as an interactive React component.
 To import React components in your MDX files, the component files must be located in the `/snippets/` folder. Learn more about [reusable snippets](/create/reusable-snippets).
 
 <Note>
-Nested imports are not supported. If a React component references other components, all components must be imported directly into the parent MDX file rather than importing them within the component file itself.
+Nested imports are not supported. If a React component references other components, you must import all components directly into the parent MDX file rather than importing components within component files.
 </Note>
 
 ### Example


### PR DESCRIPTION
Added clarification that nested React component imports aren't supported in MDX files. All components referenced in JSX must be imported directly into the parent MDX page.

Files changed:
- customize/react-components.mdx

---

Created by Mintlify agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance; no runtime or behavior changes.
> 
> **Overview**
> Clarifies MDX React component usage by adding a `Note` stating that *nested component imports are not supported*.
> 
> Documentation now instructs that if a React component depends on other components, all of them must be imported directly in the parent MDX file (rather than importing within snippet/component files).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae84f756ddb5ac2728c1373731dd76f941e22d2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->