### PR TITLE
Move reverse proxy note

### DIFF
--- a/deploy/reverse-proxy.mdx
+++ b/deploy/reverse-proxy.mdx
@@ -4,10 +4,6 @@ description: "Configure a custom reverse proxy with Nginx, Apache, or Caddy to s
 keywords: ["reverse proxy configuration","nginx","proxy routing","header forwarding"]
 ---
 
-<Note>
-  Reverse proxy configurations are only supported for [Enterprise plans](https://mintlify.com/pricing?ref=reverse-proxy).
-</Note>
-
 To serve your documentation through a custom reverse proxy, you must configure routing rules, caching policies, and header forwarding.
 
 When you implement a reverse proxy, monitor for potential issues with domain verification, SSL certificate provisioning, authentication flows, performance, and analytics tracking.
@@ -169,6 +165,10 @@ server {
 ```
 
 ## Custom subpath
+
+<Note>
+  Reverse proxy configurations for custom subpaths are only supported for [Enterprise plans](https://mintlify.com/pricing?ref=reverse-proxy).
+</Note>
 
 When you need a subpath other than `/docs` (such as `/help` or `/resources`), use the following routing configuration.
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just relocates an Enterprise-plan note to the section where it applies, with no functional or configuration updates.
> 
> **Overview**
> Moves the Enterprise-plan restriction note in `deploy/reverse-proxy.mdx` so it applies specifically to the **Custom subpath** reverse proxy configuration, instead of appearing at the top of the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01cc17504d5c08543def43975dfee11c36e6c1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->