### PR TITLE
Adding May 8, 2026 Changelog Translations

### DIFF
--- a/es/changelog.mdx
+++ b/es/changelog.mdx
@@ -35,6 +35,42 @@ noindex: true
 
 </Update>
 
+<Update label="May 8, 2026" tags={["New releases", "Improvements"]} rss={{ title: "Acceso ampliado a MCP, paquetes de créditos del assistant, grupos anidados de AsyncAPI y más" }}>
+
+<div id="expanded-mcp-content-access">
+  ## Acceso ampliado al contenido MCP
+</div>
+
+  Los [servidores MCP](/es/ai/model-context-protocol) autenticados ahora devuelven más contenido a los usuarios autorizados. Los usuarios autenticados pueden buscar páginas públicas y cualquier página a la que tengan permiso según sus grupos de usuario, en lugar de estar limitados solo a las páginas públicas. Las [credenciales de cliente](/es/ai/model-context-protocol#client-credentials) devuelven todas las páginas públicas y las páginas autenticadas que no estén restringidas a grupos concretos.
+
+  La herramienta `list_nodes` del MCP de Mintlify ahora admite filtrar por `parentId` (con recorrido `recursive` opcional), varios tipos de nodos y ámbitos de división adicionales como `dropdown`, `anchor`, `product` e `item`. Los resultados se paginan mediante un cursor opaco. Consulta la documentación de [Mintlify MCP](/es/ai/mintlify-mcp) para más detalles.
+
+<div id="assistant-credit-packages">
+  ## Paquetes de créditos del assistant
+</div>
+
+  La experiencia de facturación del [assistant](/es/assistant) se ha actualizado para usar paquetes basados en créditos en todos los planes, con terminología coherente en el panel y los controles de uso. No hay cambios en los saldos de créditos existentes ni en el consumo.
+
+<div id="asyncapi-nested-groups">
+  ## Grupos anidados de AsyncAPI
+</div>
+
+  La propiedad `asyncapi` ahora admite [grupos anidados](/es/api-playground/asyncapi-setup#examples-with-nested-groups), de modo que puedes generar páginas de canal dentro de una subsección de un grupo API más amplio o combinar varias especificaciones AsyncAPI bajo un mismo padre.
+
+<div id="improvements">
+  ## Mejoras
+</div>
+
+  - El [agente de Slack](/es/agent/slack) ahora solicita permiso antes de ejecutar acciones de terceros, como enviar un correo o crear un ticket.
+  - El [editor](/es/editor) ahora te permite arrastrar imágenes y vídeos desde el árbol de navegación directamente a una página para incrustar medios existentes en línea.
+  - Los diagramas Mermaid en el editor ahora admiten modo pantalla completa para editar diagramas complejos con más comodidad.
+  - El panel de dominios personalizados muestra ahora ambos registros `TXT` de verificación (`_acme-challenge` y `_cf-custom-hostname`) con el estado de verificación en vivo, para que puedas confirmar que el DNS es correcto antes de apuntar tu `CNAME` a Mintlify. Consulta [dominio personalizado](/es/customize/custom-domain) para más detalles.
+  - El aprovisionamiento de certificados TLS para [dominios personalizados](/es/customize/custom-domain#automatic-tls-provisioning) lo gestiona ahora directamente Mintlify.
+  - Los despliegues conectados a GitLab pueden revalidar su fuente Git desde la página de [configuración de Git](https://dashboard.mintlify.com/settings/deployment/git-settings) haciendo clic en la insignia **Active**, útil cuando las opciones de rama o la configuración parecen desactualizadas.
+  - La vista detallada de comentarios del [panel de feedback](/es/optimize/feedback) ahora solo muestra envíos que incluyen comentarios escritos, lo que facilita revisar la retroalimentación cualitativa.
+
+</Update>
+
 <Update label="May 1, 2026" tags={["New releases", "Improvements"]} rss={{ title: "Conexiones del agente" }}>
 
 <div id="agent-connections">

--- a/fr/changelog.mdx
+++ b/fr/changelog.mdx
@@ -35,6 +35,42 @@ noindex: true
 
 </Update>
 
+<Update label="8 mai 2026" tags={["Nouvelles versions", "Améliorations"]} rss={{ title: "Accès MCP élargi, forfaits de crédits de l'assistant, groupes AsyncAPI imbriqués et plus encore" }}>
+
+<div id="expanded-mcp-content-access">
+  ## Accès élargi au contenu MCP
+</div>
+
+  Les [serveurs MCP](/fr/ai/model-context-protocol) authentifiés renvoient désormais plus de contenu aux utilisateurs autorisés. Les utilisateurs authentifiés peuvent rechercher les pages publiques ainsi que toutes celles auxquelles ils ont accès selon leurs groupes, au lieu d'être limités aux pages publiques uniquement. Les [identifiants client](/fr/ai/model-context-protocol#client-credentials) renvoient toutes les pages publiques et les pages authentifiées qui ne sont pas restreintes à des groupes spécifiques.
+
+  L'outil `list_nodes` du MCP Mintlify prend désormais en charge le filtrage par `parentId` (avec traversée `recursive` en option), plusieurs types de nœuds, et des portées de division supplémentaires dont `dropdown`, `anchor`, `product` et `item`. Les résultats sont paginés via un curseur opaque. Consultez la documentation du [MCP Mintlify](/fr/ai/mintlify-mcp) pour plus de détails.
+
+<div id="assistant-credit-packages">
+  ## Forfaits de crédits de l'assistant
+</div>
+
+  L'expérience de facturation de l'[assistant](/fr/assistant) utilise désormais des forfaits à crédits sur tous les plans, avec une terminologie cohérente dans le tableau de bord et les contrôles d'utilisation. Aucun changement sur les soldes de crédits existants ni sur la consommation.
+
+<div id="asyncapi-nested-groups">
+  ## Groupes AsyncAPI imbriqués
+</div>
+
+  La propriété `asyncapi` prend désormais en charge les [groupes imbriqués](/fr/api-playground/asyncapi-setup#examples-with-nested-groups), ce qui permet de générer des pages de canal à l'intérieur d'une sous-section d'un groupe API plus large ou de combiner plusieurs spécifications AsyncAPI sous un parent commun.
+
+<div id="improvements">
+  ## Améliorations
+</div>
+
+  - L'[agent Slack](/fr/agent/slack) demande désormais l'autorisation d'exécuter des actions tierces telles qu'envoyer un courriel ou créer un ticket.
+  - L'[éditeur](/fr/editor) permet désormais de faire glisser des images et des vidéos depuis l'arborescence de navigation directement sur une page pour intégrer des médias existants en ligne.
+  - Les diagrammes Mermaid dans l'éditeur prennent désormais en charge un mode plein écran pour faciliter l'édition des diagrammes complexes.
+  - Le tableau de bord des domaines personnalisés affiche maintenant les deux enregistrements `TXT` de vérification (`_acme-challenge` et `_cf-custom-hostname`) avec un état de vérification en direct, afin de confirmer que le DNS est correct avant de pointer votre `CNAME` vers Mintlify. Consultez [Domaine personnalisé](/fr/customize/custom-domain) pour plus de détails.
+  - La mise à disposition des certificats TLS pour les [domaines personnalisés](/fr/customize/custom-domain#automatic-tls-provisioning) est désormais gérée directement par Mintlify.
+  - Les déploiements connectés à GitLab peuvent à présent revalider leur source Git depuis la page [Paramètres Git](https://dashboard.mintlify.com/settings/deployment/git-settings) en cliquant sur le badge **Active**, utile lorsque les options de branche ou la configuration semblent obsolètes.
+  - La vue détaillée des retours du [tableau de bord des retours](/fr/optimize/feedback) n'affiche désormais que les envois comportant des commentaires rédigés, ce qui facilite l'analyse des retours qualitatifs.
+
+</Update>
+
 <Update label="1er mai 2026" tags={["Nouvelles versions", "Améliorations"]} rss={{ title: "Connexions de l'agent" }}>
 
 <div id="agent-connections">

--- a/zh/changelog.mdx
+++ b/zh/changelog.mdx
@@ -35,6 +35,42 @@ noindex: true
 
 </Update>
 
+<Update label="May 8, 2026" tags={["New releases", "Improvements"]} rss={{ title: "扩大 MCP 内容访问、助手积分套餐、AsyncAPI 嵌套分组等更多更新" }}>
+
+<div id="expanded-mcp-content-access">
+  ## 扩大 MCP 内容访问范围
+</div>
+
+  经过身份验证的 [MCP 服务器](/zh/ai/model-context-protocol)现在会向已授权用户返回更多内容。已登录用户可以搜索公开页面以及根据其用户组有权访问的任何页面，而不再仅限于公开页面。[客户端凭据](/zh/ai/model-context-protocol#client-credentials)可返回所有公开页面以及未限制为特定用户组的已认证页面。
+
+  Mintlify MCP 的 `list_nodes` 工具现在支持按 `parentId` 筛选（可选 `recursive` 遍历）、多种节点类型，以及 `dropdown`、`anchor`、`product`、`item` 等更多划分范围。结果通过不透明游标分页。详见 [Mintlify MCP](/zh/ai/mintlify-mcp) 文档。
+
+<div id="assistant-credit-packages">
+  ## 助手积分套餐
+</div>
+
+  [助手](/zh/assistant)的计费体验已更新为所有套餐统一使用积分型套餐，仪表板与用量控制中的术语也已统一。现有积分余额与用量不受影响。
+
+<div id="asyncapi-nested-groups">
+  ## AsyncAPI 嵌套分组
+</div>
+
+  `asyncapi` 现支持[嵌套分组](/zh/api-playground/asyncapi-setup#examples-with-nested-groups)，因此你可以在更广泛的 API 分组的小节内生成频道页面，或在同一父级下合并多个 AsyncAPI 规范。
+
+<div id="improvements">
+  ## 改进
+</div>
+
+  - [Slack agent](/zh/agent/slack) 在执行发送邮件或创建工单等第三方操作前会请求权限。
+  - [编辑器](/zh/editor) 现在支持将图片和视频从导航树直接拖到页面上，以行内嵌入已有媒体。
+  - 编辑器中的 Mermaid 图表支持全屏模式，便于编辑复杂图表。
+  - 自定义域名仪表板现在会同时显示两条验证用 `TXT` 记录（`_acme-challenge` 和 `_cf-custom-hostname`）及其实时验证状态，方便你在将 `CNAME` 指向 Mintlify 之前确认 DNS 配置正确。详见[自定义域名](/zh/customize/custom-domain)。
+  - [自定义域名](/zh/customize/custom-domain#automatic-tls-provisioning)的 TLS 证书开通现由 Mintlify 直接处理。
+  - 已连接 GitLab 的部署现在可以在 [Git 设置](https://dashboard.mintlify.com/settings/deployment/git-settings)页面点击 **Active** 徽标重新验证 Git 源，在分支选项或配置显得陈旧时很有用。
+  - [反馈仪表板](/zh/optimize/feedback)的详细反馈视图现在仅包含有文字评论的提交，更易浏览定性反馈。
+
+</Update>
+
 <Update label="May 1, 2026" tags={["New releases", "Improvements"]} rss={{ title: "Agent 连接" }}>
 
 <div id="agent-connections">


### PR DESCRIPTION
adding May 8, 2026 changelog translations for Spanish, French, and Chinese.

Only the 3 language changelog files are modified.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds translated changelog content; main risk is broken/incorrect links or formatting in MDX.
> 
> **Overview**
> Adds a new **May 8, 2026** `Update` entry to the Spanish (`es/changelog.mdx`), French (`fr/changelog.mdx`), and Chinese (`zh/changelog.mdx`) changelogs.
> 
> The new entry documents expanded authenticated MCP content access, assistant credit packages billing terminology, AsyncAPI nested groups support, and several product/editor improvements (Slack agent permission prompts, drag-and-drop media embedding, Mermaid fullscreen, custom domain verification/TLS updates, GitLab source revalidation, and feedback filtering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664aded90e63d45242c50c2c2566aec09c291c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->