### PR TITLE
API reference deprecated endpoints

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -352,10 +352,7 @@
                 "pages": [
                   "api/agent/v2/create-agent-job",
                   "api/agent/v2/get-agent-job",
-                  "api/agent/v2/send-message",
-                  "api/agent/create-agent-job",
-                  "api/agent/get-agent-job",
-                  "api/agent/get-all-jobs"
+                  "api/agent/v2/send-message"
                 ]
               },
               {
@@ -709,10 +706,7 @@
                 "pages": [
                   "fr/api/agent/v2/create-agent-job",
                   "fr/api/agent/v2/get-agent-job",
-                  "fr/api/agent/v2/send-message",
-                  "fr/api/agent/create-agent-job",
-                  "fr/api/agent/get-agent-job",
-                  "fr/api/agent/get-all-jobs"
+                  "fr/api/agent/v2/send-message"
                 ]
               },
               {
@@ -1066,10 +1060,7 @@
                 "pages": [
                   "es/api/agent/v2/create-agent-job",
                   "es/api/agent/v2/get-agent-job",
-                  "es/api/agent/v2/send-message",
-                  "es/api/agent/create-agent-job",
-                  "es/api/agent/get-agent-job",
-                  "es/api/agent/get-all-jobs"
+                  "es/api/agent/v2/send-message"
                 ]
               },
               {
@@ -1434,10 +1425,7 @@
                 "pages": [
                   "zh/api/agent/v2/create-agent-job",
                   "zh/api/agent/v2/get-agent-job",
-                  "zh/api/agent/v2/send-message",
-                  "zh/api/agent/create-agent-job",
-                  "zh/api/agent/get-agent-job",
-                  "zh/api/agent/get-all-jobs"
+                  "zh/api/agent/v2/send-message"
                 ]
               },
               {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Documentation changes

Removed deprecated v1 Agent API endpoints from the API reference navigation across all language versions (en, fr, es, zh). The deprecated files still exist but are no longer discoverable via the sidebar.

**Removed Endpoints:**
*   `api/agent/create-agent-job` (v1)
*   `api/agent/get-agent-job` (v1)
*   `api/agent/get-all-jobs` (v1)

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [x] Instructions are clear and easy to follow
- [x] Steps are in logical order
- [x] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [x] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

[Slack Thread](https://mintlify.slack.com/archives/C07M02Q0D6V/p1773535710568929?thread_ts=1773535710.568929&cid=C07M02Q0D6V)

<div><a href="https://cursor.com/agents/bc-052f0e51-3964-5eb9-acf3-188fdc974bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-052f0e51-3964-5eb9-acf3-188fdc974bf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->