### PR TITLE
Revert "Update agent docs with enhanced capabilities"

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -8,33 +8,17 @@ keywords: ["automation", "automate", "AI", "autoupdate", "maintenance"]
   The agent is available on [Enterprise plans](https://mintlify.com/pricing?ref=agent) for anyone with access to your dashboard.
 </Info>
 
-The agent is an AI tool that creates pull requests with proposed changes to your documentation based on your prompts. When you send a request, the agent:
-
-- **Researches**: Reads your existing documentation, any connected repositories, and relevant context.
-- **Plans**: Creates a structured task list for complex documentation work.
-- **Writes**: Generates or updates content following writing standards and best practices.
-- **Validates**: Runs Mintlify CLI checks to ensure documentation builds correctly.
-- **Creates a PR**: Opens a pull request with proposed changes for review.
-
-All changes go through pull requests. The agent never commits directly to your main branch.
+The agent creates pull requests with proposed changes to your documentation based on your prompts. When you send a request to the agent, it references your documentation, connected repositories, and Slack messages to create content that follows technical writing best practices and adheres to the Mintlify schema.
 
 ## What you can do with the agent
 
 Use the agent to:
 
-- Write new content based on your prompts, pull requests, Slack threads, or file attachments.
-- Update existing documentation with new features or API changes.
-- Process and include images, diagrams, and other files directly from Slack.
-- Search and revise code examples and API references across your docs.
+- Write new content based on your prompts, links to pull requests, or Slack threads.
+- Revise outdated code examples and API references.
+- Search and update existing content.
 - Answer questions about your docs and technical writing topics.
-- Address code review feedback and maintain documentation quality.
 - Capture knowledge from Slack conversations and pull requests before it gets lost.
-
-The agent can:
-
-- **Read files and images**: Process attachments from Slack messages to include diagrams, code snippets, and other content in your docs.
-- **Address code review feedback**: Read pull request comments and resolve them.
-- **Access full file system**: Navigate and coordinate changes across multiple files and directories efficiently.
 
 ## Where you can use the agent
 
@@ -43,7 +27,7 @@ The agent can:
     <img src="/images/agent/dashboard-light.png" alt="The agent panel open in the dashboard." className="block dark:hidden" />
     <img src="/images/agent/dashboard-dark.png" alt="The agent panel open in the dashboard." className="hidden dark:block" />
   </Frame>
-- **Slack**: Add the agent to your Slack workspace and mention `@mintlify` in any channel. You can attach files and images directly to your messages for the agent to process.
+- **Slack**: Add the agent to your Slack workspace and mention `@mintlify` to prompt it.
 - **API**: Embed the agent in custom applications using the [agent endpoints](/api/agent/create-agent-job).
 
 ## Next steps

--- a/agent/slack.mdx
+++ b/agent/slack.mdx
@@ -29,7 +29,6 @@ Once connected, you can:
 
 - Send direct messages to the agent to use it privately to update your documentation.
 - Mention `@mintlify` in a channel to use it publicly and collaboratively.
-- Attach files and images directly to your messages for the agent to process and include in your docs.
 - Continue conversations in threads to iterate on changes.
 - Share pull request links with the agent to update related documentation.
 
@@ -39,7 +38,6 @@ Use the agent to update your documentation with a new request or in an existing 
 
 - **New request**: Send a direct message to the agent or mention `@mintlify` in a channel with instructions on what to update.
 - **Existing thread**: Reply in the thread and mention `@mintlify` with instructions on what to update.
-- **With attachments**: Upload images, diagrams, code files, or other documents with your message. The agent automatically processes and includes them in your documentation.
 
 The agent reads the context of the request or thread and creates a pull request in your connected repository with the updates.
 

--- a/agent/workflows.mdx
+++ b/agent/workflows.mdx
@@ -30,23 +30,11 @@ Prompt the agent with a specific pull request to generate release notes or chang
 
 For example: `@mintlify Generate release notes for this PR: [PR link]`.
 
-## Address pull request review feedback
-
-Share a pull request link with the agent to address reviewer comments and code review feedback on documentation pull requests.
-
-For example: `@mintlify Address the review comments on this PR: [PR link]`.
-
 ## Generate code examples
 
 Prompt the agent to generate code examples for features throughout your docs or on specific pages.
 
 For example: `@mintlify Generate a code example to make the authentication method easier to understand`.
-
-## Add images or files to your docs
-
-Attach files or images directly to your Slack message when prompting the agent. The agent processes the attachment and includes it in the documentation.
-
-For example: `@mintlify Add this diagram to the architecture overview page` with the image attached to the message.
 
 ## Review existing content
 


### PR DESCRIPTION
Reverts mintlify/docs#3426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only edits that primarily remove/adjust descriptions; no product logic or APIs are changed.
> 
> **Overview**
> This PR **reverts expanded agent documentation** by simplifying the “What is the agent?” page copy and trimming the listed capabilities to a shorter, higher-level set.
> 
> It also removes/tones down Slack-related guidance about attachments and several workflow sections (e.g., addressing PR review feedback and adding images/files), leaving a more minimal set of example workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8b6416be4f9aa89752dd61a3a17c70ccaa5f29d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->