### PR TITLE
Add broken-link flags

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -175,7 +175,7 @@ If this `mint update` command is not available on your local version, re-install
 
 ### Find broken links
 
-Identify any broken internal links with the following command:
+Identify broken links in your documentation:
 
 ```bash
 mint broken-links
@@ -183,11 +183,13 @@ mint broken-links
 
 The command ignores files matching [.mintignore](/organize/mintignore) patterns. Links that point to ignored files are reported as broken.
 
-To also check anchor links like `/path/to/page#anchor`, use the `--check-anchors` flag:
+By default, only internal links are checked. Use flags to expand the scope:
 
-```bash
-mint broken-links --check-anchors
-```
+| Flag | Description |
+| --- | --- |
+| `--check-anchors` | Also validate anchor links (for example, `/page#section`) against heading slugs. |
+| `--check-external` | Also check external links for broken URLs. |
+| `--check-snippets` | Also check links inside `<Snippet>` components. |
 
 ### Find accessibility issues
 


### PR DESCRIPTION
## Documentation changes

Closes https://linear.app/mintlify/issue/DOC-246/docs-for-onb-119-support-anchor-links-in-mint-broken-links

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates CLI usage guidance without affecting runtime behavior.
> 
> **Overview**
> Updates `installation.mdx` to clarify `mint broken-links` behavior and document additional flags. The broken-links section is reorganized into a small flag reference table covering `--check-anchors`, `--check-external`, and `--check-snippets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e591c5b2c6f6216d08115e48e064e9c1dc635494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->