### PR TITLE
fix: resolve tag filters overflow on mobile

### DIFF
--- a/create/changelogs.mdx
+++ b/create/changelogs.mdx
@@ -19,7 +19,6 @@ Check out the [Mintlify changelog](/changelog) as an example: you can include li
     Add an `Update` for each changelog entry.
 
     Include relevant information like feature releases, bug fixes, or other announcements.
-
   </Step>
 </Steps>
 
@@ -28,12 +27,10 @@ Check out the [Mintlify changelog](/changelog) as an example: you can include li
 title: "Changelog"
 description: "Product updates and announcements"
 ---
-
 <Update label="March 2025" description="v0.0.10">
   Added a new Wintergreen flavor.
 
-Released a new version of the Spearmint flavor, now with 10% more mint.
-
+  Released a new version of the Spearmint flavor, now with 10% more mint.
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -50,15 +47,15 @@ Control how people navigate your changelog and stay up to date with your product
 Each `label` property for an `Update` automatically creates an entry in the right sidebar's table of contents. This is the default navigation for your changelog.
 
 <Frame>
-  <img
-    src="/images/changelog-toc-light.png"
-    alt="Changelog with table of contents displayed in light mode."
-    className="block dark:hidden"
+  <img 
+    src="/images/changelog-toc-light.png" 
+    alt="Changelog with table of contents displayed in light mode." 
+    className="block dark:hidden" 
   />
-  <img
-    src="/images/changelog-toc-dark.png"
-    alt="Changelog with table of contents displayed in dark mode."
-    className="hidden dark:block"
+  <img 
+    src="/images/changelog-toc-dark.png" 
+    alt="Changelog with table of contents displayed in dark mode." 
+    className="hidden dark:block" 
   />
 </Frame>
 
@@ -70,8 +67,7 @@ Add `tags` to your `Update` components to replace the table of contents with tag
 <Update label="March 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Added a new Wintergreen flavor.
 
-Released a new version of the Spearmint flavor, now with 10% more mint.
-
+  Released a new version of the Spearmint flavor, now with 10% more mint.
 </Update>
 
 <Update label="February 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -81,29 +77,26 @@ Released a new version of the Spearmint flavor, now with 10% more mint.
 <Update label="January 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   Deprecated the Peppermint flavor.
 
-Released a new version of the Spearmint flavor.
-
+  Released a new version of the Spearmint flavor.
 </Update>
 ```
 
 <Frame>
-  <img
-    src="/images/changelog-filters-light.png"
-    alt="Changelog in light mode with the Peppermint tag filter selected."
-    className="block dark:hidden"
+  <img 
+    src="/images/changelog-filters-light.png" 
+    alt="Changelog in light mode with the Peppermint tag filter selected." 
+    className="block dark:hidden" 
   />
-  <img
-    src="/images/changelog-filters-dark.png"
-    alt="Changelog in dark mode with the Peppermint tag filter selected."
-    className="hidden dark:block"
+  <img 
+    src="/images/changelog-filters-dark.png" 
+    alt="Changelog in dark mode with the Peppermint tag filter selected." 
+    className="hidden dark:block" 
   />
 </Frame>
 
 <Tip>
-  The table of contents and changelog filters are hidden when using `custom`,
-  `center`, or `wide` page modes. Learn more about [page
-  modes](/organize/pages#page-mode).
-</Tip>
+  The table of contents and changelog filters are hidden when using `custom`, `center`, or `wide` page modes. Learn more about [page modes](/organize/pages#page-mode).
+</Tip> 
 
 ### Subscribable changelogs
 
@@ -139,9 +132,9 @@ RSS feed entries contain pure Markdown only. Components, code, and HTML elements
 
 RSS feeds can integrate with Slack, email, or other subscription tools to notify users of product changes. Some options include:
 
-- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-- [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
-- Discord bots like [Readybot](https://readybot.io) or [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+* [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
+* Discord bots like [Readybot](https://readybot.io) or [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 To make the RSS feed discoverable, you can display an RSS icon button that links to the feed at the top of the page. Add `rss: true` to the page frontmatter:
 
@@ -152,14 +145,14 @@ rss: true
 ```
 
 <Frame>
-  <img
-    src="/images/changelog-rss-button-light.png"
-    alt="Changelog page in light mode with RSS feed button enabled."
-    className="block dark:hidden"
+  <img 
+    src="/images/changelog-rss-button-light.png" 
+    alt="Changelog page in light mode with RSS feed button enabled." 
+    className="block dark:hidden" 
   />
-  <img
-    src="/images/changelog-rss-button-dark.png"
-    alt="Changelog page in dark mode with RSS feed button enabled."
-    className="hidden dark:block"
+  <img 
+    src="/images/changelog-rss-button-dark.png" 
+    alt="Changelog page in dark mode with RSS feed button enabled." 
+    className="hidden dark:block" 
   />
 </Frame>

--- a/create/changelogs.mdx
+++ b/create/changelogs.mdx
@@ -19,6 +19,7 @@ Check out the [Mintlify changelog](/changelog) as an example: you can include li
     Add an `Update` for each changelog entry.
 
     Include relevant information like feature releases, bug fixes, or other announcements.
+
   </Step>
 </Steps>
 
@@ -27,10 +28,12 @@ Check out the [Mintlify changelog](/changelog) as an example: you can include li
 title: "Changelog"
 description: "Product updates and announcements"
 ---
+
 <Update label="March 2025" description="v0.0.10">
   Added a new Wintergreen flavor.
 
-  Released a new version of the Spearmint flavor, now with 10% more mint.
+Released a new version of the Spearmint flavor, now with 10% more mint.
+
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -47,15 +50,15 @@ Control how people navigate your changelog and stay up to date with your product
 Each `label` property for an `Update` automatically creates an entry in the right sidebar's table of contents. This is the default navigation for your changelog.
 
 <Frame>
-  <img 
-    src="/images/changelog-toc-light.png" 
-    alt="Changelog with table of contents displayed in light mode." 
-    className="block dark:hidden" 
+  <img
+    src="/images/changelog-toc-light.png"
+    alt="Changelog with table of contents displayed in light mode."
+    className="block dark:hidden"
   />
-  <img 
-    src="/images/changelog-toc-dark.png" 
-    alt="Changelog with table of contents displayed in dark mode." 
-    className="hidden dark:block" 
+  <img
+    src="/images/changelog-toc-dark.png"
+    alt="Changelog with table of contents displayed in dark mode."
+    className="hidden dark:block"
   />
 </Frame>
 
@@ -63,11 +66,12 @@ Each `label` property for an `Update` automatically creates an entry in the righ
 
 Add `tags` to your `Update` components to replace the table of contents with tag filters. Users can filter the changelog by selecting one or more tags:
 
-```mdx Tag filters example wrap
+```mdx Tag filters example
 <Update label="March 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Added a new Wintergreen flavor.
 
-  Released a new version of the Spearmint flavor, now with 10% more mint.
+Released a new version of the Spearmint flavor, now with 10% more mint.
+
 </Update>
 
 <Update label="February 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -77,26 +81,29 @@ Add `tags` to your `Update` components to replace the table of contents with tag
 <Update label="January 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   Deprecated the Peppermint flavor.
 
-  Released a new version of the Spearmint flavor.
+Released a new version of the Spearmint flavor.
+
 </Update>
 ```
 
 <Frame>
-  <img 
-    src="/images/changelog-filters-light.png" 
-    alt="Changelog in light mode with the Peppermint tag filter selected." 
-    className="block dark:hidden" 
+  <img
+    src="/images/changelog-filters-light.png"
+    alt="Changelog in light mode with the Peppermint tag filter selected."
+    className="block dark:hidden"
   />
-  <img 
-    src="/images/changelog-filters-dark.png" 
-    alt="Changelog in dark mode with the Peppermint tag filter selected." 
-    className="hidden dark:block" 
+  <img
+    src="/images/changelog-filters-dark.png"
+    alt="Changelog in dark mode with the Peppermint tag filter selected."
+    className="hidden dark:block"
   />
 </Frame>
 
 <Tip>
-  The table of contents and changelog filters are hidden when using `custom`, `center`, or `wide` page modes. Learn more about [page modes](/organize/pages#page-mode).
-</Tip> 
+  The table of contents and changelog filters are hidden when using `custom`,
+  `center`, or `wide` page modes. Learn more about [page
+  modes](/organize/pages#page-mode).
+</Tip>
 
 ### Subscribable changelogs
 
@@ -132,9 +139,9 @@ RSS feed entries contain pure Markdown only. Components, code, and HTML elements
 
 RSS feeds can integrate with Slack, email, or other subscription tools to notify users of product changes. Some options include:
 
-* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-* [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
-* Discord bots like [Readybot](https://readybot.io) or [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+- [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
+- Discord bots like [Readybot](https://readybot.io) or [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 To make the RSS feed discoverable, you can display an RSS icon button that links to the feed at the top of the page. Add `rss: true` to the page frontmatter:
 
@@ -145,14 +152,14 @@ rss: true
 ```
 
 <Frame>
-  <img 
-    src="/images/changelog-rss-button-light.png" 
-    alt="Changelog page in light mode with RSS feed button enabled." 
-    className="block dark:hidden" 
+  <img
+    src="/images/changelog-rss-button-light.png"
+    alt="Changelog page in light mode with RSS feed button enabled."
+    className="block dark:hidden"
   />
-  <img 
-    src="/images/changelog-rss-button-dark.png" 
-    alt="Changelog page in dark mode with RSS feed button enabled." 
-    className="hidden dark:block" 
+  <img
+    src="/images/changelog-rss-button-dark.png"
+    alt="Changelog page in dark mode with RSS feed button enabled."
+    className="hidden dark:block"
   />
 </Frame>

--- a/es/create/changelogs.mdx
+++ b/es/create/changelogs.mdx
@@ -8,9 +8,7 @@ Crea un registro de cambios para tu documentación añadiendo [componentes Updat
 
 Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en cada actualización puedes incluir enlaces, imágenes, texto y demos de tus nuevas funciones.
 
-<div id="setting-up-your-changelog">
-  ## Configurar tu página de cambios
-</div>
+<div id="setting-up-your-changelog">## Configurar tu página de cambios</div>
 
 <Steps>
   <Step title="Crea una página para tu registro de cambios">
@@ -22,6 +20,7 @@ Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en ca
     Añade un `Update` para cada entrada del registro.
 
     Incluye información relevante como lanzamientos de funcionalidades, correcciones de errores u otros anuncios.
+
   </Step>
 </Steps>
 
@@ -30,10 +29,12 @@ Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en ca
 title: "Cambios"
 description: "Actualizaciones del producto y anuncios"
 ---
+
 <Update label="March 2025" description="v0.0.10">
   Se agregó un nuevo sabor Wintergreen.
 
-  Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
+Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
+
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -41,15 +42,11 @@ description: "Actualizaciones del producto y anuncios"
 </Update>
 ```
 
-<div id="customizing-your-changelog">
-  ## Personalizar tu página de cambios
-</div>
+<div id="customizing-your-changelog">## Personalizar tu página de cambios</div>
 
 Controla cómo las personas navegan por tu página de cambios y se mantienen al día con la información de tu producto.
 
-<div id="table-of-contents">
-  ### Tabla de contenidos
-</div>
+<div id="table-of-contents">### Tabla de contenidos</div>
 
 Cada propiedad `label` de un `Update` crea automáticamente una entrada en la tabla de contenidos de la barra lateral derecha. Esta es la navigation predeterminada para tu página de cambios.
 
@@ -59,17 +56,16 @@ Cada propiedad `label` de un `Update` crea automáticamente una entrada en la ta
   <img src="/images/changelog-toc-dark.png" alt="Página de cambios con la tabla de contenidos mostrada en modo oscuro." className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">
-  ### Filtros por etiquetas
-</div>
+<div id="tag-filters">### Filtros por etiquetas</div>
 
 Agrega `tags` a tus componentes `Update` para reemplazar la tabla de contenido con filtros por etiquetas. Los usuarios pueden filtrar los cambios seleccionando una o varias etiquetas:
 
-```mdx Tag filters example wrap
+```mdx Tag filters example
 <Update label="Marzo 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Se agregó un nuevo sabor Wintergreen.
 
-  Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
+Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
+
 </Update>
 
 <Update label="Febrero 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -79,7 +75,8 @@ Agrega `tags` a tus componentes `Update` para reemplazar la tabla de contenido c
 <Update label="Enero 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   Se marcó como en desuso el sabor Peppermint.
 
-  Se lanzó una nueva versión del sabor Spearmint.
+Se lanzó una nueva versión del sabor Spearmint.
+
 </Update>
 ```
 
@@ -90,7 +87,9 @@ Agrega `tags` a tus componentes `Update` para reemplazar la tabla de contenido c
 </Frame>
 
 <Tip>
-  La tabla de contenidos y los filtros del registro de cambios se ocultan al usar los modos de página `custom`, `center` o `wide`. Más información sobre los [modos de página](/es/organize/pages#page-mode).
+  La tabla de contenidos y los filtros del registro de cambios se ocultan al
+  usar los modos de página `custom`, `center` o `wide`. Más información sobre
+  los [modos de página](/es/organize/pages#page-mode).
 </Tip>
 
 <div id="subscribable-changelogs">
@@ -129,9 +128,9 @@ Las entradas del feed RSS contienen únicamente Markdown puro. Los componentes, 
 
 Los feeds RSS pueden integrarse con Slack, correo electrónico u otras herramientas de suscripción para notificar a los usuarios sobre cambios en el producto. Algunas opciones incluyen:
 
-* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-* [Correo electrónico](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) mediante Zapier
-* Bots de Discord como [Readybot](https://readybot.io) o [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+- [Correo electrónico](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) mediante Zapier
+- Bots de Discord como [Readybot](https://readybot.io) o [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 Para que el feed RSS sea fácil de descubrir, puedes mostrar un botón con el icono RSS que enlace al feed en la parte superior de la página. Agrega `rss: true` al frontmatter de la página:
 

--- a/es/create/changelogs.mdx
+++ b/es/create/changelogs.mdx
@@ -8,7 +8,9 @@ Crea un registro de cambios para tu documentación añadiendo [componentes Updat
 
 Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en cada actualización puedes incluir enlaces, imágenes, texto y demos de tus nuevas funciones.
 
-<div id="setting-up-your-changelog">## Configurar tu página de cambios</div>
+<div id="setting-up-your-changelog">
+  ## Configurar tu página de cambios
+</div>
 
 <Steps>
   <Step title="Crea una página para tu registro de cambios">
@@ -20,7 +22,6 @@ Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en ca
     Añade un `Update` para cada entrada del registro.
 
     Incluye información relevante como lanzamientos de funcionalidades, correcciones de errores u otros anuncios.
-
   </Step>
 </Steps>
 
@@ -29,12 +30,10 @@ Consulta el [registro de cambios de Mintlify](/es/changelog) como ejemplo: en ca
 title: "Cambios"
 description: "Actualizaciones del producto y anuncios"
 ---
-
 <Update label="March 2025" description="v0.0.10">
   Se agregó un nuevo sabor Wintergreen.
 
-Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
-
+  Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -42,11 +41,15 @@ Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
 </Update>
 ```
 
-<div id="customizing-your-changelog">## Personalizar tu página de cambios</div>
+<div id="customizing-your-changelog">
+  ## Personalizar tu página de cambios
+</div>
 
 Controla cómo las personas navegan por tu página de cambios y se mantienen al día con la información de tu producto.
 
-<div id="table-of-contents">### Tabla de contenidos</div>
+<div id="table-of-contents">
+  ### Tabla de contenidos
+</div>
 
 Cada propiedad `label` de un `Update` crea automáticamente una entrada en la tabla de contenidos de la barra lateral derecha. Esta es la navigation predeterminada para tu página de cambios.
 
@@ -56,7 +59,9 @@ Cada propiedad `label` de un `Update` crea automáticamente una entrada en la ta
   <img src="/images/changelog-toc-dark.png" alt="Página de cambios con la tabla de contenidos mostrada en modo oscuro." className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">### Filtros por etiquetas</div>
+<div id="tag-filters">
+  ### Filtros por etiquetas
+</div>
 
 Agrega `tags` a tus componentes `Update` para reemplazar la tabla de contenido con filtros por etiquetas. Los usuarios pueden filtrar los cambios seleccionando una o varias etiquetas:
 
@@ -64,8 +69,7 @@ Agrega `tags` a tus componentes `Update` para reemplazar la tabla de contenido c
 <Update label="Marzo 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Se agregó un nuevo sabor Wintergreen.
 
-Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
-
+  Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
 </Update>
 
 <Update label="Febrero 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -75,8 +79,7 @@ Se lanzó una nueva versión del sabor Spearmint, ahora con 10% más menta.
 <Update label="Enero 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   Se marcó como en desuso el sabor Peppermint.
 
-Se lanzó una nueva versión del sabor Spearmint.
-
+  Se lanzó una nueva versión del sabor Spearmint.
 </Update>
 ```
 
@@ -87,9 +90,7 @@ Se lanzó una nueva versión del sabor Spearmint.
 </Frame>
 
 <Tip>
-  La tabla de contenidos y los filtros del registro de cambios se ocultan al
-  usar los modos de página `custom`, `center` o `wide`. Más información sobre
-  los [modos de página](/es/organize/pages#page-mode).
+  La tabla de contenidos y los filtros del registro de cambios se ocultan al usar los modos de página `custom`, `center` o `wide`. Más información sobre los [modos de página](/es/organize/pages#page-mode).
 </Tip>
 
 <div id="subscribable-changelogs">
@@ -128,9 +129,9 @@ Las entradas del feed RSS contienen únicamente Markdown puro. Los componentes, 
 
 Los feeds RSS pueden integrarse con Slack, correo electrónico u otras herramientas de suscripción para notificar a los usuarios sobre cambios en el producto. Algunas opciones incluyen:
 
-- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-- [Correo electrónico](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) mediante Zapier
-- Bots de Discord como [Readybot](https://readybot.io) o [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+* [Correo electrónico](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) mediante Zapier
+* Bots de Discord como [Readybot](https://readybot.io) o [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 Para que el feed RSS sea fácil de descubrir, puedes mostrar un botón con el icono RSS que enlace al feed en la parte superior de la página. Agrega `rss: true` al frontmatter de la página:
 

--- a/fr/create/changelogs.mdx
+++ b/fr/create/changelogs.mdx
@@ -22,6 +22,7 @@ Consultez le [journal des modifications de Mintlify](/fr/changelog) comme exempl
     Ajoutez un `Update` pour chaque entrée du journal des modifications.
 
     Incluez des informations pertinentes comme des sorties de nouvelles fonctionnalités, des correctifs de bugs ou d&#39;autres annonces.
+
   </Step>
 </Steps>
 
@@ -30,10 +31,12 @@ Consultez le [journal des modifications de Mintlify](/fr/changelog) comme exempl
 title: "Journal des modifications"
 description: "Mises à jour produit et annonces"
 ---
+
 <Update label="March 2025" description="v0.0.10">
   Ajout d'une nouvelle saveur Wintergreen.
 
-  Publication d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
+Publication d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
+
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -47,9 +50,7 @@ description: "Mises à jour produit et annonces"
 
 Maîtrisez la manière dont les utilisateurs parcourent votre journal des modifications et restent à jour sur les informations de votre produit.
 
-<div id="table-of-contents">
-  ### Table des matières
-</div>
+<div id="table-of-contents">### Table des matières</div>
 
 Chaque propriété `label` d’un `Update` crée automatiquement une entrée dans la table des matières de la barre latérale droite. C’est la navigation par défaut de votre journal des modifications.
 
@@ -59,17 +60,16 @@ Chaque propriété `label` d’un `Update` crée automatiquement une entrée dan
   <img src="/images/changelog-toc-dark.png" alt="Journal des modifications avec la table des matières affichée en mode sombre." className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">
-  ### Filtres de tags
-</div>
+<div id="tag-filters">### Filtres de tags</div>
 
 Ajoutez `tags` à vos composants `Update` pour remplacer la table des matières par des filtres de tags. Les utilisateurs peuvent filtrer le journal des modifications en sélectionnant un ou plusieurs tags :
 
-```mdx Tag filters example wrap
+```mdx Tag filters example
 <Update label="Mars 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Ajout d'une nouvelle saveur Wintergreen.
 
-  Sortie d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
+Sortie d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
+
 </Update>
 
 <Update label="Février 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -79,7 +79,8 @@ Ajoutez `tags` à vos composants `Update` pour remplacer la table des matières 
 <Update label="Janvier 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   La saveur Peppermint est désormais obsolète.
 
-  Sortie d'une nouvelle version de la saveur Spearmint.
+Sortie d'une nouvelle version de la saveur Spearmint.
+
 </Update>
 ```
 
@@ -90,14 +91,16 @@ Ajoutez `tags` à vos composants `Update` pour remplacer la table des matières 
 </Frame>
 
 <Tip>
-  La table des matières et les filtres du journal des modifications sont masqués lorsque vous utilisez les modes de page `custom`, `center` ou `wide`. En savoir plus sur les [modes de page](/fr/organize/pages#page-mode).
+  La table des matières et les filtres du journal des modifications sont masqués
+  lorsque vous utilisez les modes de page `custom`, `center` ou `wide`. En
+  savoir plus sur les [modes de page](/fr/organize/pages#page-mode).
 </Tip>
 
-<div id="subscribable-changelogs">
-  ### Flux de modifications abonnables
-</div>
+<div id="subscribable-changelogs">### Flux de modifications abonnables</div>
 
-<Note>Les flux RSS sont uniquement disponibles pour la documentation publique.</Note>
+<Note>
+  Les flux RSS sont uniquement disponibles pour la documentation publique.
+</Note>
 
 Utilisez les composants `Update` pour créer un flux RSS auquel il est possible de s’abonner à l’URL de votre page avec `/rss.xml` ajouté. Par exemple : `mintlify.com/docs/changelog/rss.xml`.
 
@@ -129,9 +132,9 @@ Les entrées du flux RSS contiennent uniquement du Markdown. Les composants, le 
 
 Les flux RSS peuvent s’intégrer à Slack, à l’e-mail ou à d’autres outils d’abonnement pour informer les utilisateurs des modifications du produit. Parmi les options :
 
-* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-* [E-mail](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
-* Des bots Discord comme [Readybot](https://readybot.io) ou [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+- [E-mail](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
+- Des bots Discord comme [Readybot](https://readybot.io) ou [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 Pour rendre le flux RSS découvrable, vous pouvez afficher un bouton avec l’icône RSS qui renvoie vers le flux en haut de la page. Ajoutez `rss: true` au frontmatter de la page :
 

--- a/fr/create/changelogs.mdx
+++ b/fr/create/changelogs.mdx
@@ -22,7 +22,6 @@ Consultez le [journal des modifications de Mintlify](/fr/changelog) comme exempl
     Ajoutez un `Update` pour chaque entrée du journal des modifications.
 
     Incluez des informations pertinentes comme des sorties de nouvelles fonctionnalités, des correctifs de bugs ou d&#39;autres annonces.
-
   </Step>
 </Steps>
 
@@ -31,12 +30,10 @@ Consultez le [journal des modifications de Mintlify](/fr/changelog) comme exempl
 title: "Journal des modifications"
 description: "Mises à jour produit et annonces"
 ---
-
 <Update label="March 2025" description="v0.0.10">
   Ajout d'une nouvelle saveur Wintergreen.
 
-Publication d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
-
+  Publication d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
 </Update>
 
 <Update label="February 2025" description="v0.0.09">
@@ -50,7 +47,9 @@ Publication d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % 
 
 Maîtrisez la manière dont les utilisateurs parcourent votre journal des modifications et restent à jour sur les informations de votre produit.
 
-<div id="table-of-contents">### Table des matières</div>
+<div id="table-of-contents">
+  ### Table des matières
+</div>
 
 Chaque propriété `label` d’un `Update` crée automatiquement une entrée dans la table des matières de la barre latérale droite. C’est la navigation par défaut de votre journal des modifications.
 
@@ -60,7 +59,9 @@ Chaque propriété `label` d’un `Update` crée automatiquement une entrée dan
   <img src="/images/changelog-toc-dark.png" alt="Journal des modifications avec la table des matières affichée en mode sombre." className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">### Filtres de tags</div>
+<div id="tag-filters">
+  ### Filtres de tags
+</div>
 
 Ajoutez `tags` à vos composants `Update` pour remplacer la table des matières par des filtres de tags. Les utilisateurs peuvent filtrer le journal des modifications en sélectionnant un ou plusieurs tags :
 
@@ -68,8 +69,7 @@ Ajoutez `tags` à vos composants `Update` pour remplacer la table des matières 
 <Update label="Mars 2025" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   Ajout d'une nouvelle saveur Wintergreen.
 
-Sortie d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
-
+  Sortie d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de menthe en plus.
 </Update>
 
 <Update label="Février 2025" description="v0.0.09" tags={["Spearmint"]}>
@@ -79,8 +79,7 @@ Sortie d'une nouvelle version de la saveur Spearmint, maintenant avec 10 % de me
 <Update label="Janvier 2025" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   La saveur Peppermint est désormais obsolète.
 
-Sortie d'une nouvelle version de la saveur Spearmint.
-
+  Sortie d'une nouvelle version de la saveur Spearmint.
 </Update>
 ```
 
@@ -91,16 +90,14 @@ Sortie d'une nouvelle version de la saveur Spearmint.
 </Frame>
 
 <Tip>
-  La table des matières et les filtres du journal des modifications sont masqués
-  lorsque vous utilisez les modes de page `custom`, `center` ou `wide`. En
-  savoir plus sur les [modes de page](/fr/organize/pages#page-mode).
+  La table des matières et les filtres du journal des modifications sont masqués lorsque vous utilisez les modes de page `custom`, `center` ou `wide`. En savoir plus sur les [modes de page](/fr/organize/pages#page-mode).
 </Tip>
 
-<div id="subscribable-changelogs">### Flux de modifications abonnables</div>
+<div id="subscribable-changelogs">
+  ### Flux de modifications abonnables
+</div>
 
-<Note>
-  Les flux RSS sont uniquement disponibles pour la documentation publique.
-</Note>
+<Note>Les flux RSS sont uniquement disponibles pour la documentation publique.</Note>
 
 Utilisez les composants `Update` pour créer un flux RSS auquel il est possible de s’abonner à l’URL de votre page avec `/rss.xml` ajouté. Par exemple : `mintlify.com/docs/changelog/rss.xml`.
 
@@ -132,9 +129,9 @@ Les entrées du flux RSS contiennent uniquement du Markdown. Les composants, le 
 
 Les flux RSS peuvent s’intégrer à Slack, à l’e-mail ou à d’autres outils d’abonnement pour informer les utilisateurs des modifications du produit. Parmi les options :
 
-- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-- [E-mail](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
-- Des bots Discord comme [Readybot](https://readybot.io) ou [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
+* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+* [E-mail](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email) via Zapier
+* Des bots Discord comme [Readybot](https://readybot.io) ou [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot)
 
 Pour rendre le flux RSS découvrable, vous pouvez afficher un bouton avec l’icône RSS qui renvoie vers le flux en haut de la page. Ajoutez `rss: true` au frontmatter de la page :
 

--- a/zh/create/changelogs.mdx
+++ b/zh/create/changelogs.mdx
@@ -8,7 +8,9 @@ keywords: ["product updates", "release notes", "RSS"]
 
 查看 [Mintlify 更新日志](/zh/changelog) 作为示例：你可以在每次更新中包含指向新功能的链接、图片、文本和演示。
 
-<div id="setting-up-your-changelog">## 设置更新日志</div>
+<div id="setting-up-your-changelog">
+  ## 设置更新日志
+</div>
 
 <Steps>
   <Step title="为更新日志创建页面">
@@ -20,7 +22,6 @@ keywords: ["product updates", "release notes", "RSS"]
     为每条更新日志记录添加一个 `Update`。
 
     包含相关信息，例如功能发布、错误修复或其他公告。
-
   </Step>
 </Steps>
 
@@ -29,12 +30,10 @@ keywords: ["product updates", "release notes", "RSS"]
 title: "更新日志"
 description: "产品更新和公告"
 ---
-
 <Update label="2025年3月" description="v0.0.10">
   新增冬青薄荷口味。
 
-绿薄荷口味发布新版本，薄荷含量提升10%。
-
+  绿薄荷口味发布新版本，薄荷含量提升10%。
 </Update>
 
 <Update label="2025年2月" description="v0.0.09">
@@ -42,11 +41,15 @@ description: "产品更新和公告"
 </Update>
 ```
 
-<div id="customizing-your-changelog">## 自定义更新日志</div>
+<div id="customizing-your-changelog">
+  ## 自定义更新日志
+</div>
 
 控制用户浏览更新日志的方式，并让他们及时掌握产品动态。
 
-<div id="table-of-contents">### 目录</div>
+<div id="table-of-contents">
+  ### 目录
+</div>
 
 每个 `Update` 的 `label` 属性都会在右侧侧边栏的目录中自动创建一个条目。这是你的更新日志的默认导航方式。
 
@@ -56,7 +59,9 @@ description: "产品更新和公告"
   <img src="/images/changelog-toc-dark.png" alt="深色模式下显示目录的更新日志。" className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">### 标签筛选</div>
+<div id="tag-filters">
+  ### 标签筛选
+</div>
 
 在 `Update` 组件中添加 `tags`，即可将目录替换为标签筛选器。用户可以通过选择一个或多个标签来筛选更新日志：
 
@@ -64,8 +69,7 @@ description: "产品更新和公告"
 <Update label="2025年3月" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   添加了新的 Wintergreen 口味。
 
-发布了新版本的 Spearmint 口味，现在薄荷含量增加了 10%。
-
+  发布了新版本的 Spearmint 口味，现在薄荷含量增加了 10%。
 </Update>
 
 <Update label="2025年2月" description="v0.0.09" tags={["Spearmint"]}>
@@ -75,8 +79,7 @@ description: "产品更新和公告"
 <Update label="2025年1月" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   已废弃 Peppermint 口味。
 
-发布了新版本的 Spearmint 口味。
-
+  发布了新版本的 Spearmint 口味。
 </Update>
 ```
 
@@ -87,11 +90,12 @@ description: "产品更新和公告"
 </Frame>
 
 <Tip>
-  在使用 `custom`、`center` 或 `wide`
-  页面模式时，目录和更新日志筛选器会被隐藏。了解更多[页面模式](/zh/organize/pages#page-mode)。
+  在使用 `custom`、`center` 或 `wide` 页面模式时，目录和更新日志筛选器会被隐藏。了解更多[页面模式](/zh/organize/pages#page-mode)。
 </Tip>
 
-<div id="subscribable-changelogs">### 可订阅的更新日志</div>
+<div id="subscribable-changelogs">
+  ### 可订阅的更新日志
+</div>
 
 <Note>RSS 源仅适用于公开的文档。</Note>
 
@@ -125,9 +129,9 @@ RSS 源条目只包含纯 Markdown。组件、代码和 HTML 元素将被排除�
 
 RSS 源可与 Slack、电子邮件或其他订阅工具集成，用于通知用户产品更新。可选方案包括：
 
-- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-- 通过 Zapier 的 [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email)
-- 如 [Readybot](https://readybot.io) 或 [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot) 等 Discord 机器人
+* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+* 通过 Zapier 的 [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email)
+* 如 [Readybot](https://readybot.io) 或 [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot) 等 Discord 机器人
 
 为便于发现 RSS 源，你可以在页面顶部显示一个链接到该源的 RSS icon 按钮。在页面 frontmatter 中添加 `rss: true`：
 

--- a/zh/create/changelogs.mdx
+++ b/zh/create/changelogs.mdx
@@ -8,9 +8,7 @@ keywords: ["product updates", "release notes", "RSS"]
 
 查看 [Mintlify 更新日志](/zh/changelog) 作为示例：你可以在每次更新中包含指向新功能的链接、图片、文本和演示。
 
-<div id="setting-up-your-changelog">
-  ## 设置更新日志
-</div>
+<div id="setting-up-your-changelog">## 设置更新日志</div>
 
 <Steps>
   <Step title="为更新日志创建页面">
@@ -22,6 +20,7 @@ keywords: ["product updates", "release notes", "RSS"]
     为每条更新日志记录添加一个 `Update`。
 
     包含相关信息，例如功能发布、错误修复或其他公告。
+
   </Step>
 </Steps>
 
@@ -30,10 +29,12 @@ keywords: ["product updates", "release notes", "RSS"]
 title: "更新日志"
 description: "产品更新和公告"
 ---
+
 <Update label="2025年3月" description="v0.0.10">
   新增冬青薄荷口味。
 
-  绿薄荷口味发布新版本，薄荷含量提升10%。
+绿薄荷口味发布新版本，薄荷含量提升10%。
+
 </Update>
 
 <Update label="2025年2月" description="v0.0.09">
@@ -41,15 +42,11 @@ description: "产品更新和公告"
 </Update>
 ```
 
-<div id="customizing-your-changelog">
-  ## 自定义更新日志
-</div>
+<div id="customizing-your-changelog">## 自定义更新日志</div>
 
 控制用户浏览更新日志的方式，并让他们及时掌握产品动态。
 
-<div id="table-of-contents">
-  ### 目录
-</div>
+<div id="table-of-contents">### 目录</div>
 
 每个 `Update` 的 `label` 属性都会在右侧侧边栏的目录中自动创建一个条目。这是你的更新日志的默认导航方式。
 
@@ -59,17 +56,16 @@ description: "产品更新和公告"
   <img src="/images/changelog-toc-dark.png" alt="深色模式下显示目录的更新日志。" className="hidden dark:block" />
 </Frame>
 
-<div id="tag-filters">
-  ### 标签筛选
-</div>
+<div id="tag-filters">### 标签筛选</div>
 
 在 `Update` 组件中添加 `tags`，即可将目录替换为标签筛选器。用户可以通过选择一个或多个标签来筛选更新日志：
 
-```mdx Tag filters example wrap
+```mdx Tag filters example
 <Update label="2025年3月" description="v0.0.10" tags={["Wintergreen", "Spearmint"]}>
   添加了新的 Wintergreen 口味。
 
-  发布了新版本的 Spearmint 口味，现在薄荷含量增加了 10%。
+发布了新版本的 Spearmint 口味，现在薄荷含量增加了 10%。
+
 </Update>
 
 <Update label="2025年2月" description="v0.0.09" tags={["Spearmint"]}>
@@ -79,7 +75,8 @@ description: "产品更新和公告"
 <Update label="2025年1月" description="v0.0.08" tags={["Peppermint", "Spearmint"]}>
   已废弃 Peppermint 口味。
 
-  发布了新版本的 Spearmint 口味。
+发布了新版本的 Spearmint 口味。
+
 </Update>
 ```
 
@@ -90,12 +87,11 @@ description: "产品更新和公告"
 </Frame>
 
 <Tip>
-  在使用 `custom`、`center` 或 `wide` 页面模式时，目录和更新日志筛选器会被隐藏。了解更多[页面模式](/zh/organize/pages#page-mode)。
+  在使用 `custom`、`center` 或 `wide`
+  页面模式时，目录和更新日志筛选器会被隐藏。了解更多[页面模式](/zh/organize/pages#page-mode)。
 </Tip>
 
-<div id="subscribable-changelogs">
-  ### 可订阅的更新日志
-</div>
+<div id="subscribable-changelogs">### 可订阅的更新日志</div>
 
 <Note>RSS 源仅适用于公开的文档。</Note>
 
@@ -129,9 +125,9 @@ RSS 源条目只包含纯 Markdown。组件、代码和 HTML 元素将被排除�
 
 RSS 源可与 Slack、电子邮件或其他订阅工具集成，用于通知用户产品更新。可选方案包括：
 
-* [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
-* 通过 Zapier 的 [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email)
-* 如 [Readybot](https://readybot.io) 或 [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot) 等 Discord 机器人
+- [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack)
+- 通过 Zapier 的 [Email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email)
+- 如 [Readybot](https://readybot.io) 或 [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot) 等 Discord 机器人
 
 为便于发现 RSS 源，你可以在页面顶部显示一个链接到该源的 RSS icon 按钮。在页面 frontmatter 中添加 `rss: true`：
 


### PR DESCRIPTION
## Problem
Changelog tag filters overflow on mobile devices instead of scrolling horizontally.

## Solution
Removed `wrap` from tag filters code blocks to enable proper horizontal scrolling on mobile.

## Related
Mentioned this as a follow-up issue in PR #2636.

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/d80e8250-5d18-461e-af86-6d963ac4dba8" width="500" /> | <img src="https://github.com/user-attachments/assets/e0866114-14eb-4cbb-84e7-e8de677665dd" width="500" /> |

<!-- CURSOR_SUMMARY -->

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8b06d3cd24804ef51d9a2dd6e82b27744f728ee5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->