### PR TITLE
fix: editor search keyboard shortcut

### DIFF
--- a/editor/keyboard-shortcuts.mdx
+++ b/editor/keyboard-shortcuts.mdx
@@ -74,7 +74,7 @@ Markdown mode uses the Monaco editor, which supports standard VS Code keyboard s
 
 | Command | macOS | Windows |
 | :--- | :--- | :--- |
-| **Search files** | <kbd>Cmd</kbd> + <kbd>P</kbd> | <kbd>Ctrl</kbd> + <kbd>P</kbd> |
+| **Search files** | <kbd>Cmd</kbd> + <kbd>K</kbd> | <kbd>Ctrl</kbd> + <kbd>K</kbd> |
 | **Find** | <kbd>Cmd</kbd> + <kbd>F</kbd> | <kbd>Ctrl</kbd> + <kbd>F</kbd> |
 
 ### Editing


### PR DESCRIPTION
## Documentation changes

cmd+P was replaced with cmd+K

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single keyboard shortcut reference; no runtime or behavioral code is modified.
> 
> **Overview**
> Updates the `editor/keyboard-shortcuts.mdx` documentation to reflect that **Markdown mode “Search files”** now uses <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>K</kbd> instead of <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>P</kbd>.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 147d1a132ce74ed47a89637567926bf80b43868f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->