### PR TITLE
Update assistant credit package language

### DIFF
--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -79,26 +79,26 @@ Changes take up to 10 minutes to propagate.
 
 ## Manage billing
 
-The assistant uses packages with monthly message allowances. A message is any user interaction with the assistant that receives a correct response. If you have unused messages, up to half of your message allowance can carry over to the next billing cycle. For example, if you have a 1,000 message allowance and you use 300 messages, 500 messages carry over to the next billing cycle giving you a total of 1,500 messages for the next billing cycle.
+The assistant uses credit packages with monthly allowances. Each assistant message consumes one credit. A message is any user interaction with the assistant that receives a correct response. Unused credits do not carry over to the next billing cycle.
 
-By default, the assistant allows overages. You can disable overages to avoid incurring additional costs for usage beyond your package. If you reach your message allowance with overages disabled, the assistant is unavailable until your message allowance resets. If you allow overages, each message beyond your allowance incurs an overage charge, but occasional overages may be cheaper than upgrading to a higher package depending on your usage.
+By default, the assistant allows overages. You can disable overages to avoid incurring additional costs for usage beyond your package. If you reach your credit allowance with overages disabled, the assistant is unavailable until your credit allowance resets. If you allow overages, each credit beyond your allowance incurs an overage charge, but occasional overages may be cheaper than upgrading to a higher package depending on your usage.
 
 ### Change your assistant package
 
-Packages determine your monthly message allowance and pricing.
+Packages determine your monthly credit allowance and pricing.
 
 View and change your current package on the [Usage](https://dashboard.mintlify.com/settings/organization/usage) page of your dashboard. You can also reach the Usage page by selecting **View usage** next to **Billing portal** on the Billing page.
 
-In the **Message packages** section (or **Credit packages** for credit-based assistants), select your preferred package from the dropdown menu.
+In the **Credit packages** section, select your preferred package from the dropdown menu.
 
 **Upgrade your package:**
-- Your new message allowance is available immediately.
+- Your new credit allowance is available immediately.
 - You pay a prorated difference for the current billing cycle.
 
 **Downgrade your package:**
-- Your message allowance updates immediately.
+- Your credit allowance updates immediately.
 - Pricing changes take effect at the start of your next billing cycle.
-- Unused messages from your current package **do not** carry over.
+- Unused credits from your current package **do not** carry over.
 
 ### Allow overages
 
@@ -106,4 +106,4 @@ If you want to disallow overages, disable them in the **Billing controls** secti
 
 ### Set usage alerts
 
-In the **Billing controls** section, set usage alerts to receive an email when you reach a certain percentage of your message allowance.
+In the **Billing controls** section, set usage alerts to receive an email when you reach a certain percentage of your credit allowance.

--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -79,7 +79,9 @@ Changes take up to 10 minutes to propagate.
 
 ## Manage billing
 
-The assistant uses credit packages with monthly allowances. Each assistant message consumes one credit. A message is any user interaction with the assistant that receives a correct response. Unused credits do not carry over to the next billing cycle.
+The assistant uses credit packages with monthly allowances. Each assistant message consumes one credit. A message is any user interaction with the assistant that receives a correct response.
+
+If you have unused credits at the end of the month, up to half of your credit allowance can carry over to the next billing cycle. For example, if you have a 1,000 credit allowance and you use 300 credits, 500 credits carry over to the next billing cycle giving you a total of 1,500 credits for the next billing cycle.
 
 By default, the assistant allows overages. You can disable overages to avoid incurring additional costs for usage beyond your package. If you reach your credit allowance with overages disabled, the assistant is unavailable until your credit allowance resets. If you allow overages, each credit beyond your allowance incurs an overage charge, but occasional overages may be cheaper than upgrading to a higher package depending on your usage.
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates that don’t affect product behavior; risk is limited to potential user confusion if terminology mismatches the UI.
> 
> **Overview**
> Updates `assistant/configure.mdx` billing docs to consistently describe assistant usage in terms of **credits** (credit packages, credit allowance, carryover, overages, and alerts) instead of **messages**.
> 
> Clarifies package management instructions by referencing only the **Credit packages** section and updating upgrade/downgrade bullets to use credit-based terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56a01da72baa4868dc01f951300841894ea439c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->