### PR TITLE
Remove broken changelog link

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -331,7 +331,7 @@ noindex: true
 <Update label="December 12, 2025" tags={["New releases", "Improvements"]} rss={{  title: "Agent suggestions and Q&A bots" }}>
   ## Agent suggestions
   
-  The agent can now monitor Git repositories and [suggest](/agent/suggestions) documentation updates. When user-facing code changes are detected, suggestions appear in the agent panel. Suggestions include the relevant pull request and a list of proposed documentation updates. Add suggestions as context for the agent to create pull requests or dismiss them.
+  The agent can now monitor Git repositories and suggest documentation updates. When user-facing code changes are detected, suggestions appear in the agent panel. Suggestions include the relevant pull request and a list of proposed documentation updates. Add suggestions as context for the agent to create pull requests or dismiss them.
 
   ## Q&A bots in Slack and Discord
 


### PR DESCRIPTION
## Documentation changes

Will fix the failing CI check after it's translated.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a broken markdown link in the changelog; no runtime or product behavior impact.
> 
> **Overview**
> Removes a broken markdown link from the December 12, 2025 changelog entry by converting `[suggest](/agent/suggestions)` into plain text, avoiding an invalid/incorrect destination in published docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05139460447b141befa477372b010bd26729d4b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->