### PR TITLE
/authed/mcp endpoint for partial-auth sites

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -57,14 +57,19 @@ View and copy your MCP server URL on the [MCP server page](https://dashboard.min
 </Frame>
 
 <Note>
-  Hosted MCP servers use the `/mcp` path in their URLs. Other navigation elements cannot use the `/mcp` path.
+  Hosted MCP servers use the `/mcp` and `/authed/mcp` paths. Other navigation elements cannot use these paths.
 </Note>
 
 ### Enable authenticated MCP
 
 If your documentation requires authentication, your MCP server requires users to authenticate before connecting. When a user adds your MCP server URL to their AI tool, they must log in with their existing credentials. After authenticating, a redirect sends them back to their tool. The MCP server only returns content each user has permission to access based on their [user groups](/deploy/authentication-setup).
 
-If your documentation has partial authentication with both public and protected pages, users can connect to your MCP server without authenticating to access public content. Users who authenticate gain access to protected content available to them.
+If your documentation has partial authentication with both public and protected pages, you have two MCP server endpoints:
+
+- `/mcp`: Does not require authentication. Returns only public content. Share this with users who need access to public content.
+- `/authed/mcp`: Always requires authentication. Returns content scoped to each user's permissions based on their [user groups](/deploy/authentication-setup). Share this with users who need access to protected content.
+
+The `/authed/mcp` endpoint uses its own OAuth flow at `/authed/mcp/oauth/*`. Redirect domains configured for your MCP server apply to both `/mcp` and `/authed/mcp`.
 
 By default, your MCP server is only available for localhost tools. To allow web-based tools to connect, add the redirect domains for the AI tools. A redirect domain is the hostname that an AI tool uses after a user completes authentication like `claude.ai` or `app.cursor.ai`. Your users' AI tools cannot complete authentication unless their redirect domain is on this list.
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes https://github.com/mintlify/docs/pull/4671
Closes https://github.com/mintlify/docs/pull/4672

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change, but inaccuracies could confuse customers configuring MCP endpoints and OAuth redirects.
> 
> **Overview**
> Clarifies hosted MCP URL constraints by reserving both `/_mcp_` and `/_authed/mcp_` paths.
> 
> Updates the *partial authentication* guidance to document two endpoints—`/mcp` (public-only) and `/authed/mcp` (always requires auth, permission-scoped)—and notes that `/authed/mcp` uses a dedicated OAuth flow under `/authed/mcp/oauth/*` while sharing the same configured redirect domains.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8dce17905c186ed707be75382d116ca626f40d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->