### PR TITLE
Document api.spec.download field

### DIFF
--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -843,6 +843,15 @@ This section contains the full reference for the `docs.json` file.
         </ResponseField>
       </Expandable>
     </ResponseField>
+    <ResponseField name="spec" type="object">
+      Configurations for the OpenAPI spec.
+
+      <Expandable title="Spec">
+        <ResponseField name="download" type="boolean">
+          Whether to show a download button for the OpenAPI spec on API reference pages. Defaults to `false`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
     <ResponseField name="mdx" type="object">
       Configurations for API pages generated from MDX files.
 


### PR DESCRIPTION
Added documentation for the new `api.spec.download` configuration field that controls whether a download button for OpenAPI specs appears on API reference pages. This field defaults to `false` and allows users to enable spec file downloads for their API documentation.

## Files changed
- `organize/settings.mdx` - Added documentation for the new `api.spec` configuration object with the `download` boolean property

Generated from [Add spec download field to docs.json](https://github.com/mintlify/mint/pull/6216) @k-finken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it adds a new config field reference without affecting runtime behavior.
> 
> **Overview**
> Documents a new `api.spec` configuration object in `organize/settings.mdx`, adding `api.spec.download` (default `false`) to control whether API reference pages show an OpenAPI spec download button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4044f6da48a194b37d1a8cd68a06951a3fc9ae5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->