### PR TITLE
fix: remove tip to only give workflows access to docs repos

### DIFF
--- a/deploy/github.mdx
+++ b/deploy/github.mdx
@@ -63,10 +63,6 @@ After completing either path, install the GitHub app by following the steps in [
 
 Install the Mintlify GitHub App through your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app).
 
-<Tip>
-  We recommend only granting access to your documentation repository.
-</Tip>
-
 <Frame>
   <img
     className="h-80"
@@ -96,7 +92,7 @@ Read and write permissions:
 
 ## Manage repository access
 
-When installing the GitHub App, you can grant access to all of your repositories or specific ones. We recommend only granting access to your documentation repository and any repositories that you want to provide as context for the agent. You can modify this selection anytime in your [GitHub App settings](https://github.com/apps/mintlify/installations/new).
+When installing the GitHub App, you can grant access to all of your repositories or specific ones. We recommend only granting access to your documentation repository and any repositories that you want to provide as context for the agent or workflows. You can modify this selection anytime in your [GitHub App settings](https://github.com/apps/mintlify/installations/new).
 
 ## Configure docs source
 


### PR DESCRIPTION
## Documentation changes

Removed the following that is no longer true:

```
<Tip>
  We recommend only granting access to your documentation repository.
</Tip>
```
