### PR TITLE
fix: add -L flag to curl example in markdown-export

### DIFF
--- a/ai/markdown-export.mdx
+++ b/ai/markdown-export.mdx
@@ -21,7 +21,7 @@ Add `.md` to any page's URL to view a Markdown version.
 Send a request with `Accept: text/markdown` or `Accept: text/plain` to any page URL to receive the Markdown version instead of HTML. This is useful for AI tools and integrations that programmatically fetch documentation content.
 
 ```bash
-curl -H "Accept: text/markdown" https://mintlify.com/docs/ai/markdown-export
+curl -L -H "Accept: text/markdown" https://mintlify.com/docs/ai/markdown-export
 ```
 
 ## Audience-specific content


### PR DESCRIPTION
The URL redirects, so without -L the command silently fails.

## Documentation changes

needs the `-L` tag to prevent failing due to a redirect

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single command example; no runtime or behavior changes to the product.
> 
> **Overview**
> Updates the `ai/markdown-export.mdx` docs to add `-L` to the `curl` example for fetching Markdown via `Accept: text/markdown`, ensuring the command follows redirects and works as written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2296649446342de096ae1078f3bdade85d369560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->