### PR TITLE
Add client credentials grant documentation for MCP

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -115,7 +115,7 @@ Client credentials authenticate against the `/authed/mcp` endpoint and return th
     1. Navigate to the [MCP server page](https://dashboard.mintlify.com/products/mcp) in your dashboard.
     2. In the **Client Credentials** section, select **Create credential**.
     3. Enter a label for the credential to identify its purpose.
-    4. Copy the **client ID** and **client secret**. The client secret is only shown once and cannot be retrieved later.
+    4. Copy the **client ID** and **client secret**. The client secret is only shown once. You cannot retrieve it later.
   </Step>
   <Step title="Exchange credentials for an access token">
     Send a POST request to your MCP server's token endpoint with your client ID and secret. Your token endpoint is at the `/authed/mcp/oauth/token` path of your documentation URL.

--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -104,6 +104,91 @@ By default, your MCP server is only available for localhost tools. To allow web-
   </Step>
 </Steps>
 
+### Client credentials
+
+Client credentials let you connect to your authenticated MCP server programmatically without a browser-based login. Use client credentials for server-side integrations, CI/CD pipelines, automated workflows, and any environment where a user cannot complete an interactive OAuth flow.
+
+Client credentials authenticate against the `/authed/mcp` endpoint and return the same content as an authenticated user with access to all pages.
+
+<Steps>
+  <Step title="Create a client credential">
+    1. Navigate to the [MCP server page](https://dashboard.mintlify.com/products/mcp) in your dashboard.
+    2. In the **Client Credentials** section, select **Create credential**.
+    3. Enter a label for the credential to identify its purpose.
+    4. Copy the **client ID** and **client secret**. The client secret is only shown once and cannot be retrieved later.
+  </Step>
+  <Step title="Exchange credentials for an access token">
+    Send a POST request to your MCP server's token endpoint with your client ID and secret. Your token endpoint is at the `/authed/mcp/oauth/token` path of your documentation URL.
+
+    <CodeGroup>
+    ```bash cURL
+    curl -X POST https://your-docs.com/authed/mcp/oauth/token \
+      -H 'Content-Type: application/x-www-form-urlencoded' \
+      -d 'grant_type=client_credentials&client_id=CLIENT_ID&client_secret=CLIENT_SECRET'
+    ```
+
+    ```bash cURL (Basic Auth)
+    curl -X POST https://your-docs.com/authed/mcp/oauth/token \
+      -H 'Content-Type: application/x-www-form-urlencoded' \
+      -H 'Authorization: Basic BASE64_CLIENT_ID_COLON_SECRET' \
+      -d 'grant_type=client_credentials'
+    ```
+    </CodeGroup>
+
+    The response includes an access token:
+
+    ```json
+    {
+      "access_token": "eyJhbGciOi...",
+      "token_type": "Bearer",
+      "expires_in": 1209600,
+      "scope": "mcp:search"
+    }
+    ```
+
+    Access tokens expire after 14 days. Request a new token when the current one expires.
+  </Step>
+  <Step title="Connect to the MCP server">
+    Use the access token as a bearer token when connecting to the `/authed/mcp` endpoint.
+
+    <CodeGroup>
+    ```bash cURL
+    curl -X POST https://your-docs.com/authed/mcp \
+      -H 'Authorization: Bearer ACCESS_TOKEN' \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d '{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "protocolVersion": "2025-03-26",
+          "capabilities": {},
+          "clientInfo": {"name": "my-integration", "version": "1.0.0"}
+        }
+      }'
+    ```
+
+    ```bash Claude Code
+    claude mcp add --transport http \
+      --header "Authorization: Bearer ACCESS_TOKEN" \
+      my-docs https://your-docs.com/authed/mcp
+    ```
+    </CodeGroup>
+  </Step>
+</Steps>
+
+#### Managing client credentials
+
+You can manage your client credentials from the [MCP server page](https://dashboard.mintlify.com/products/mcp) in your dashboard.
+
+- **Disable a credential** to temporarily revoke access without deleting it. Disabled credentials cannot exchange tokens. Re-enable the credential to restore access.
+- **Delete a credential** to permanently revoke access. This cannot be undone.
+
+<Warning>
+  Treat client secrets like passwords. Do not commit them to source control or expose them in client-side code. Use environment variables or a secrets manager to store them.
+</Warning>
+
 ### Rate limits
 
 To protect availability, Mintlify applies rate limits to MCP servers.
@@ -115,6 +200,7 @@ To protect availability, Mintlify applies rate limits to MCP servers.
 | Get page per documentation site (domain) | 10,000 requests per hour | Limits total get page tool calls across all users of your MCP server. |
 | Authenticated search per documentation site (domain) | 5,000 requests per hour | Limits total authenticated search tool calls across all users of your MCP server. |
 | Authenticated get page per documentation site (domain) | 5,000 requests per hour | Limits total authenticated get page tool calls across all users of your MCP server. |
+| Client credentials token requests per user (IP address) | 1,000 requests per hour | Limits how frequently a single IP can request access tokens via the client credentials grant. |
 
 ## Content filtering and indexing
 

--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -182,7 +182,6 @@ Client credentials authenticate against the `/authed/mcp` endpoint and return th
 
 You can manage your client credentials from the [MCP server page](https://dashboard.mintlify.com/products/mcp) in your dashboard.
 
-- **Disable a credential** to temporarily revoke access without deleting it. Disabled credentials cannot exchange tokens. Re-enable the credential to restore access.
 - **Delete a credential** to permanently revoke access. This cannot be undone.
 
 <Warning>
@@ -200,7 +199,6 @@ To protect availability, Mintlify applies rate limits to MCP servers.
 | Get page per documentation site (domain) | 10,000 requests per hour | Limits total get page tool calls across all users of your MCP server. |
 | Authenticated search per documentation site (domain) | 5,000 requests per hour | Limits total authenticated search tool calls across all users of your MCP server. |
 | Authenticated get page per documentation site (domain) | 5,000 requests per hour | Limits total authenticated get page tool calls across all users of your MCP server. |
-| Client credentials token requests per user (IP address) | 1,000 requests per hour | Limits how frequently a single IP can request access tokens via the client credentials grant. |
 
 ## Content filtering and indexing
 


### PR DESCRIPTION
## Summary
- Adds a new **Client credentials** section to the MCP documentation page (`ai/model-context-protocol.mdx`)
- Documents the full flow: creating credentials in the dashboard, exchanging them for an access token, and connecting to `/authed/mcp`
- Includes code examples for both `client_secret_post` and HTTP Basic Auth token requests, plus cURL and Claude Code connection examples
- Adds credential management guidance (disable/delete) and a security warning about secret handling
- Adds client credentials token rate limit (1,000/hr per IP) to the rate limits table

## Test plan
- [ ] Verify the new section renders correctly on the docs site
- [ ] Confirm all code examples are accurate against the live `/authed/mcp/oauth/token` endpoint
- [ ] Check that the Steps, CodeGroup, and Warning components render properly
- [ ] Validate links to the dashboard MCP page resolve correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance and examples for using the client-credentials OAuth flow; no product code or runtime behavior is modified.
> 
> **Overview**
> Adds a **Client credentials** section to `ai/model-context-protocol.mdx`, documenting how to create MCP client credentials in the dashboard, exchange them for tokens via `/authed/mcp/oauth/token` (with both form and Basic Auth examples), and use the bearer token to connect to `/authed/mcp` (cURL + Claude Code examples).
> 
> Also adds brief credential lifecycle guidance (deletion) and a security warning about handling client secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fed639e19f3fefe50f838b5705626c118d89314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->