### PR TITLE
docs: document searchable for hidden tabs and groups

### DIFF
--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -309,6 +309,8 @@ To include hidden pages in search indexing, add `seo.indexing` to your `docs.jso
 }
 ```
 
+To include only the pages under a specific hidden tab or group, set `searchable: true` on that tab or group. See [Search, SEO, and AI indexing](/organize/hidden-pages#search-seo-and-ai-indexing) for details.
+
 <Note>
   For documentation sites that require authentication, sitemaps and `robots.txt` files also require authenticating to access. Sitemaps exclude pages that belong to [user groups](/deploy/authentication-setup#control-access-with-groups).
 </Note>

--- a/organize/hidden-pages.mdx
+++ b/organize/hidden-pages.mdx
@@ -92,13 +92,49 @@ To hide a tab, add the `hidden` property for the tab in your `docs.json` file:
 
 ## Search, SEO, and AI indexing
 
-By default, hidden pages don't appear in indexing for search engines, documentation site search, or as AI assistant context. To include hidden pages in search results and assistant context, add the `seo` property to your `docs.json`:
+By default, hidden pages don't appear in indexing for search engines, documentation site search, or as AI assistant context. You have two ways to include hidden content in search and indexing.
+
+### Include all hidden pages
+
+To include every hidden page across your site in search, sitemaps, and AI context, add the `seo` property to your `docs.json`:
 
 ```json
 "seo": {
     "indexing": "all"
 }
 ```
+
+### Include pages under specific hidden tabs or groups
+
+To include only the pages under a specific hidden tab or group, set `searchable: true` on that tab or group in your `docs.json`. Use this option when you hide tabs or groups to control navigation layout but still want descendant pages discoverable.
+
+```json highlight={5}
+"tabs": [
+  {
+    "tab": "Storage",
+    "hidden": true,
+    "searchable": true,
+    "groups": [
+      {
+        "group": "Buckets",
+        "pages": ["products/storage/buckets/create-bucket"]
+      }
+    ]
+  }
+]
+```
+
+With `searchable: true`, descendant pages remain in:
+
+- Documentation site search
+- `sitemap.xml`
+- AI assistant context
+- MCP server search results
+- Search engine indexing (the `noindex` meta tag is not applied)
+
+The tab or group itself stays hidden from the rendered navigation.
+
+A page's own `hidden: true` frontmatter always takes precedence. To re-exclude a descendant group, set `hidden: true` on it without `searchable: true`.
 
 ### Understanding hidden versus noindex
 


### PR DESCRIPTION
## Summary

Adds documentation for the new `searchable: true` option on hidden tabs and groups (mintlify/mint#7768, mintlify/server#5291).

- `organize/hidden-pages.mdx` — Splits the existing "Search, SEO, and AI indexing" section into two paths: site-wide `seo.indexing: "all"` and per-subtree `searchable: true`. Adds a worked example and the precedence rules.
- `optimize/seo.mdx` — One-line cross-reference under the sitemap section so customers find `searchable` from the SEO entry point.

## Why

Without this, customers who use hidden tabs as a navigation-layout workaround (e.g. per-product isolated left navs) won't know the new opt-in exists. Hidden tabs silently strip descendant pages from search, sitemap, and AI context by default; until they discover `searchable`, the merge doesn't help them.

## Test plan

- [x] `mint broken-links` — no broken links
- [x] `vale optimize/seo.mdx organize/hidden-pages.mdx` — 0 errors, 0 warnings (2 suggestions on pre-existing lines not touched by this change)
- [x] Code blocks have language tags
- [x] Sentence case headings, second-person voice
- [ ] Visual review on preview deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify indexing behavior for hidden navigation content without changing product logic.
> 
> **Overview**
> Documents a new opt-in path for indexing hidden navigation content: `organize/hidden-pages.mdx` now distinguishes between site-wide `seo.indexing: "all"` and per-tab/group `searchable: true`, including an example and precedence notes.
> 
> Adds a cross-reference in `optimize/seo.mdx` so readers of the sitemap/robots section discover the `searchable: true` option for indexing descendants of hidden tabs/groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642b00d9eb3d5d81fb75f75f33eccd2e8fbc9a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->