### PR TITLE
Add warning about vale comments

### DIFF
--- a/deploy/ci.mdx
+++ b/deploy/ci.mdx
@@ -419,3 +419,9 @@ This text is ignored by Vale
 ```
 
 Vale automatically recognizes and respects these comments in MDX files without additional configuration. Use comments to skip lines or sections that should be ignored by the linter.
+
+<Warning>
+  Do not place `{/* vale off */}` or similar MDX expression comments as direct children of a JSX component between sibling elements. For example, between two `<Step>` elements inside a `<Steps>` component.
+  
+  Place comments inside a specific element's content or restructure the content to avoid needing comments.
+</Warning>


### PR DESCRIPTION
## Documentation changes

Add a warning about using Vale comments as children of JSX elements since it causes parsing errors.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance to avoid an MDX parsing pitfall; no code or runtime behavior is affected.
> 
> **Overview**
> Adds a new **Warning** in `deploy/ci.mdx` clarifying that Vale MDX comments (e.g., `{/* vale off */}`) should not be placed as direct children between JSX sibling elements (such as between `<Step>` items in `<Steps>`), and recommends moving the comment inside an element or restructuring content to prevent parsing errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75e2f024d02054c3328ab34c88b15e37a06c456c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->