### PR TITLE
Update docs for gear icon page settings

### DIFF
--- a/editor/navigation.mdx
+++ b/editor/navigation.mdx
@@ -15,9 +15,9 @@ Use the navigation sidebar to organize your documentation. Changes you make in t
   <img src="/images/editor/navigation-dark.png" alt="Add new navigation element." className="hidden dark:block" />
 </Frame>
 
-To add a navigation element nested inside another element, click the **+** button next to the name of the parent element.
+To add a navigation element nested inside another element, click the **+** plus button next to the name of the parent element.
 
-After creating an element, drag-and-drop it to reorder or nest it within other elements. Click the gear icon next to any element to configure its properties, or right-click to access additional options like duplicate, hide, or delete.
+After creating an element, drag-and-drop it to reorder or nest it within other elements. Hover over an element then click the gear icon to configure its properties, or right-click an element to access additional options like duplicate, convert to another element, or delete.
 
 <Note>
   Some elements cannot nest inside other elements. For example, tabs cannot nest inside groups. The web editor prevents you from nesting invalid elements.
@@ -103,12 +103,14 @@ Each language maintains the same navigation structure with translated content.
 
 **Add icons:**
 
-1. Click the gear icon next to a navigation item.
-2. Click the icon field.
+1. Hover over a navigation item.
+2. Click the gear icon.
+3. Click the icon field.
 
 **Add tags:**
 
-1. Click the gear icon next to a navigation item.
+1. Hover over a navigation item.
+1. Click the gear icon.
 1. Click the tag field.
 1. Enter a tag like "NEW" or "BETA" that highlights important items.
 

--- a/editor/pages.mdx
+++ b/editor/pages.mdx
@@ -62,7 +62,7 @@ See [Format text](/create/text) and [Format code](/create/code) for more informa
 
 Configure page settings to control how pages appear in navigation, search results, and your site layout.
 
-Click the gear icon next to a navigation item, or right-click a file and select **Configure**.
+Hover over a page, then click the gear icon. You can also right-click a file and select **Configure**.
 
 ### Customize navigation appearance
 


### PR DESCRIPTION
Updated documentation to reflect the new gear icon UI for accessing page settings. The gear icon is now the primary method for configuring pages, with right-click as an alternative option.

## Files changed
- `editor/pages.mdx` - Updated "Configure pages" section to mention gear icon
- `editor/navigation.mdx` - Updated navigation element configuration instructions and "Customize appearance" section to use gear icon

Generated from [Update page settings experience](https://github.com/mintlify/mint/pull/5890) @handotdev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording updates describing a UI interaction change; no product logic or behavior is modified.
> 
> **Overview**
> Updates web editor documentation to reflect the new *gear icon* flow as the primary way to configure navigation items and pages, with right-click as an alternative.
> 
> Clarifies interaction steps (hover + gear icon) for adding icons/tags and configuring elements, and updates wording around available context-menu actions (e.g., duplicate/convert/delete).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 969b824ea8a6a4cd2b209ba22b2376e4fd0f1e6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->