### PR TITLE
Document root property for groups

### DIFF
--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -44,7 +44,7 @@ In the `navigation` object, `pages` is an array where each entry must reference 
 
 ## Groups
 
-Use groups to organize your sidebar navigation into sections. Groups can be nested within each other, labeled with tags, and styled with icons.
+Use groups to organize your sidebar navigation into sections. You can nest groups within each other, label them with tags, and style them with icons.
 
 <img
   className="block dark:hidden pointer-events-none"
@@ -318,7 +318,7 @@ Global anchors support both external URLs and relative paths to pages within you
 
 ## Dropdowns
 
-Dropdowns are contained in an expandable menu at the top of your sidebar navigation. Each item in a dropdown directs to a section of your documentation.
+Dropdowns are an expandable menu at the top of your sidebar navigation. Each item in a dropdown directs to a section of your documentation.
 
 <img
   className="block dark:hidden pointer-events-none"
@@ -433,7 +433,7 @@ In the `navigation` object, `products` is an array where each entry is an object
 
 Integrate OpenAPI specifications directly into your navigation structure to automatically generate API documentation. Create dedicated API sections or place endpoint pages within other navigation components.
 
-Set a default OpenAPI specification at any level of your navigation hierarchy. Child elements will inherit this specification unless they define their own specification.
+Set a default OpenAPI specification at any level of your navigation hierarchy. Child elements inherit the specification unless they define their own.
 
 <Note>
   When you add the `openapi` property to a navigation element (such as an anchor, tab, or group) without specifying any pages, Mintlify automatically generates pages for **all endpoints** defined in your OpenAPI specification.
@@ -827,7 +827,7 @@ Each navigation element can contain one type of child element at each level of y
 
 ## Breadcrumbs
 
-Breadcrumbs display the full navigation path at the top of pages. Some themes have breadcrumbs enabled by default and others do not. You can control whether breadcrumbs are enabled for your site using the `styling` property in your `docs.json`.
+Breadcrumbs display the full navigation path at the top of pages. Some themes have breadcrumbs enabled by default and others do not. You can control whether breadcrumbs display on your site using the `styling` property in your `docs.json`.
 
 <CodeGroup>
 
@@ -851,10 +851,10 @@ Control how users interact with navigation elements using the `interaction` prop
 
 ### Enable auto-navigation for groups
 
-When a user expands a navigation group, some themes will automatically navigate to the first page in the group. You can override a theme's default behavior using the `drilldown` option.
+When a user expands a navigation group, some themes automatically navigate to the first page in the group. You can override a theme's default behavior using the `drilldown` option.
 
-- Set to `true` to force automatic navigation to the first page when a navigation group is selected.
-- Set to `false` to prevent navigation and only expand or collapse the group when it is selected.
+- Set to `true` to force automatic navigation to the first page when a user selects a navigation group.
+- Set to `false` to prevent navigation and only expand or collapse the group when a user selects a navigation group.
 - Leave unset to use the theme's default behavior.
 
 <CodeGroup>


### PR DESCRIPTION
Added documentation for the new `root` property in navigation groups. This property allows groups to have a designated main page that users navigate to when clicking the group title.

## Files changed
- `organize/navigation.mdx` - Added "Root page" subsection to the Groups section with explanation and code examples

Generated from [feat: "root" in groups](https://github.com/mintlify/mint/pull/5849) @lawreka

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime code or configuration behavior is modified.
> 
> **Overview**
> Documents a new `root` property for navigation `groups`, explaining that clicking a group title can route to a designated “main” page and providing a JSON example.
> 
> Also updates the Groups section to list `root` as an optional field and applies small copy edits for clarity in the Dropdowns, OpenAPI, Breadcrumbs, and `interaction.drilldown` descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ba6871430f1f65ba1c6b11282fda570281664f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->