### PR TITLE
Add auth note to llms.txt

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -10,6 +10,10 @@ The [llms.txt file](https://llmstxt.org) is an industry standard that helps LLMs
 
 Mintlify automatically hosts an `llms.txt` file at the root of your project that lists all available pages in your documentation. This file is always up to date and requires zero maintenance. You can optionally add a custom `llms.txt` file to the root of your project.
 
+<Note>
+  If your site requires authentication to access your documentation, your `llms.txt` and `llms-full.txt` files are not available to LLMs and AI tools. LLMs and AI tools can only index publicly available content.
+</Note>
+
 View your `llms.txt` by appending `/llms.txt` to your documentation site's URL.
 
 <PreviewButton href="https://mintlify.com/docs/llms.txt">Open the llms.txt for this site.</PreviewButton>


### PR DESCRIPTION
## Documentation changes

This PR adds a note that `llms.txt` and `llms-full.txt` require public docs to for AI tools to access

Closes https://linear.app/mintlify/issue/DOC-259/add-auth-warning-to-llmstxt-documentation-page

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact; risk is limited to wording/accuracy.
> 
> **Overview**
> Adds a prominent `<Note>` to `ai/llmstxt.mdx` warning that when a documentation site is behind authentication, `llms.txt` and `llms-full.txt` won’t be accessible/indexable by LLMs or AI tools, clarifying the public-access requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 433d16ce4b53709930c50b529cc3761c398ed6ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->