### PR TITLE
Fix OAuth example to avoid unsupported custom basepath

### DIFF
--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -129,7 +129,7 @@ You host your documentation at `docs.foo.com` and your entire team has access to
 
 ### OAuth 2.0 example
 
-You host your documentation at `foo.com/docs` and you have an existing OAuth server at `auth.foo.com` that supports the Authorization Code Flow.
+You host your documentation at `docs.foo.com` and you have an existing OAuth server at `auth.foo.com` that supports the Authorization Code Flow.
 
 **Configure your OAuth server details** in your dashboard:
 - **Authorization URL**: `https://auth.foo.com/authorization`
@@ -137,7 +137,7 @@ You host your documentation at `foo.com/docs` and you have an existing OAuth ser
 - **Scopes**: `['provider.users.docs']`
 - **Token URL**: `https://auth.foo.com/exchange`
 - **Info API URL**: `https://api.foo.com/docs/user-info`
-- **Logout URL**: `https://auth.foo.com/logout?returnTo=https%3A%2F%2Ffoo.com%2Fdocs`
+- **Logout URL**: `https://auth.foo.com/logout?returnTo=https%3A%2F%2Fdocs.foo.com`
 
 **Create a user info endpoint** at `api.foo.com/docs/user-info`, which requires an OAuth access token with the `provider.users.docs` scope, and returns:
 

--- a/es/deploy/authentication-setup.mdx
+++ b/es/deploy/authentication-setup.mdx
@@ -140,7 +140,7 @@ Selecciona el método de handshake que quieres configurar.
 
     ### Ejemplo de OAuth 2.0
 
-    Alojas tu documentación en `foo.com/docs` y tienes un servidor OAuth existente en `auth.foo.com` que admite el flujo de código de autorización (Authorization Code Flow).
+    Alojas tu documentación en `docs.foo.com` y tienes un servidor OAuth existente en `auth.foo.com` que admite el flujo de código de autorización (Authorization Code Flow).
 
     **Configura los detalles de tu servidor OAuth** en tu dashboard:
 
@@ -149,7 +149,7 @@ Selecciona el método de handshake que quieres configurar.
     * **Scopes**: `['provider.users.docs']`
     * **Token URL**: `https://auth.foo.com/exchange`
     * **Info API URL**: `https://api.foo.com/docs/user-info`
-    * **Logout URL**: `https://auth.foo.com/logout?returnTo=https%3A%2F%2Ffoo.com%2Fdocs`
+    * **Logout URL**: `https://auth.foo.com/logout?returnTo=https%3A%2F%2Fdocs.foo.com`
 
     **Crea un endpoint de información de usuario** en `api.foo.com/docs/user-info`, que requiera un token de acceso OAuth con el scope `provider.users.docs`, y devuelva:
 

--- a/fr/deploy/authentication-setup.mdx
+++ b/fr/deploy/authentication-setup.mdx
@@ -140,7 +140,7 @@ Sélectionnez la méthode de poignée de main que vous souhaitez configurer.
 
     ### Exemple OAuth 2.0
 
-    Vous hébergez votre documentation sur `foo.com/docs` et vous disposez d’un serveur OAuth existant sur `auth.foo.com` qui prend en charge le flux « Authorization Code ».
+    Vous hébergez votre documentation sur `docs.foo.com` et vous disposez d’un serveur OAuth existant sur `auth.foo.com` qui prend en charge le flux « Authorization Code ».
 
     **Configurez les détails de votre serveur OAuth** dans votre Dashboard :
 
@@ -149,7 +149,7 @@ Sélectionnez la méthode de poignée de main que vous souhaitez configurer.
     * **Scopes** : `['provider.users.docs']`
     * **Token URL** : `https://auth.foo.com/exchange`
     * **Info API URL** : `https://api.foo.com/docs/user-info`
-    * **Logout URL** : `https://auth.foo.com/logout?returnTo=https%3A%2F%2Ffoo.com%2Fdocs`
+    * **Logout URL** : `https://auth.foo.com/logout?returnTo=https%3A%2F%2Fdocs.foo.com`
 
     **Créez un endpoint d’informations utilisateur** à `api.foo.com/docs/user-info`, qui requiert un jeton d’accès OAuth avec le scope `provider.users.docs`, et renvoie :
 

--- a/zh/deploy/authentication-setup.mdx
+++ b/zh/deploy/authentication-setup.mdx
@@ -140,7 +140,7 @@ keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 
     ### OAuth 2.0 示例
 
-    你将文档托管在 `foo.com/docs`，并且你有一个现有的 OAuth 服务器 `auth.foo.com`，它支持 Authorization Code Flow。
+    你将文档托管在 `docs.foo.com`，并且你有一个现有的 OAuth 服务器 `auth.foo.com`，它支持 Authorization Code Flow。
 
     **在控制台中配置你的 OAuth 服务器详细信息**：
 
@@ -149,7 +149,7 @@ keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
     * **Scopes**：`['provider.users.docs']`
     * **Token URL**：`https://auth.foo.com/exchange`
     * **Info API URL**：`https://api.foo.com/docs/user-info`
-    * **Logout URL**：`https://auth.foo.com/logout?returnTo=https%3A%2F%2Ffoo.com%2Fdocs`
+    * **Logout URL**：`https://auth.foo.com/logout?returnTo=https%3A%2F%2Fdocs.foo.com`
 
     在 `api.foo.com/docs/user-info` 上**创建一个用户信息端点**，该端点要求使用带有 `provider.users.docs` scope 的 OAuth 访问令牌，并返回：
 


### PR DESCRIPTION
## Summary

This PR is intended to update the OAuth 2.0 examples in the auth setup docs to avoid using a custom basepath as the hosted documentation URL, which was explicitly addressed in PR #4387.

Because of the previous PR, the page states that auth is not supported when using a custom basepath such as `example.com/docs`, but the OAuth example currently uses `foo.com/docs` as the docs URL. This could make the OAuth setup appear supported for deployment in a way that the same page says is unsupported.

### Documentation Changes

- Changed the OAuth example docs host from `foo.com/docs` to `docs.foo.com`
- Updated the corresponding encoded `returnTo` value in the Logout URL
- Applied the same fix to the English, Chinese, Spanish, and French auth setup pages 

### Notes

This is a documentation-only consistency fix. I left the `api.foo.com/docs/user-info` example unchanged because that appears to be an application/API endpoint path, not the hosted Mintlify docs path.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits; changes are limited to example URLs and minor formatting/newline fixes.
> 
> **Overview**
> Aligns the OAuth 2.0 example in `authentication-setup.mdx` (EN/ES/FR/ZH) with the documented restriction that authentication is not supported on custom basepaths by switching the sample docs URL from `foo.com/docs` to `docs.foo.com`.
> 
> Updates the example `Logout URL` `returnTo` value accordingly, and normalizes the final table row/newline at EOF in translated pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1293fb89eecc33f0c55f0ad7446ec59c8204117e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->