### PR TITLE
Hide pages behavior in editor

### DIFF
--- a/editor/pages.mdx
+++ b/editor/pages.mdx
@@ -107,4 +107,4 @@ Right-click a page and select **Delete**. Deleting a page removes it from your n
 
 ### Hide pages
 
-To remove a page from navigation without deleting the file, right-click the page and click **Hide Page**. The file remains in your repository and you can unhide the page by adding it to your `docs.json` navigation.
+To remove a page from navigation without deleting the file, enable the **Hidden** toggle in the page settings. A hidden page remains in your repository and users can still access the page by navigating directly to the page's URL. You can unhide a page in the page settings or add it to your `docs.json` navigation.


### PR DESCRIPTION
This PR updates how to hide pages in the web editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **Hide pages** section in `editor/pages.mdx` to reflect the new workflow: pages are now hidden via a **Hidden** toggle in page settings rather than a right-click **Hide Page** action.
> 
> Clarifies behavior by noting hidden pages remain in the repo, stay accessible via direct URL, and can be unhidden either in page settings or by re-adding them to `docs.json` navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38f9b363e4893270b7817dcd9930d3c227895d57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->