### PR TITLE
Add partial auth support for MCP

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -43,11 +43,11 @@ AI tools can search the web, but MCP provides distinct advantages for documentat
 
 ## Access your MCP server
 
-Mintlify automatically generates an MCP server for your documentation and hosts it at the `/mcp` path of your documentation URL. For example, Mintlify's MCP server is available at `https://mintlify.com/docs/mcp`.
+Mintlify generates an MCP server for your documentation and hosts it at the `/mcp` path of your documentation URL. For example, Mintlify's MCP server is available at `https://mintlify.com/docs/mcp`.
 
-For public documentation, your MCP server is available to anyone. It searches all indexed public pages.
-
-For documentation that requires authentication, you must enable your MCP server before it is available to users. Users must authenticate before connecting to your MCP server. Your MCP server searches only the content each user has access to based on their [user groups](/deploy/authentication-setup).
+* For public documentation, your MCP server is available to anyone. It searches all indexed public pages.
+* For documentation with partial authentication, where some pages are public and others are protected, you must enable your MCP server before it is available to users. Unauthenticated users can search public content. Users who authenticate can search all content they have permission to access based on their [user groups](/deploy/authentication-setup).
+* For documentation where all pages require authentication, you must enable your MCP server before it is available to users. Users must authenticate before connecting to your MCP server. Your MCP server searches only the content each user has access to based on their [user groups](/deploy/authentication-setup).
 
 View and copy your MCP server URL on the [MCP server page](https://dashboard.mintlify.com/products/mcp) in your dashboard.
 
@@ -63,6 +63,8 @@ View and copy your MCP server URL on the [MCP server page](https://dashboard.min
 ### Enable authenticated MCP
 
 If your documentation requires authentication, your MCP server requires users to authenticate before connecting. When a user adds your MCP server URL to their AI tool, they must log in with their existing credentials. After authenticating, a redirect sends them back to their tool. The MCP server only returns content each user has permission to access based on their [user groups](/deploy/authentication-setup).
+
+If your documentation has partial authentication with both public and protected pages, users can connect to your MCP server without authenticating to access public content. Users who authenticate gain access to protected content available to them.
 
 By default, your MCP server is only available for localhost tools. To allow web-based tools to connect, add the redirect domains for the AI tools. A redirect domain is the hostname that an AI tool uses after a user completes authentication like `claude.ai` or `app.cursor.ai`. Your users' AI tools cannot complete authentication unless their redirect domain is on this list.
 
@@ -91,7 +93,7 @@ To protect availability, Mintlify applies rate limits to MCP servers.
 
 Your MCP server searches content that Mintlify indexes from your documentation repository. File processing and search indexing control what content is available through your MCP server.
 
-For documentation that requires authentication, your MCP server only indexes pages in [public user groups](/deploy/authentication-setup#make-pages-public).
+For documentation that requires authentication, your MCP server only indexes pages in [public user groups](/deploy/authentication-setup#make-pages-public). For documentation with partial authentication, your MCP server indexes public pages for unauthenticated users and any pages in public user groups.
 
 ### File processing with `.mintignore`
 


### PR DESCRIPTION
## Documentation changes


---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies auth/indexing behavior; no runtime or security logic is modified.
> 
> **Overview**
> Updates the MCP documentation to explicitly cover **partial authentication** setups (mix of public and protected pages).
> 
> Clarifies when the hosted MCP server must be enabled, what unauthenticated vs authenticated users can search, and how indexing/content filtering behaves for partially-authenticated docs (including public pages and pages in public user groups).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38dc6a982548a79184e48c096b79f90a64fc8738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->