### PR TITLE
Add Danish language

### DIFF
--- a/guides/internationalization.mdx
+++ b/guides/internationalization.mdx
@@ -17,8 +17,7 @@ Create a separate directory for each language using [ISO 639-1 language codes](h
 - `ar` - Arabic
 - `ca` - Catalan
 - `cs` - Czech
-- `zh` or `zh-Hans` - Chinese (Simplified)
-- `zh-Hant` - Chinese (Traditional)
+- `da` - Danish
 - `de` - German
 - `en` - English
 - `es` - Spanish
@@ -44,6 +43,8 @@ Create a separate directory for each language using [ISO 639-1 language codes](h
 - `uk` - Ukrainian
 - `uz` - Uzbek
 - `vi` - Vietnamese
+- `zh` or `zh-Hans` - Chinese (Simplified)
+- `zh-Hant` - Chinese (Traditional)
 </Expandable>
 
 ```text Example file structure

--- a/guides/internationalization.mdx
+++ b/guides/internationalization.mdx
@@ -16,6 +16,8 @@ Create a separate directory for each language using [ISO 639-1 language codes](h
 <Expandable title="supported language codes">
 - `ar` - Arabic
 - `ca` - Catalan
+- `zh` or `zh-Hans` - Chinese (Simplified)
+- `zh-Hant` - Chinese (Traditional)
 - `cs` - Czech
 - `da` - Danish
 - `de` - German
@@ -43,8 +45,6 @@ Create a separate directory for each language using [ISO 639-1 language codes](h
 - `uk` - Ukrainian
 - `uz` - Uzbek
 - `vi` - Vietnamese
-- `zh` or `zh-Hans` - Chinese (Simplified)
-- `zh-Hant` - Chinese (Traditional)
 </Expandable>
 
 ```text Example file structure

--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -676,6 +676,7 @@ We currently support the following languages for localization:
 | Chinese | `cn` |
 | Chinese (Traditional) | `zh-Hant` |
 | Czech | `cs` |
+| Danish | `da` |
 | Dutch | `nl` |
 | English | `en` |
 | Finnish | `fi` |

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -170,7 +170,7 @@ Language switcher in the global nav.
 
 **Type:** array of object—each with: `language` (string, required), `default` (boolean), `hidden` (boolean), `href` (string uri, required)
 
-**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
+**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `da`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
 
 ##### `navigation.global.versions`
 
@@ -190,7 +190,7 @@ Language switcher for multi-language sites. Each entry can include language-spec
 
 **Type:** array of object—each with: `language` (string, required), `default` (boolean), `hidden` (boolean), `banner` (object), `footer` (object), `navbar` (object)
 
-**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
+**Supported language codes:** `ar`, `ca`, `cn`, `cs`, `da`, `de`, `en`, `es`, `fr`, `fr-CA`, `he`, `hi`, `hu`, `id`, `it`, `ja`, `jp`, `ko`, `lv`, `nl`, `no`, `pl`, `pt`, `pt-BR`, `ro`, `ru`, `sv`, `tr`, `uk`, `uz`, `vi`, `zh`, `zh-Hans`, `zh-Hant`
 
 #### `navigation.versions`
 


### PR DESCRIPTION
## Documentation changes

Adds Danish to supported languages

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to language code lists; no runtime, auth, or config behavior changes.
> 
> **Overview**
> Documents **Danish** (`da`) as a supported locale across Mintlify’s i18n and navigation docs.
> 
> The PR adds `da` to the expandable supported-language list in `guides/internationalization.mdx` (with Czech moved into alphabetical order and Danish inserted after it). It also adds a Danish row to the localization table in `organize/navigation.mdx` and appends `da` to both **Supported language codes** lists under `navigation.global.languages` and `navigation.languages` in `organize/settings-reference.mdx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda3e6d00a9309de23cf67b3ae397b7785a362fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->