### PR TITLE
Workflows in beta copy

### DIFF
--- a/agent/workflows.mdx
+++ b/agent/workflows.mdx
@@ -5,9 +5,7 @@ keywords: ["automation", "automate", "cron", "auto-update"]
 ---
 
 <Info>
-  Workflows are available on [Enterprise plans](https://mintlify.com/pricing?ref=agent).
-
-  You can have up to 10 active workflows.
+Workflows are in beta. Reach out to us directly to enable them.
 </Info>
 
 Workflows run the agent automatically on a schedule or when a push happens to a repository you specify. Each workflow defines a prompt for the agent and a trigger for when to run it.


### PR DESCRIPTION
## Documentation changes

Set workflow info text to:

"Workflows are in beta. Reach out to us directly to enable them."


---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy change with no functional or behavioral impact.
> 
> **Overview**
> Updates the `agent/workflows.mdx` docs to remove Enterprise-plan/limit messaging and instead show a single beta notice: **“Workflows are in beta. Reach out to us directly to enable them.”**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db30cc0030af971331b981a1af56d10fbef4ce90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->