### PR TITLE
chore: offsite doc issues

### DIFF
--- a/api-playground/overview.mdx
+++ b/api-playground/overview.mdx
@@ -213,8 +213,8 @@ The playground automatically renders responses based on the `Content-Type` heade
 
 - **Images**: Rendered inline (`image/*`).
 - **Audio**: Rendered with a built-in audio player (`audio/*`).
-- **Video**: Rendered with a built-in video player (`video/*`). Any response with a `video/*` content type, such as `video/mp4` or `video/webm`, displays as a playable video directly in the playground. No additional configuration is required.
-- **All other responses**: Displayed in a code block. JSON responses are automatically detected, pretty-printed, and syntax-highlighted.
+- **Video**: Rendered with a built-in video player (`video/*`). Any response with a `video/*` content type, such as `video/mp4` or `video/webm`, displays as a playable video directly in the playground.
+- **All other responses**: Displayed in a code block.
 
 ## Further reading
 


### PR DESCRIPTION
## Documentation changes

Wrapping up all the docs issues that were assigned to Ricky.

Closes https://linear.app/mintlify/issue/DOC-198/cover-unauthenticated-feedback-and-ai-404-suggestions-in-docs
Closes https://linear.app/mintlify/issue/DOC-197/add-docs-for-api-playground-video-responses-and-disableproxy-uploads

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Improves the API Playground docs by expanding `api.playground.proxy` guidance to clarify when requests are routed through Mintlify vs sent directly from the browser, including scenarios where disabling the proxy is useful.
> 
> Adds a new **Response rendering** section documenting how the playground displays responses based on `Content-Type` (inline images, built-in audio/video players, otherwise code block).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f95a1c63461e3fb0022cdd41c18adaa631f3125a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->