### PR TITLE
Add MCP rate limits

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -60,6 +60,15 @@ View and copy your MCP server URL on the [MCP server page](https://dashboard.min
   Hosted MCP servers use the `/mcp` path in their URLs. Other navigation elements cannot use the `/mcp` path.
 </Note>
 
+### Rate limits
+
+To protect availability, Mintlify applies rate limits to MCP servers.
+
+| Scope | Limit | Description |
+| :---- | :---- | :---------- |
+| Per user (IP address) | 200 requests per hour | Limits how frequently a single user can search your documentation. |
+| Per documentation site (domain) | 1,000 requests per hour | Limits total searches across all users of your MCP server. |
+
 ## Content filtering and indexing
 
 Your MCP server searches content that Mintlify indexes from your documentation repository. File processing and search indexing control what content is available through your MCP server.


### PR DESCRIPTION
## Documentation changes

This PR adds per-IP and per-domain rate limits for MCP servers.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds usage limits guidance; no code or behavioral changes in the product.
> 
> **Overview**
> Documents **MCP server rate limiting** in `ai/model-context-protocol.mdx`.
> 
> Adds a new **Rate limits** section specifying enforced quotas (200 requests/hour per IP and 1,000 requests/hour per documentation domain) to clarify usage constraints for MCP search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc790e38f4e80204421fb97b0d0c96e214f3511c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->