### PR TITLE
fix: use full s3 URLs for themes images

### DIFF
--- a/customize/themes.mdx
+++ b/customize/themes.mdx
@@ -9,7 +9,7 @@ export const ThemeCard = ({ title, value, description, href }) => {
   return (
     <a className="mt-4 gap-10 group cursor-pointer" href={href}>
       <div>
-        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`/images/themes/${value}.png`} alt={title} noZoom />
+        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`https://mintlify.s3.us-west-1.amazonaws.com/mintlify/images/themes/${value}.png`} alt={title} noZoom />
       </div>
       <div>
         <div className="mt-4 flex space-x-2 items-center">


### PR DESCRIPTION
## Documentation changes

Because the themes cards is an exported component, we have to use full S3 URLs for images.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation change affecting only image source URLs; risk is limited to broken previews if the S3 path is incorrect.
> 
> **Overview**
> Updates `customize/themes.mdx` so `ThemeCard` loads preview images from a fully-qualified S3 URL (`https://mintlify.s3...`) rather than the relative `/images/themes/...` path, ensuring images resolve when the component is exported/embedded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a74913b45cdb765654e80617421dff30aea4ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->