### PR TITLE
Remove unused pages feature from editor docs

### DIFF
--- a/editor/navigation.mdx
+++ b/editor/navigation.mdx
@@ -17,7 +17,7 @@ Use the navigation sidebar to organize your documentation. Changes you make in t
 
 To add a navigation element nested inside another element, click the **+** button next to the name of the parent element.
 
-After creating an element, drag and drop it to reorder or nest it within other elements. Right-click any element to configure its properties, duplicate it, hide it from navigation, or delete it.
+After creating an element, drag-and-drop it to reorder or nest it within other elements. Right-click any element to configure its properties, duplicate it, hide it from navigation, or delete it.
 
 <Note>
   Some elements cannot nest inside other elements. For example, tabs cannot nest inside groups. The web editor prevents you from nesting invalid elements.
@@ -35,8 +35,6 @@ Add files from your repository that aren't yet in navigation.
   <img src="/images/editor/add-existing-file-menu-dark.png" alt="Add existing file menu expandeda." className="hidden dark:block" />
 </Frame>
 
-You can also drag files from the **Unused pages** section directly into your navigation tree.
-
 ## Organize into sections
 
 Choose the right navigation structure for your documentation's scope and audience.
@@ -47,7 +45,7 @@ Use pages for individual documentation files. Pages are the core building blocks
 
 Pages can exist at the root level, within groups, tabs, anchors, dropdowns, or menus.
 
-If files are not in another navigation element, they appear in the **Unused pages** section. Unused pages are [hidden](/organize/hidden-pages) from your published documentation.
+Files not included in your navigation are [hidden](/organize/hidden-pages) from your published documentation.
 
 ### When to use groups
 

--- a/editor/pages.mdx
+++ b/editor/pages.mdx
@@ -12,30 +12,11 @@ Browse your documentation pages in the **Navigation** tab of the left panel.
 - Click pages to open them in the editor.
 - Click the search icon or press <kbd>Cmd</kbd> + <kbd>P</kbd> (macOS) or <kbd>Ctrl</kbd> + <kbd>P</kbd> (Windows) to search for files by filename. Search matches exact filenames, so use hyphens between words (for example, `get-agent-job` instead of `get agent job`).
 
-### View unused pages
-
-The **Unused pages** section at the bottom of the **Settings** section of the sidebar shows pages and other files that exist in your repository, but aren't included in your navigation. These are [hidden](/organize/hidden-pages) pages that don't appear on your published site until you add them to navigation.
-
 ## Create new pages
 
 1. Click the **\+** button in the navigation element where you want to add a page.
 1. Click **Add a page**.
 1. Enter a filename. The editor adds the `.mdx` extension automatically.
-
-## Add unused pages to navigation
-
-Add pages from the **Unused pages** section to your navigation.
-
-**Drag and drop:**
-
-1. Find the page in the **Unused pages** section.
-1. Drag the page to the desired location in your navigation tree.
-
-**In the navigation tree:**
-
-1. Click the plus button, <Icon icon="plus" />, where you want to add the file.
-1. Click **Add existing file**.
-1. Select the page you want to add.
 
 ## Edit content
 


### PR DESCRIPTION
## Documentation changes

This PR removes mentions of unused pages since we now show the full file tree again.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits that remove obsolete UI instructions; low risk beyond potentially missing guidance if the product behavior differs from the new text.
> 
> **Overview**
> Removes documentation for the editor’s **Unused pages** sidebar feature, including the sections describing how to view unused pages and drag/drop or add them into navigation.
> 
> Updates related wording in `editor/navigation.mdx` to reflect that files not in navigation are simply hidden, and makes minor copy edits (e.g., “drag-and-drop”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23e5b868944e3fd03adad1744ebfd2bbf0df1bd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->