### PR TITLE
Add feature availability chart for headless projects

### DIFF
--- a/guides/custom-frontend.mdx
+++ b/guides/custom-frontend.mdx
@@ -7,13 +7,33 @@ keywords: ["Astro", "headless", "self-hosted", "custom", "headless docs", "headl
 
 Mintlify's headless mode lets you control how your documentation looks and behaves while using Mintlify to manage your content. Instead of using Mintlify's hosted frontend, you can build your own custom frontend with [Astro](https://astro.build) and render your MDX content and `docs.json` configuration however you want.
 
-This headless approach is useful when you need full control over your documentation's design, layout, or behavior to match an existing design system or embed documentation into a larger site.
+This headless approach is useful when you need full control over your documentation's design, layout, or behavior to match an existing design system or embed documentation into a larger site while still using Mintlify for publishing, search, MDX components, and AI features.
 
-The `@mintlify/astro` integration reads your `docs.json` config and MDX content at build time, then processes everything into a format that Astro can render. Use your own layouts, components, and styles on top of it.
-
-With a headless custom frontend, you can still use Mintlify components without importing them and you have the publishing, search, and AI infrastructure.
+The `@mintlify/astro` integration reads your `docs.json` config and MDX content at build time, then processes everything into a format that Astro can render. Build your own layouts, components, and styles on top of it.
 
 This guide walks you through setting up a headless Mintlify project with the starter template and getting it running locally.
+
+<Expandable title="Feature availability for headless projects">
+| Feature | Availability | Notes |
+|---------|--------------|-------|
+| Mintlify components | Included | Use components like `<Card>`, `<Steps>`, and `<Tabs>` in your MDX files without importing them. |
+| Content processing | Included | The `@mintlify/astro` integration reads your `docs.json` and MDX files and processes them at build time. |
+| Search | Included | The `SearchBar` component connects to Mintlify's search API using your project subdomain. |
+| AI assistant | Included | The `Assistant` component provides an AI chat interface powered by your content. Available on [Pro and Enterprise plans](https://mintlify.com/pricing). |
+| Layouts and styling | Custom build | Header, footer, sidebar, table of contents, page templates, and all CSS. The starter template includes examples built with Tailwind CSS. |
+| Routing and navigation | Custom build | A catch-all Astro route renders each page. Use `resolvePageData()` and `unwrapNav()` from `@mintlify/astro/helpers` to resolve navigation state from `docs.json`. |
+| Deployment and hosting | Custom build | Deploy your Astro site to any hosting provider. |
+| SEO | You build | Meta tags, Open Graph tags, sitemap, and `robots.txt` are your responsibility to generate. |
+| Third-party integrations | Custom build | Add integrations directly to your Astro layout. Tools configured in `docs.json` for hosted projects do not apply in headless. |
+| `llms.txt`, `llms-full.txt`, and `skill.md` | Custom build | For headless projects, you must generate and serve these files. |
+| Dashboard analytics | Custom build | If you use the `Assistant` component, assistant usage analytics are available in your dashboard. For page traffic, add your own analytics provider to your Astro layout. |
+| Web editor | Not available | Requires Mintlify's hosted rendering environment. |
+| Authentication and password protection | Not available | Only available for sites hosted on a Mintlify subdomain or custom domain pointed at Mintlify. |
+| API playground | Not available | Only available for sites hosted on the Mintlify platform. |
+| User feedback | Not available | The page feedback feature is part of Mintlify's hosted rendering layer. |
+| Preview deployments | Not available | Use your hosting provider's preview environment. |
+| PDF export | Not available | Not available for headless projects. |
+</Expandable>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Documentation changes

Clarify which features are available for headless projects, which are unavailable, and which must be built by the user.

Closes https://linear.app/mintlify/issue/DOC-307/clarify-ownership-and-differences-for-headless-docs

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies what Mintlify provides vs what users must implement in headless/Astro setups.
> 
> **Overview**
> Updates the headless custom frontend guide to more explicitly position headless mode as *bringing Mintlify publishing/search/components/AI* while you control the frontend.
> 
> Adds an expandable **feature availability** matrix that spells out what’s *included*, what’s *custom/user-built*, and what’s *not available* in headless projects (e.g., SEO ownership, routing/layout responsibilities, and limitations like web editor/auth/API playground).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d34c5f5f22a2e6e4a5cf7793feb62ab943d83f8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->