### PR TITLE
docs: add agent feedback documentation

### DIFF
--- a/agent/feedback.mdx
+++ b/agent/feedback.mdx
@@ -4,21 +4,21 @@ description: "Collect feedback from AI agents that read your documentation to id
 keywords: ["agent feedback", "AI feedback", "LLM feedback", "markdown pages", "documentation quality"]
 ---
 
-When AI agents browse your documentation through [markdown pages](/ai-native), they can submit feedback about issues they encounter. This feedback appears in your dashboard alongside user feedback so you can track and resolve documentation problems reported by both humans and AI agents.
+When AI agents browse your documentation through [Markdown pages](/ai-native#discovering), they can submit feedback about issues they encounter. This feedback appears in your dashboard alongside user feedback so you can track and resolve documentation problems reported by both humans and AI agents.
 
-## How it works
+## How agent feedback works
 
-Your markdown pages include instructions that tell AI agents how to report issues. Agents submit feedback through a POST request with the page path and a description of the problem.
+Your Markdown pages include instructions that tell agents how to report issues. Agents submit feedback through a POST request with the page path and a description of the problem.
 
-Agent feedback appears in the [feedback dashboard](https://dashboard.mintlify.com/products/analytics/v2/feedback) with an **Agent** badge to distinguish it from human feedback. You can filter, manage, and resolve agent feedback using the same workflow as other feedback types.
+Agent feedback appears in the [feedback dashboard](https://dashboard.mintlify.com/products/analytics/v2/feedback) with an <Badge color="blue">Agent</Badge> badge to distinguish it from human feedback. You can filter, manage, and resolve agent feedback the same way as other feedback types.
 
-Agent feedback is enabled by default for all documentation sites. Your markdown page responses automatically include feedback instructions for AI agents.
+Agent feedback is enabled by default for all documentation sites. No configuration required.
 
 ## View agent feedback
 
 1. Navigate to the [feedback dashboard](https://dashboard.mintlify.com/products/analytics/v2/feedback) in your dashboard.
 2. Select **Ratings by page** to see an overview, or **Detailed feedback** for individual submissions.
-3. Look for the **Agent** badge to identify feedback submitted by AI agents.
+3. Look for the <Badge color="blue">Agent</Badge> badge to identify feedback submitted by AI agents.
 
 Use the **Show agent feedback** checkbox in the filter menu to include or exclude agent feedback from your view.
 

--- a/agent/feedback.mdx
+++ b/agent/feedback.mdx
@@ -1,0 +1,33 @@
+---
+title: "Agent feedback"
+description: "Collect feedback from AI agents that read your documentation to identify incorrect, outdated, or confusing content."
+keywords: ["agent feedback", "AI feedback", "LLM feedback", "markdown pages", "documentation quality"]
+---
+
+When AI agents browse your documentation through [markdown pages](/ai-native), they can submit feedback about issues they encounter. This feedback appears in your dashboard alongside user feedback so you can track and resolve documentation problems reported by both humans and AI agents.
+
+## How it works
+
+Your markdown pages include instructions that tell AI agents how to report issues. Agents submit feedback through a POST request with the page path and a description of the problem.
+
+Agent feedback appears in the [feedback dashboard](https://dashboard.mintlify.com/products/analytics/v2/feedback) with an **Agent** badge to distinguish it from human feedback. You can filter, manage, and resolve agent feedback using the same workflow as other feedback types.
+
+Agent feedback is enabled by default for all documentation sites. Your markdown page responses automatically include feedback instructions for AI agents.
+
+## View agent feedback
+
+1. Navigate to the [feedback dashboard](https://dashboard.mintlify.com/products/analytics/v2/feedback) in your dashboard.
+2. Select **Ratings by page** to see an overview, or **Detailed feedback** for individual submissions.
+3. Look for the **Agent** badge to identify feedback submitted by AI agents.
+
+Use the **Show agent feedback** checkbox in the filter menu to include or exclude agent feedback from your view.
+
+## Manage agent feedback
+
+Agent feedback supports the same management features as other feedback types:
+
+- **Change status**: Mark feedback as Pending, In Progress, Resolved, or Dismissed.
+- **Add internal notes**: Click a piece of feedback to add notes for your team.
+- **Bulk actions**: Select multiple items to change status, flag, or delete in bulk.
+
+For more information on managing feedback, see [Feedback](/optimize/feedback).

--- a/docs.json
+++ b/docs.json
@@ -107,6 +107,7 @@
                       "agent/linear",
                       "agent/notion",
                       "agent/workflows",
+                      "agent/feedback",
                       "agent/customize",
                       "agent/effective-prompts",
                       "agent/use-cases"


### PR DESCRIPTION
## Summary
- Add new `agent/feedback.mdx` page documenting the agent feedback feature
- Add page to the Agent navigation group in `docs.json`

## What is agent feedback
AI agents reading markdown versions of documentation pages can submit feedback about incorrect, outdated, or confusing content via a POST endpoint. This feedback appears in the dashboard with an "Agent" badge and can be managed alongside human feedback.

## Test plan
- [ ] Verify page renders correctly on the docs site
- [ ] Confirm navigation link appears in the Agent section
- [ ] Check all internal links resolve (`/ai-native`, `/optimize/feedback`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new MDX page and a navigation entry; the main risk is broken/incorrect links or missing components (e.g., `Badge`) affecting page rendering.
> 
> **Overview**
> Adds a new `agent/feedback.mdx` page documenting how AI agents submit feedback on Markdown pages, how it appears in the dashboard (with an `Agent` badge), and how to filter/manage it.
> 
> Updates `docs.json` to include `agent/feedback` in the **Agent** navigation group so the new page is discoverable from the sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf23a088fad6b848f776f5f00ce067c093d1dda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->