### PR TITLE
Add root pages for groups with index/overview pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -62,6 +62,7 @@
                     "group": "Web editor",
                     "root": "editor/index",
                     "pages": [
+                      "editor/index",
                       "editor/pages",
                       "editor/media",
                       "editor/navigation",
@@ -77,6 +78,7 @@
                   "create/code",
                   {
                     "group": "Agent",
+                    "root": "agent/index",
                     "pages": [
                       "agent/index",
                       "agent/quickstart",
@@ -89,6 +91,7 @@
                   },
                   {
                     "group": "Components",
+                    "root": "components/index",
                     "pages": [
                       "components/index",
                       "components/accordions",
@@ -149,6 +152,7 @@
                   "deploy/preview-deployments",
                   {
                     "group": "/docs subpath",
+                    "root": "deploy/docs-subpath",
                     "pages": [
                       "deploy/docs-subpath",
                       "deploy/cloudflare",
@@ -198,6 +202,7 @@
                     "pages": [
                       {
                         "group": "Analytics",
+                        "root": "integrations/analytics/overview",
                         "pages": [
                           "integrations/analytics/overview",
                           "integrations/analytics/amplitude",
@@ -226,6 +231,7 @@
                       },
                       {
                         "group": "Support",
+                        "root": "integrations/support/overview",
                         "pages": [
                           "integrations/support/overview",
                           "integrations/support/intercom",
@@ -234,6 +240,7 @@
                       },
                       {
                         "group": "Privacy",
+                        "root": "integrations/privacy/overview",
                         "pages": [
                           "integrations/privacy/overview",
                           "integrations/privacy/osano"


### PR DESCRIPTION
## Documentation changes

See title

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only documentation config changes; main risk is misconfigured paths causing broken sidebar routing.
> 
> **Overview**
> Updates `docs.json` navigation to define explicit `root` pages for groups that have an `index`/`overview` entry (e.g., Web editor, Agent, Components, `/docs subpath`, and Integrations subsections like Analytics/Support/Privacy). This ensures group headers route to the intended landing page instead of relying on implicit behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e95ea6c2397af35be1b41ff530bf08908f88c44e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->