### PR TITLE
Document GitLab OAuth requirement for workflows

### DIFF
--- a/agent/workflows.mdx
+++ b/agent/workflows.mdx
@@ -21,14 +21,6 @@ Use workflows that run on a schedule to automate recurring tasks like publishing
 Use workflows that run on push events to automate reactive maintenance tasks like updating API references or identifying documentation updates needed for new features.
 </Tip>
 
-## GitLab setup
-
-To use GitLab repositories in a workflow, connect each project through the GitLab OAuth integration on the [GitLab OAuth settings page](https://dashboard.mintlify.com/settings/organization/gitlab-oauth). You must connect every repository the workflow touches, including your documentation repository and any trigger or context repositories.
-
-<Warning>
-  Workflows require a paid GitLab tier. The agent uses short-lived project access tokens for repository access, which GitLab's Free plan does not support.
-</Warning>
-
 ## Create a workflow
 
 ### Create a workflow in the dashboard
@@ -245,6 +237,14 @@ To toggle a workflow:
 3. Click the toggle next to the workflow you want to disable or enable.
 
 When you re-enable a cron-based workflow, Mintlify recalculates the next run time from the current time.
+
+## GitLab setup
+
+To use GitLab repositories in a workflow, connect each project through the GitLab OAuth integration on the [GitLab OAuth settings page](https://dashboard.mintlify.com/settings/organization/gitlab-oauth). You must connect every repository the workflow touches, including your documentation repository and any trigger or context repositories.
+
+<Note>
+  Workflows require a paid GitLab tier. The agent uses short-lived project access tokens for repository access, which GitLab's Free plan does not support.
+</Note>
 
 ## Prompts
 

--- a/agent/workflows.mdx
+++ b/agent/workflows.mdx
@@ -240,7 +240,7 @@ When you re-enable a cron-based workflow, Mintlify recalculates the next run tim
 
 ## GitLab setup
 
-To use GitLab repositories in a workflow, connect each project through the GitLab OAuth integration on the [GitLab OAuth settings page](https://dashboard.mintlify.com/settings/organization/gitlab-oauth). You must connect every repository the workflow touches, including your documentation repository and any trigger or context repositories.
+To use GitLab repositories in a workflow, connect each project through the GitLab OAuth integration on the GitLab OAuth settings page. You must connect every repository the workflow touches, including your documentation repository and any trigger or context repositories.
 
 <Note>
   Workflows require a paid GitLab tier. The agent uses short-lived project access tokens for repository access, which GitLab's Free plan does not support.

--- a/agent/workflows.mdx
+++ b/agent/workflows.mdx
@@ -21,6 +21,14 @@ Use workflows that run on a schedule to automate recurring tasks like publishing
 Use workflows that run on push events to automate reactive maintenance tasks like updating API references or identifying documentation updates needed for new features.
 </Tip>
 
+## GitLab setup
+
+To use GitLab repositories in a workflow, connect each project through the GitLab OAuth integration on the [GitLab OAuth settings page](https://dashboard.mintlify.com/settings/organization/gitlab-oauth). You must connect every repository the workflow touches, including your documentation repository and any trigger or context repositories.
+
+<Warning>
+  Workflows require a paid GitLab tier. The agent uses short-lived project access tokens for repository access, which GitLab's Free plan does not support.
+</Warning>
+
 ## Create a workflow
 
 ### Create a workflow in the dashboard
@@ -92,7 +100,7 @@ Success criteria: Someone who reads the changelog knows the most up to date info
 
 For GitHub repositories, you must have the Mintlify GitHub App installed on every repository listed in the `context` or `on.push.repo` fields. Add new repositories on the [GitHub app](https://dashboard.mintlify.com/settings/organization/github-app) page of your Mintlify dashboard.
 
-For GitLab repositories, you must have the [GitLab integration](/deploy/gitlab) configured with a valid access token and webhook.
+For GitLab repositories, each project must be connected via OAuth on the [GitLab OAuth settings page](https://dashboard.mintlify.com/settings/organization/gitlab-oauth). See [GitLab setup](#gitlab-setup).
 
 <Frame>
   <img src="/images/github/app-repos-light.png" alt="The GitHub app page showing connected repositories for two organizations." className="block dark:hidden" />


### PR DESCRIPTION
## Documentation changes

Added gitlab support for workflows to the docs

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change clarifying GitLab prerequisites for workflows; low risk aside from potential user confusion if the new requirements are inaccurate.
> 
> **Overview**
> Updates the Workflows docs to clarify that **GitLab workflows require per-project OAuth connections** (via the dashboard’s GitLab OAuth settings) rather than relying on the generic GitLab integration token.
> 
> Adds a new **`GitLab setup`** section calling out that every repo used by a workflow (docs, trigger, and context repos) must be connected, and notes that workflows require a **paid GitLab tier** due to short-lived project access tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3ca785375c96337aa876acd023ae1919743ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->