### PR TITLE
fix: remove duplicated root page in pages list

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -62,7 +62,6 @@
                     "group": "Web editor",
                     "root": "editor/index",
                     "pages": [
-                      "editor/index",
                       "editor/git-essentials",
                       "editor/pages",
                       "editor/media",
@@ -81,7 +80,6 @@
                     "group": "Agent",
                     "root": "agent/index",
                     "pages": [
-                      "agent/index",
                       "agent/quickstart",
                       "agent/slack",
                       "agent/suggestions",
@@ -94,7 +92,6 @@
                     "group": "Components",
                     "root": "components/index",
                     "pages": [
-                      "components/index",
                       "components/accordions",
                       "components/badge",
                       "components/banner",
@@ -155,7 +152,6 @@
                     "group": "/docs subpath",
                     "root": "deploy/docs-subpath",
                     "pages": [
-                      "deploy/docs-subpath",
                       "deploy/cloudflare",
                       "deploy/route53-cloudfront",
                       "deploy/vercel",
@@ -205,7 +201,6 @@
                         "group": "Analytics",
                         "root": "integrations/analytics/overview",
                         "pages": [
-                          "integrations/analytics/overview",
                           "integrations/analytics/amplitude",
                           "integrations/analytics/clarity",
                           "integrations/analytics/clearbit",
@@ -234,7 +229,6 @@
                         "group": "Support",
                         "root": "integrations/support/overview",
                         "pages": [
-                          "integrations/support/overview",
                           "integrations/support/intercom",
                           "integrations/support/front"
                         ]
@@ -243,7 +237,6 @@
                         "group": "Privacy",
                         "root": "integrations/privacy/overview",
                         "pages": [
-                          "integrations/privacy/overview",
                           "integrations/privacy/osano"
                         ]
                       }


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs navigation-only change that just de-duplicates page entries; low risk aside from potential sidebar ordering/visibility differences.
> 
> **Overview**
> Removes duplicated root entries from `docs.json` navigation groups where a `root` is already specified (e.g., `editor/index`, `agent/index`, `components/index`, `deploy/docs-subpath`, and several `integrations/*/overview` pages).
> 
> This keeps the same section landing pages via `root` while avoiding repeated pages in the rendered sidebar/navigation lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 155c9b648bed3c092b6c519cdcceabfea517195d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->