### PR TITLE
fix: remove suggestions pages from translations

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -438,9 +438,7 @@
                     "group": "Assistant IA",
                     "pages": [
                       "fr/agent/index",
-                      "fr/agent/quickstart",
                       "fr/agent/slack",
-                      "fr/agent/suggestions",
                       "fr/agent/customize",
                       "fr/agent/effective-prompts",
                       "fr/agent/workflows"
@@ -794,9 +792,7 @@
                     "group": "Asistente",
                     "pages": [
                       "es/agent/index",
-                      "es/agent/quickstart",
                       "es/agent/slack",
-                      "es/agent/suggestions",
                       "es/agent/customize",
                       "es/agent/effective-prompts",
                       "es/agent/workflows"
@@ -1150,9 +1146,7 @@
                     "group": "AI 助手",
                     "pages": [
                       "zh/agent/index",
-                      "zh/agent/quickstart",
                       "zh/agent/slack",
-                      "zh/agent/suggestions",
                       "zh/agent/customize",
                       "zh/agent/effective-prompts",
                       "zh/agent/workflows"


### PR DESCRIPTION
## Documentation changes

This PR removes the es/ zh/ and fr/ pages form navigation groups that were removed in other PRs.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates navigation entries for translated docs. Main risk is unintended broken links or missing navigation items if any removed pages still exist or are referenced elsewhere.
> 
> **Overview**
> Removes `agent/quickstart` and `agent/suggestions` from the **French, Spanish, and Chinese** navigation groups in `docs.json`, aligning translated navigation with pages that were removed previously.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 389a34f0f875eace6bfcb3be9b086bf0d7fcd6f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->