### PR TITLE
Automerge translations

### DIFF
--- a/.mintlify/workflows/translate.md
+++ b/.mintlify/workflows/translate.md
@@ -8,22 +8,20 @@ notify:
   slack:
     channel_ids:
       - C0AKYE83VV4
+automerge: true
 ---
 
-Translate any MDX files and API spec files changed since the last translation PR into all supported languages, and mirror any structural changes to `docs.json`. There should always be at most one open translation PR. Each run closes any existing translation PR, deletes its branch, and opens a fresh one covering all changes since the previous translation PR was created.
+Translate any MDX files and API spec files changed since the last merged translation PR into all supported languages, and mirror any structural changes to `docs.json`.
 
 ## Steps
 
-1. Find any open pull request in `mintlify/docs` with the label `translation`. If one exists, note its branch name, close it, and delete its branch.
-2. Determine the base commit for this translation run:
-   - If a previous translation PR was found in step 1, use the commit that was the merge base of that PR's branch and `main` at the time the PR was created (i.e., the point on `main` from which that branch diverged). This ensures no changes are missed between runs.
-   - If no previous translation PR existed, use the base commit of the last merged PR.
-3. Diff `main` from that base commit to `HEAD` to identify all added, modified, and deleted English-language files.
-4. For each **deleted** English MDX file, delete the corresponding translated files in all language subdirectories (`es/`, `fr/`, `zh/`).
-5. For each **added or modified** English MDX file, translate the content into each supported language. Write translated files to the appropriate language subdirectories, mirroring the source file path.
-6. If any root-level API spec file was changed (`openapi.json`, `discovery-openapi.json`, `analytics.openapi.json`, `admin-openapi.json`, `asyncapi.yaml`), translate the human-readable string values (such as `description`, `summary`, and `title` fields) into each supported language. Write translated files to the corresponding path in each language subdirectory (for example, `openapi.json` → `es/openapi.json`, `fr/openapi.json`, `zh/openapi.json`). Only translate prose strings—do not translate keys, enum values, types, format strings, or any other non-prose fields.
-7. If `docs.json` was changed, apply the equivalent structural changes to `docs.json` for all translated language sections. See [Updating docs.json](#updating-docsjson) for details.
-8. Open a pull request with the translated files and any `docs.json` changes. Apply the `translation` label to the PR so future runs can identify and replace it.
+1. Determine the base commit for this translation run: use the base commit of the last merged PR with the label `translation`. If no such PR exists, use the base commit of the last merged PR.
+2. Diff `main` from that base commit to `HEAD` to identify all added, modified, and deleted English-language files.
+3. For each **deleted** English MDX file, delete the corresponding translated files in all language subdirectories (`es/`, `fr/`, `zh/`).
+4. For each **added or modified** English MDX file, translate the content into each supported language. Write translated files to the appropriate language subdirectories, mirroring the source file path.
+5. If any root-level API spec file was changed (`openapi.json`, `discovery-openapi.json`, `analytics.openapi.json`, `admin-openapi.json`, `asyncapi.yaml`), translate the human-readable string values (such as `description`, `summary`, and `title` fields) into each supported language. Write translated files to the corresponding path in each language subdirectory (for example, `openapi.json` → `es/openapi.json`, `fr/openapi.json`, `zh/openapi.json`). Only translate prose strings—do not translate keys, enum values, types, format strings, or any other non-prose fields.
+6. If `docs.json` was changed, apply the equivalent structural changes to `docs.json` for all translated language sections. See [Updating docs.json](#updating-docsjson) for details.
+7. Open a pull request with the translated files and any `docs.json` changes. Apply the `translation` label to the PR and enable automerge.
 
 ## Important
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only workflow guidance changes; no production code paths are modified, with the main risk being altered translation PR automation expectations.
> 
> **Overview**
> **Translation workflow guidance is updated to rely on the last *merged* `translation` PR as the diff baseline** (instead of managing/closing an existing open translation PR) and the intro text is adjusted accordingly.
> 
> **Enables automerge for translation PRs** by adding `automerge: true` to the workflow frontmatter and explicitly instructing that newly opened translation PRs should have automerge enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20efce249445d93e0b02d1323293ddce645662ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->