### PR TITLE
Update authentication URL references

### DIFF
--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -119,7 +119,7 @@ You host your documentation at `docs.foo.com` and your entire team has access to
 
     Mintlify calls this endpoint with the OAuth access token to retrieve user information. No additional query parameters are sent.
 
-    Add this endpoint URL to the **Info API URL** field in your [authentication settings](https://dashboard.mintlify.com/settings/deployment/authentication).
+    Add this endpoint URL to the **Info API URL** field in your [authentication settings](https://dashboard.mintlify.com/products/authentication).
   </Step>
 </Steps>
 


### PR DESCRIPTION
Updated all authentication dashboard URL references to reflect the new location at `/products/authentication` instead of `/settings/deployment/authentication`. This aligns the documentation with PR #5862 which moved the authentication page from Settings to the Products section.

## Files changed
- `deploy/authentication-setup.mdx` - Updated 6 URL references from `/settings/deployment/authentication` to `/products/authentication`

Generated from [Move authentication to main page](https://github.com/mintlify/mint/pull/5862) @handotdev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no runtime or behavioral impact; risk is limited to potential broken URLs if the new path is incorrect.
> 
> **Overview**
> Updates `deploy/authentication-setup.mdx` to replace all dashboard Authentication links from `/settings/deployment/authentication` to the new `/products/authentication` path across the password, Mintlify Auth, OAuth, and JWT setup steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f2fc57fbe96e255d34e7ca7fa250a555ff3c619. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->