### PR TITLE
Update locale codes

### DIFF
--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -149,7 +149,7 @@ Language switcher in the global nav.
 
 **Type:** array of object — each with: `language` (string, required), `default` (boolean), `hidden` (boolean), `href` (string uri, required)
 
-**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
+**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
 
 ##### `navigation.global.versions`
 
@@ -169,7 +169,7 @@ Language switcher for multi-language sites. Each entry can include language-spec
 
 **Type:** array of object — each with: `language` (string, required), `default` (boolean), `hidden` (boolean), `banner` (object), `footer` (object), `navbar` (object)
 
-**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
+**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
 
 #### `navigation.versions`
 

--- a/organize/settings-structure.mdx
+++ b/organize/settings-structure.mdx
@@ -89,7 +89,7 @@ See [Navigation](/organize/navigation) for complete documentation on building yo
       Language switcher configuration for localized sites. See [Languages](/organize/navigation#languages).
 
       <Expandable title="languages">
-        <ResponseField name="language" type='"ar" | "ca" | "cn" | "cs" | "de" | "en" | "es" | "fr" | "he" | "hi" | "hu" | "id" | "it" | "ja" | "jp" | "ko" | "lv" | "nl" | "no" | "pl" | "pt" | "pt-BR" | "ro" | "ru" | "sv" | "tr" | "uk" | "uz" | "vi" | "zh" | "zh-Hans" | "zh-Hant"' required>
+        <ResponseField name="language" type='"ar" | "ca" | "cn" | "cs" | "de" | "en" | "es" | "fr" | "fr-CA" | "he" | "hi" | "hu" | "id" | "it" | "ja" | "jp" | "ko" | "lv" | "nl" | "no" | "pl" | "pt" | "pt-BR" | "ro" | "ru" | "sv" | "tr" | "uk" | "uz" | "vi" | "zh" | "zh-Hans" | "zh-Hant"' required>
           Language code in ISO 639-1 format.
         </ResponseField>
         <ResponseField name="default" type="boolean">
@@ -143,7 +143,7 @@ See [Navigation](/organize/navigation) for complete documentation on building yo
   Language switcher for [multi-language](/organize/navigation#languages) sites. Each entry can include language-specific `banner`, `footer`, and `navbar` configurations in addition to the navigation structure.
 
   <Expandable title="navigation.languages">
-    <ResponseField name="language" type='"ar" | "ca" | "cn" | "cs" | "de" | "en" | "es" | "fr" | "he" | "hi" | "hu" | "id" | "it" | "ja" | "jp" | "ko" | "lv" | "nl" | "no" | "pl" | "pt" | "pt-BR" | "ro" | "ru" | "sv" | "tr" | "uk" | "uz" | "vi" | "zh" | "zh-Hans" | "zh-Hant"' required>
+    <ResponseField name="language" type='"ar" | "ca" | "cn" | "cs" | "de" | "en" | "es" | "fr" | "fr-CA" | "he" | "hi" | "hu" | "id" | "it" | "ja" | "jp" | "ko" | "lv" | "nl" | "no" | "pl" | "pt" | "pt-BR" | "ro" | "ru" | "sv" | "tr" | "uk" | "uz" | "vi" | "zh" | "zh-Hans" | "zh-Hant"' required>
       Language code in ISO 639-1 format.
     </ResponseField>
     <ResponseField name="default" type="boolean">


### PR DESCRIPTION
## Documentation changes

Adds missing locale codes

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that adjust listed locale codes; no runtime or schema logic changes.
> 
> **Overview**
> Updates the `docs.json` documentation to reflect additional/updated locale options for navigation language switchers.
> 
> Specifically, the supported language code lists now include `fr-CA` and `hu`, and replace the nonstandard `ua` code with `uk` in both the schema reference and site-structure docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07422fa52abbe56f9be3eeb3369a0acbec7f7b92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->