### PR TITLE
API playground schema updates

### DIFF
--- a/api-playground/asyncapi-setup.mdx
+++ b/api-playground/asyncapi-setup.mdx
@@ -128,7 +128,7 @@ This is useful when you want to organize WebSocket channels as a subsection of a
 
 ## Schema rendering
 
-Array schemas and combinatorial schemas (`oneOf`, `anyOf`, `allOf`) expand to show their child attributes inline in the generated channel pages. Readers can open the expandable section for an array item schema or select a tab for each `oneOf`/`anyOf` option to see all nested fields — the same behavior as in OpenAPI-generated pages.
+Array schemas and combinatorial schemas (`oneOf`, `anyOf`, `allOf`) expand to show their child attributes inline in the generated channel pages. Readers can open the expandable section for an array item schema or select a tab for each `oneOf`/`anyOf` option to see all nested fields.
 
 ## Channel page
 

--- a/api-playground/asyncapi-setup.mdx
+++ b/api-playground/asyncapi-setup.mdx
@@ -126,6 +126,10 @@ This is useful when you want to organize WebSocket channels as a subsection of a
 }
 ```
 
+## Schema rendering
+
+Array schemas and combinatorial schemas (`oneOf`, `anyOf`, `allOf`) expand to show their child attributes inline in the generated channel pages. Readers can open the expandable section for an array item schema or select a tab for each `oneOf`/`anyOf` option to see all nested fields — the same behavior as in OpenAPI-generated pages.
+
 ## Channel page
 
 If you want more control over how you order your channels or if you want to reference only specific channels, create an MDX file with the `asyncapi` property in the frontmatter.

--- a/api-playground/complex-data-types.mdx
+++ b/api-playground/complex-data-types.mdx
@@ -55,6 +55,10 @@ components:
   </Expandable>
 </ParamField>
 
+### `any` and `undefined` types
+
+Fields typed as `any` or `undefined` render the same way as `oneOf` schemas — with a picker that lets users select a concrete shape before sending a request. This allows the API playground to present a meaningful input even when the schema doesn't constrain the value to a single type.
+
 ### Providing options with `oneOf` and `anyOf`
 
 When you use `oneOf` or `anyOf`, the options display in a tabbed container. Specify a `title` field in each subschema to give your options names. For example, here's how you might display two different types of delivery addresses:

--- a/api-playground/complex-data-types.mdx
+++ b/api-playground/complex-data-types.mdx
@@ -57,7 +57,7 @@ components:
 
 ### `any` and `undefined` types
 
-Fields typed as `any` or `undefined` render the same way as `oneOf` schemas — with a picker that lets users select a concrete shape before sending a request. This allows the API playground to present a meaningful input even when the schema doesn't constrain the value to a single type.
+Fields typed as `any` or `undefined` render the same way as `oneOf` schemas with a picker that lets users select a concrete shape before sending a request. This allows the API playground to present a meaningful input even when the schema doesn't constrain the value to a single type.
 
 ### Providing options with `oneOf` and `anyOf`
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents how the API playground and AsyncAPI channel pages **render complex schemas**, without changing product behavior.
> 
> **AsyncAPI setup** gains a **Schema rendering** section describing inline expansion for arrays and for `oneOf` / `anyOf` / `allOf` (expandable array items and tabbed combinator options on generated channel pages).
> 
> **Complex data types** gains a short section on **`any` and `undefined`**, explaining they use the same type-picker UX as `oneOf` so users can choose a concrete shape before sending a request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ce6eb375a245cff91535085e61e90b711392a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->