### PR TITLE
Document the search boost feature

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -220,6 +220,7 @@
                   "ai/llmstxt",
                   "ai/skillmd",
                   "ai/model-context-protocol",
+                  "optimize/search-boost",
                   "optimize/seo",
                   "ai/markdown-export",
                   "optimize/pdf-exports",

--- a/docs.json
+++ b/docs.json
@@ -25,6 +25,7 @@
               {
                 "group": "Get started",
                 "icon": "rocket",
+                "boost": 2,
                 "pages": [
                   "index",
                   "quickstart",
@@ -406,6 +407,7 @@
               {
                 "group": "Changelog",
                 "icon": "calendar",
+                "boost": 0.5,
                 "pages": [
                   "changelog"
                 ]

--- a/optimize/search-boost.mdx
+++ b/optimize/search-boost.mdx
@@ -1,0 +1,60 @@
+---
+title: "Search boost"
+description: "Bias your documentation site's in-product search ranking toward specific pages or sections by setting a boost multiplier in frontmatter or your `docs.json` navigation."
+keywords: ["search ranking", "search boost", "boost", "search prioritization"]
+---
+
+Use `boost` to bias the in-product search ranking of specific pages or sections. The value is a numeric multiplier applied to each chunk's relevance score: `boost: 3` makes a chunk three times as relevant as it would be without a boost.
+
+`boost` only affects the search bar on your Mintlify-hosted documentation site. It does not change how external search engines index your pages.
+
+## Boost a single page
+
+Set `boost` in a page's [frontmatter](/organize/pages) to multiply its search ranking.
+
+```mdx
+---
+title: "Custom domain"
+description: "Connect your custom domain to your Mintlify documentation."
+boost: 3
+---
+```
+
+## Boost a navigation group
+
+Set `boost` on a group in your `docs.json` navigation to apply the multiplier to every page under it.
+
+```json
+{
+  "navigation": {
+    "groups": [
+      {
+        "group": "Get started",
+        "boost": 5,
+        "pages": [
+          "quickstart",
+          "concepts"
+        ]
+      }
+    ]
+  }
+}
+```
+
+A page inherits the boost factor from its nearest ancestor that sets one. A child page or nested group can override the inherited boost by setting its own `boost` value. A page's frontmatter `boost` always wins over a value inherited from the navigation.
+
+## De-prioritize content
+
+Use a value below `1` to push pages further down in search results. For example, `boost: 0.5` halves a page's relevance score relative to other pages. A `boost` of `1` is equivalent to no boost.
+
+```mdx
+---
+title: "Deprecated API"
+description: "Documentation for the deprecated v1 API."
+boost: 0.25
+---
+```
+
+<Note>
+  Boost factors compose with the existing relevance score. Use them sparingly. Large multipliers can cause less-relevant pages to dominate search results and degrade overall search quality.
+</Note>

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -61,6 +61,10 @@ Use frontmatter to control:
   Set to `true` to prevent search engines from indexing the page. See [Disable indexing](/optimize/seo#disable-indexing) for details. All pages with `hidden: true` in their frontmatter receive `noindex: true` automatically.
 </ResponseField>
 
+<ResponseField name="boost" type="number">
+  Multiply the page's in-product search ranking by this factor. Use values greater than `1` to prioritize the page and values between `0` and `1` to de-prioritize it. See [Search boost](/optimize/search-boost) for details.
+</ResponseField>
+
 <ResponseField name="deprecated" type="boolean">
   Set to `true` to display a "deprecated" label next to the page title. Use this to mark outdated content or legacy features while keeping the page accessible.
 </ResponseField>

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -228,6 +228,12 @@ Groups for organizing content into labeled sections.
 
 **Type:** array of object
 
+##### `navigation.groups[].boost`
+
+Numeric multiplier applied to the in-product search ranking of every page in this group. Pages inherit the boost factor from the nearest ancestor group that sets one. Use values greater than `1` to prioritize, between `0` and `1` to de-prioritize. See [Search boost](/optimize/search-boost).
+
+**Type:** number
+
 #### `navigation.pages`
 
 Individual pages in your documentation.


### PR DESCRIPTION
## Summary
- New `optimize/search-boost.mdx` page covering: how `boost` works as a numeric multiplier on in-product search ranking, frontmatter usage on a single page, group-level usage in `docs.json` navigation (with inheritance and override rules), and de-prioritization via sub-1 values
- Add a `boost` `<ResponseField>` to `organize/pages.mdx` next to `noindex`, with a link to the new page
- Register `optimize/search-boost` in the Optimize navigation group of `docs.json`

The boost feature shipped in mintlify/server#4740 and mintlify/mint#7238. This PR is the user-facing documentation.

## Test plan
- [ ] `mint broken-links` clean
- [ ] `mint dev` renders the new page and the updated frontmatter ResponseField correctly
- [ ] `vale optimize/search-boost.mdx organize/pages.mdx` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; the only behavioral impact is docs-site navigation ordering/search weighting examples in `docs.json`.
> 
> **Overview**
> Adds new documentation for *Search boost* (`optimize/search-boost.mdx`), explaining `boost` as a multiplier for in-product search ranking, including page-frontmatter and `docs.json` group usage with inheritance/override rules.
> 
> Updates existing references to surface the new option: introduces a `boost` frontmatter field in `organize/pages.mdx`, documents `navigation.groups[].boost` in `organize/settings-reference.mdx`, and registers `optimize/search-boost` in the Optimize navigation; also adds sample `boost` values to the `Get started` group and `Changelog` tab in `docs.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383a1a48e6714c592479357fc3a694a8484c5d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->