### PR TITLE
fix broken links in zh/index.mdx to point to correct paths

### DIFF
--- a/zh/index.mdx
+++ b/zh/index.mdx
@@ -42,13 +42,13 @@ export const HeroCard = ({ filename, title, description, href }) => {
     </div>
 
     <div className="px-6 lg:px-0 mt-12 lg:mt-24 grid sm:grid-cols-2 gap-x-6 gap-y-4">
-      <HeroCard filename="rocket" title="快速开始" description="通过我们的分步指南，在几分钟内部署你的第一个文档站点" href="/docs/zh/quickstart" />
+      <HeroCard filename="rocket" title="快速开始" description="通过我们的分步指南，在几分钟内部署你的第一个文档站点" href="/zh/quickstart" />
 
-      <HeroCard filename="cli" title="CLI 安装" description="安装命令行界面（CLI），在本地预览和开发文档" href="/docs/zh/cli" />
+      <HeroCard filename="cli" title="CLI 安装" description="安装命令行界面（CLI），在本地预览和开发文档" href="/zh/cli" />
 
-      <HeroCard filename="editor" title="网页编辑器" description="使用基于浏览器的编辑器快速更新和管理内容" href="/docs/zh/editor/index" />
+      <HeroCard filename="editor" title="网页编辑器" description="使用基于浏览器的编辑器快速更新和管理内容" href="/zh/editor/index" />
 
-      <HeroCard filename="components" title="组件" description="使用我们开箱即用的组件构建丰富、互动性强的文档" href="/docs/zh/components/accordions" />
+      <HeroCard filename="components" title="组件" description="使用我们开箱即用的组件构建丰富、互动性强的文档" href="/zh/components/accordions" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Documentation changes

url: https://www.mintlify.com/docs/zh

<img width="3441" height="1923" alt="image" src="https://github.com/user-attachments/assets/2ac49fd5-88f1-4d98-ab9c-56a85a8b8cf9" />

This four links are incorrectly pointing to:
- https://www.mintlify.com/docs/docs/zh/quickstart
- https://www.mintlify.com/docs/docs/zh/cli
- https://www.mintlify.com/docs/docs/zh/editor/index
- https://www.mintlify.com/docs/docs/zh/components/accordions

The `/docs` part is duplicated.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only documentation page link targets and does not touch runtime logic or data handling.
> 
> **Overview**
> Fixes broken navigation links on `zh/index.mdx` by removing the duplicated `/docs` prefix.
> 
> The four hero cards now point to the correct Chinese paths (`/zh/quickstart`, `/zh/cli`, `/zh/editor/index`, `/zh/components/accordions`) so clicks land on valid pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0cff0d2873d29e989a3efb6e5861c409a259ba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->