### PR TITLE
Add updated Vale default to changelog

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -19,6 +19,10 @@ noindex: true
 
   The assistant now also builds context from the page a user is on and indexes entire OpenAPI specifications.
 
+  ## Default Vale configuration updates
+
+  The default [Vale configuration](/deploy/ci#configuration) now parses MDX as MD to avoid fragility with JSX. Previously, Vale returned false positive errors on any JSX inside of MDX components. Now, Vale parses MDX as MD to avoid these errors with tokenIgnores and blockIgnores for MDX and JSX elements that Vale should skip.
+
   ## Improvements
 
   - Workflows now support up to 50 runs per day, increased from 20.


### PR DESCRIPTION
## Documentation changes

Updates the changelog to include info on the default Vale config.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the changelog text without affecting product behavior or configuration defaults.
> 
> **Overview**
> Adds a new **“Default Vale configuration updates”** section to `changelog.mdx` (March 6, 2026 entry) noting that the default Vale config now parses MDX as Markdown and ignores MDX/JSX elements to avoid JSX-related false positives.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a428b786fb84ca06e1f189a9c0c40dfdf6c47bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->