### PR TITLE
Remove workflow beta tags

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -111,7 +111,6 @@
                   "ai/mintlify-mcp",
                   {
                     "group": "Workflows",
-                    "tag": "Beta",
                     "root": "workflows/index",
                     "pages": [
                       "workflows/index",

--- a/workflows/index.mdx
+++ b/workflows/index.mdx
@@ -5,10 +5,6 @@ keywords: ["automation", "automate", "cron", "agent"]
 boost: 3
 ---
 
-<Info>
-  Workflows are in beta. Features, availability, and pricing are subject to change.
-</Info>
-
 Workflows run the agent automatically on a schedule or in response to pushes to a repository. Each workflow defines a prompt for the agent and a trigger for when to run it. Workflows support both GitHub and GitLab repositories.
 
 When a workflow runs, the agent clones any specified repositories as context and follows the prompt. 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes beta labeling and messaging; no functional or code behavior changes.
> 
> **Overview**
> Removes *beta* labeling for Workflows in the docs by dropping the `tag: "Beta"` from the Workflows navigation group in `docs.json` and deleting the beta warning callout from `workflows/index.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80c727b1c25319a16c602ebddff4fb94aca739aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->