### PR TITLE
fix: use full s3 URLs for localized images

### DIFF
--- a/es/customize/themes.mdx
+++ b/es/customize/themes.mdx
@@ -9,7 +9,7 @@ export const ThemeCard = ({ title, value, description, href }) => {
   return (
     <a className="mt-4 gap-10 group cursor-pointer" href={href}>
       <div>
-        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`/images/themes/${value}.png`} alt={title} noZoom />
+        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`https://mintlify.s3.us-west-1.amazonaws.com/mintlify/images/themes/${value}.png`} alt={title} noZoom />
       </div>
       <div>
         <div className="mt-4 flex space-x-2 items-center">

--- a/fr/customize/themes.mdx
+++ b/fr/customize/themes.mdx
@@ -9,7 +9,7 @@ export const ThemeCard = ({ title, value, description, href }) => {
   return (
     <a className="mt-4 gap-10 group cursor-pointer" href={href}>
       <div>
-        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`/images/themes/${value}.png`} alt={title} noZoom />
+        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`https://mintlify.s3.us-west-1.amazonaws.com/mintlify/images/themes/${value}.png`} alt={title} noZoom />
       </div>
       <div>
         <div className="mt-4 flex space-x-2 items-center">

--- a/zh/customize/themes.mdx
+++ b/zh/customize/themes.mdx
@@ -9,7 +9,7 @@ export const ThemeCard = ({ title, value, description, href }) => {
   return (
     <a className="mt-4 gap-10 group cursor-pointer" href={href}>
       <div>
-        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`/images/themes/${value}.png`} alt={title} noZoom />
+        <img className="mt-0 rounded-2xl group-hover:scale-105 transition-all block" src={`https://mintlify.s3.us-west-1.amazonaws.com/mintlify/images/themes/${value}.png`} alt={title} noZoom />
       </div>
       <div>
         <div className="mt-4 flex space-x-2 items-center">


### PR DESCRIPTION
## Documentation changes

Ensures that theme images in localized documentation (es, fr, zh) are loaded from a full S3 URL instead of a relative path. This fixes an issue where images were not displaying correctly on localized versions of the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts image URLs; main risk is broken images if the S3 path changes or becomes unavailable.
> 
> **Overview**
> Switches localized `themes.mdx` pages (`es`, `fr`, `zh`) to load theme preview images via an absolute `https://mintlify.s3...` URL rather than `/images/themes/...`, ensuring images render correctly outside the default locale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a36e51eaf220596aa55fd9234827d0e6595f13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->