### PR TITLE
remove api external

### DIFF
--- a/analytics.openapi.json
+++ b/analytics.openapi.json
@@ -369,7 +369,7 @@
     }
   },
   "paths": {
-    "/api/external/v1/analytics/{projectId}/feedback": {
+    "/v1/analytics/{projectId}/feedback": {
       "get": {
         "summary": "Get user feedback",
         "description": "Returns paginated user feedback with optional filtering",
@@ -483,7 +483,7 @@
         }
       }
     },
-    "/api/external/v1/analytics/{projectId}/assistant": {
+    "/v1/analytics/{projectId}/assistant": {
       "get": {
         "summary": "Get assistant conversations",
         "description": "Returns paginated AI assistant conversation history",

--- a/api/analytics/assistant-conversations.mdx
+++ b/api/analytics/assistant-conversations.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: /analytics.openapi.json GET /api/external/v1/analytics/{projectId}/assistant
+openapi: /analytics.openapi.json GET /v1/analytics/{projectId}/assistant
 keywords: ["analytics", "assistant", "conversations", "export", "AI"]
 ---
 

--- a/api/analytics/feedback.mdx
+++ b/api/analytics/feedback.mdx
@@ -1,5 +1,5 @@
 ---
-openapi: /analytics.openapi.json GET /api/external/v1/analytics/{projectId}/feedback
+openapi: /analytics.openapi.json GET /v1/analytics/{projectId}/feedback
 keywords: ["analytics", "feedback", "export", "user feedback"]
 ---
 


### PR DESCRIPTION
## Documentation changes
- Removing /api/external from the route 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path changes in OpenAPI/MDX; no runtime code or security logic is modified, but consumers may need to update their called URLs.
> 
> **Overview**
> Updates the Analytics Export API documentation to remove the `/api/external` prefix from route paths.
> 
> The OpenAPI spec and the `assistant-conversations`/`feedback` MDX pages now reference `GET /v1/analytics/{projectId}/assistant` and `GET /v1/analytics/{projectId}/feedback` instead of `/api/external/v1/...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99a16b812d2f6aa4f0376806099f8f9d3fc31aee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->