### PR TITLE
fix variable format in docs

### DIFF
--- a/organize/settings.mdx
+++ b/organize/settings.mdx
@@ -348,23 +348,13 @@ This section contains the full reference for the `docs.json` file.
 </ResponseField>
 
 <ResponseField name="variables" type="object">
-  Global variables for use throughout your documentation. Variables use `{{variableName}}` syntax and are replaced at build time.
+  Global variables for use throughout your documentation. Variables are replaced at build time using `{{variableName}}` syntax.
 
-  ```json
-  "variables": {
-    "version": "1.0.0",
-    "api-url": "https://api.example.com"
-  }
-  ```
-
-  Reference variables in your MDX content:
-
-  ```mdx
-  The current version is {{version}}.
-  Make requests to {{api-url}}/v1/users.
-  ```
-
-  Variable names can contain alphanumeric characters, hyphens, and periods. Values are sanitized to prevent XSS attacks. Undefined variables remain as literal text.
+  <Expandable title="Variables">
+    <ResponseField name="variableName" type="string">
+      A key-value pair where the key is the variable name and the value is the replacement text. All variables referenced in your content must be defined, or the build will fail. Variable names can contain alphanumeric characters, hyphens, and periods. Values are sanitized to prevent XSS attacks.
+    </ResponseField>
+  </Expandable>
 </ResponseField>
 
 ### Structure
@@ -1293,6 +1283,10 @@ This section contains the full reference for the `docs.json` file.
           "value": "example_cookie_value"
         }
       },
+      "variables": {
+        "version": "2.0.0",
+        "api-url": "https://api.example.com"
+      },
       "contextual": {
         "options": [
           "copy",
@@ -1468,6 +1462,10 @@ This section contains the full reference for the `docs.json` file.
           "key": "example_cookie_key",
           "value": "example_cookie_value"
         }
+      },
+      "variables": {
+        "version": "2.0.0",
+        "api-url": "https://api.example.com"
       },
       "contextual": {
         "options": [
@@ -1656,6 +1654,10 @@ This section contains the full reference for the `docs.json` file.
           "key": "example_cookie_key",
           "value": "example_cookie_value"
         }
+      },
+      "variables": {
+        "version": "2.0.0",
+        "api-url": "https://api.example.com"
       },
       "contextual": {
         "options": ["copy", "view", "chatgpt", "claude"]


### PR DESCRIPTION
## Documentation changes

Fix variable format to be a drop down and have example in examples section


---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the `docs.json` reference and examples; no runtime code or behavior is modified.
> 
> **Overview**
> Updates `organize/settings.mdx` to reformat the `variables` setting documentation into an `Expandable` reference entry and clarifies that *all referenced variables must be defined (build fails otherwise)*.
> 
> Adds `variables` blocks (e.g., `version`, `api-url`) to the `docs.json` examples so the documented syntax is demonstrated in the examples section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06988ca63cc70495a870ff153622aaeb48fc9a58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->