### PR TITLE
Slack channel ids for workflows notification

### DIFF
--- a/.mintlify/workflows/changelog-generator.md
+++ b/.mintlify/workflows/changelog-generator.md
@@ -5,6 +5,10 @@ on:
 context:
   - repo: "mintlify/server"
   - repo: "mintlify/mint"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 automerge: false
 ---
 

--- a/.mintlify/workflows/code-changes-to-the-frontend.md
+++ b/.mintlify/workflows/code-changes-to-the-frontend.md
@@ -5,6 +5,10 @@ on:
     - repo: "mintlify/mint"
 context:
   - repo: "mintlify/mint"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 ---
 
 Anytime you see a frontend change to the way something renders. Make sure to open a PR modifying the relevant document to clarify that.

--- a/.mintlify/workflows/draft-feature-docs.md
+++ b/.mintlify/workflows/draft-feature-docs.md
@@ -8,6 +8,10 @@ on:
       branch: main
 context:
   - repo: "mintlify/docs"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 automerge: false
 ---
 

--- a/.mintlify/workflows/seo-audit.md
+++ b/.mintlify/workflows/seo-audit.md
@@ -2,6 +2,10 @@
 name: "SEO and metadata audit"
 on:
   cron: "0 9 * * 1"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 automerge: false
 ---
 

--- a/.mintlify/workflows/translate.md
+++ b/.mintlify/workflows/translate.md
@@ -4,6 +4,10 @@ on:
   push:
     - repo: "mintlify/docs"
       branch: "main"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 ---
 
 Translate any MDX files and API spec files changed by the last merged PR into all supported languages, and mirror any structural changes to `docs.json`.

--- a/.mintlify/workflows/translation-lag.md
+++ b/.mintlify/workflows/translation-lag.md
@@ -2,6 +2,10 @@
 name: "Translation lag tracker"
 on:
   cron: "3 15 * * 3"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 ---
 
 Compare the English MDX files in the repo against their counterparts in the `es/`, `fr/`, and `zh/` subdirectories. Use git history to find English files updated more recently than their translations.

--- a/.mintlify/workflows/update-api-reference.md
+++ b/.mintlify/workflows/update-api-reference.md
@@ -8,6 +8,10 @@ on:
       branch: main
 context:
   - repo: "mintlify/docs"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 automerge: false
 ---
 

--- a/.mintlify/workflows/update-vale-vocab.md
+++ b/.mintlify/workflows/update-vale-vocab.md
@@ -4,6 +4,10 @@ on:
   push:
     - repo: "mintlify/docs"
       branch: "main"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 ---
 
 Find words flagged by Vale spelling errors in the files changed by the last merged PR, and add valid ones to the Vale vocabulary.

--- a/.mintlify/workflows/vale-audit.md
+++ b/.mintlify/workflows/vale-audit.md
@@ -2,6 +2,10 @@
 name: "Vale style audit"
 on:
   cron: "0 15 * * 4"
+notify:
+  slack:
+    channel_ids:
+      - C0AKYE83VV4
 ---
 
 # Steps


### PR DESCRIPTION
## Documentation changes

Slack channel ids for workflows notification


---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that just adds `notify.slack.channel_ids` to workflow frontmatter; main risk is misrouting or noisy Slack notifications if the channel ID is wrong.
> 
> **Overview**
> Adds `notify: slack: channel_ids: [C0AKYE83VV4]` to the frontmatter of several `.mintlify/workflows/*.md` workflows (changelog generation, frontend-change doc prompts, feature-doc drafting, SEO/translation/Vale audits, and API reference updates) so their runs post notifications to a specific Slack channel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36b71b0eec2694ac5cde5503047af1b357cf96cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->