### PR TITLE
Editor smart substitution

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -207,6 +207,7 @@ OIDC
 obj
 oneOf
 orm
+(?i)outdent
 params
 PDFs
 pnpm

--- a/editor/keyboard-shortcuts.mdx
+++ b/editor/keyboard-shortcuts.mdx
@@ -49,7 +49,7 @@ Use these shortcuts when editing in Visual mode.
 
 | Command | macOS | Windows |
 | :--- | :--- | :--- |
-| **Add link** (when text is selected) | <kbd>Cmd</kbd> + <kbd>K</kbd> | <kbd>Ctrl</kbd> + <kbd>K</kbd> |
+| **Add link** to selected text | <kbd>Cmd</kbd> + <kbd>K</kbd> | <kbd>Ctrl</kbd> + <kbd>K</kbd> |
 | **Add line break** | <kbd>Cmd</kbd> + <kbd>Enter</kbd> | <kbd>Ctrl</kbd> + <kbd>Enter</kbd> |
 | **Component menu** | <kbd>/</kbd> | <kbd>/</kbd> |
 


### PR DESCRIPTION
## Documentation changes

This PR adds a table of smart substitution shortcuts in the editor.

Closes https://linear.app/mintlify/issue/DOC-274/document-typography-keyboard-shortcuts-in-the-editor

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a small Vale dictionary update; no runtime behavior or security-sensitive logic is modified.
> 
> **Overview**
> Adds a new **Smart substitutions** section to `editor/keyboard-shortcuts.mdx`, documenting the character sequences the editor auto-converts (e.g., `->` →, `!=` ≠) and noting substitutions are skipped in inline/code blocks.
> 
> Also tweaks the Visual mode link shortcut wording and updates the Vale accepted vocabulary to allow `outdent` (case-insensitive) to avoid lint failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9b1e5b200763931637a91030f18a6893ee49154. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->