### PR TITLE
Document drag-and-drop link creation feature

### DIFF
--- a/editor/pages.mdx
+++ b/editor/pages.mdx
@@ -45,7 +45,7 @@ Edit content with real-time previews that show how the content looks when publis
 - **Add components**: Press <kbd>/</kbd> to open the component menu and select components.
 - **Add images**: Use the image component from the <kbd>/</kbd> menu or type <kbd>/image</kbd>.
 - **Add videos**: Type <kbd>/video</kbd> to upload or select a video.
-- **Insert links**: Select text and press <kbd>Cmd</kbd> + <kbd>K</kbd>.
+- **Insert links**: Select text and press <kbd>Cmd</kbd> + <kbd>K</kbd>, or drag a page from the navigation tree into the editor to create a link with the page title.
 
 See [Components](/components) for the complete list of available components.
 


### PR DESCRIPTION
Added documentation for the new drag-and-drop feature that allows users to create links by dragging pages from the navigation tree into the visual editor. This provides a faster alternative to the existing Cmd+K keyboard shortcut for inserting links.

## Files changed
- `editor/pages.mdx` - Updated the "Insert links" bullet point in the Visual mode section to document the drag-and-drop functionality

Generated from [feat: create text node with link mark when drop a tree node in the editor](https://github.com/mintlify/mint/pull/5975) @dks333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavior impact.
> 
> **Overview**
> Updates the web editor documentation to note that links can now be created by *dragging a page from the navigation tree into the visual editor*, in addition to the existing `Cmd+K` shortcut.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5df79685ecb1d617e5a92da1b6e4daace5ecc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->