### PR TITLE
Add links to Mintlify MCP

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -45,12 +45,16 @@ The agent can only access repositories that you connect through the Mintlify Git
 
 The agent works asynchronously through pull requests, but you can also use AI coding tools like Cursor or Claude Code locally for fast, iterative edits. Install the Mintlify [skill](/ai/skillmd) and connect the [MCP server](/ai/model-context-protocol) so your editor has the same context the agent uses.
 
-<Prompt description="Install the Mintlify skill and MCP server for AI coding tools." actions={["copy", "cursor"]}>
+To let an external agent edit your content directly through MCP tool calls, connect it to the [Mintlify MCP server](/ai/mintlify-mcp).
+
+<Prompt description="Install the Mintlify skill and MCP servers for AI coding tools." actions={["copy", "cursor"]}>
 Install the Mintlify skill to get context on Mintlify project structure, components, and documentation best practices:
 
 npx skills add https://mintlify.com/docs
 
-Then add the Mintlify MCP server for access to documentation search. Follow the setup instructions at https://www.mintlify.com/docs/ai/model-context-protocol.md
+Then add the Mintlify Docs MCP server for access to documentation search. https://mintlify.com/docs/mcp
+
+Then add the Mintlify MCP server for access to the dashboard and other Mintlify-specific tools. https://mcp.mintlify.com
 </Prompt>
 
 ## Next steps

--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -12,6 +12,10 @@ The Model Context Protocol (MCP) is an open protocol that creates standardized c
 
 Your MCP server exposes tools for AI applications to search your documentation and retrieve full page content. Your users must connect your MCP server to their tools.
 
+<Tip>
+  Looking to let agents edit your content instead of read it? See the [Mintlify MCP server](/ai/mintlify-mcp) for an authenticated MCP server that exposes branching, page editing, navigation, and `docs.json` tools to trusted agents.
+</Tip>
+
 ### How MCP servers work
 
 When an AI application connects to your documentation MCP server, it can search your documentation and retrieve full page content directly in response to a user's prompt instead of relying on information from its training data or making a generic web search. Your MCP server provides access to all indexed content on your documentation site.


### PR DESCRIPTION
## Documentation changes

Add links in relevant spots to the Mintlify MCP page

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds cross-links and updates MCP setup instructions; main risk is broken/incorrect URLs or confusing product naming.
> 
> **Overview**
> Adds clearer guidance and cross-links to the authenticated **Mintlify MCP server** (`/ai/mintlify-mcp`) from both the agent overview and the general MCP documentation.
> 
> Updates the agent page’s MCP setup snippet to distinguish between the **Docs MCP server** (`https://mintlify.com/docs/mcp`) and the authenticated Mintlify MCP server (`https://mcp.mintlify.com`), and adds a tip on the MCP page pointing readers to the authenticated server when they want edit capabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627d25a22fa827d5cc0e7fed647355dc9d4d3169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->