### PR TITLE
use root for webeditor index page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -72,9 +72,8 @@
                     "group": "Web editor",
                     "root": "editor/index",
                     "pages": [
-                      
-                      "editor/media",
                       "editor/pages",
+                      "editor/media",
                       "editor/navigation",
                       "editor/configurations",
                       "editor/live-preview",


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation navigation config change; risk is limited to potential sidebar/landing-page routing differences.
> 
> **Overview**
> Sets the `root` for the **Web editor** docs navigation group to `editor/index`, and removes `editor/index` from that group’s `pages` list so it’s treated as the section landing page rather than a normal entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75abb14a7264db4dc578bee93ed4f2c1a70eac89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->