### PR TITLE
fix: Analytics API `dateTo` is exclusive

### DIFF
--- a/analytics.openapi.json
+++ b/analytics.openapi.json
@@ -398,7 +398,7 @@
           {
             "schema": {
               "type": "string",
-              "description": "Date in ISO 8601 or YYYY-MM-DD format",
+              "description": "Date in ISO 8601 or YYYY-MM-DD format. `dateTo` is an exclusive upper limit. Results include dates before, but not on, the specified date.",
               "example": "2024-01-01"
             },
             "required": false,
@@ -512,7 +512,7 @@
           {
             "schema": {
               "type": "string",
-              "description": "Date in ISO 8601 or YYYY-MM-DD format",
+              "description": "Date in ISO 8601 or YYYY-MM-DD format. `dateTo` is an exclusive upper limit. Results include dates before, but not on, the specified date.",
               "example": "2024-01-01"
             },
             "required": false,


### PR DESCRIPTION
## Documentation changes

This PR clarifies the `dateTo` description for the analytics API

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI description changes; no runtime behavior or data handling logic is modified.
> 
> **Overview**
> Clarifies the analytics export API docs to state that the `dateTo` query parameter is an *exclusive* upper bound (results include dates before, but not on, `dateTo`) for both the `GET /analytics/{projectId}/feedback` and `GET /analytics/{projectId}/assistant` endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07c039e970367f5b99cb0e7391036dba38b94c16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->