### PR TITLE
llms.txt/llms-full.txt for authed vs partially authed sites

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -12,7 +12,10 @@ The [llms.txt file](https://llmstxt.org) is an industry standard that helps LLMs
 Mintlify automatically hosts an `llms.txt` file at the root of your project that lists all available pages in your documentation. This file is always up to date and requires zero maintenance. You can optionally add a custom `llms.txt` file to the root of your project.
 
 <Note>
-  If your site requires authentication, `llms.txt` and `llms-full.txt` also require authentication to view. LLMs and AI tools that cannot authenticate into your site cannot access these files. The files exclude pages that belong to [user groups](/deploy/authentication-setup#control-access-with-groups).
+  Authentication affects `llms.txt` and `llms-full.txt` differently depending on your site configuration:
+
+  - **Fully authenticated sites**: Both files require authentication. AI tools that cannot authenticate cannot access them.
+  - **Partially authenticated sites** (some public pages): Both files are publicly accessible, but only list public pages. Pages restricted to user groups are excluded.
 
   For more information on how authentication affects AI features, see [Feature availability](/deploy/authentication-setup#feature-availability).
 </Note>

--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -15,7 +15,7 @@ Mintlify automatically hosts an `llms.txt` file at the root of your project that
   Authentication affects `llms.txt` and `llms-full.txt` differently depending on your site configuration:
 
   - **Fully authenticated sites**: Both files require authentication. AI tools that cannot authenticate cannot access them.
-  - **Partially authenticated sites** (some public pages): Both files are publicly accessible, but only list public pages. Pages restricted to user groups are excluded.
+  - **Partially authenticated sites**: Both files are publicly accessible, but only list public pages. Pages restricted to user groups are excluded.
 
   For more information on how authentication affects AI features, see [Feature availability](/deploy/authentication-setup#feature-availability).
 </Note>

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -460,11 +460,11 @@ type User = {
 
 ## Feature availability
 
-Some features behave differently or are unavailable when you enable authentication. Mintlify does not support serving arbitrary files publicly on an authenticated site. All hosted files, including `llms.txt`, `llms-full.txt`, and `skill.md`, are subject to the same authentication requirements as your documentation pages.
+Some features behave differently or are unavailable when you enable authentication.
 
 | Feature | Public | Fully authenticated (all pages protected) | Partially authenticated (some public pages) |
 | :------ | :---------- | :---------------------------------- | :-------------------------------- |
-| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files | Available behind authentication, so AI tools may not be able to access the files |
+| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files | Publicly accessible, reflecting public pages only |
 | [MCP server](/ai/model-context-protocol) | Full support | Requires authentication to connect | Available without authentication for public pages and with authentication for protected pages |
 | [Markdown export](/ai/markdown-export) | Full support | Full support, respects user groups | Full support, respects user groups |
 | [PDF export](/optimize/pdf-exports) | Full support | Not supported | Not supported |


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording updates with no code or security behavior changes in this diff.
> 
> **Overview**
> Clarifies how **`llms.txt`** and **`llms-full.txt`** behave when documentation uses authentication, distinguishing **fully** vs **partially** authenticated sites.
> 
> On **`ai/llmstxt`**, the auth note now states that fully protected sites require login for both files, while partially protected sites expose both files publicly but only include public pages (group-restricted pages are omitted).
> 
> On **`deploy/authentication-setup`**, the intro under **Feature availability** no longer claims every hosted file shares the same auth rules as doc pages. The feature table’s **Partially authenticated** column for llms files now says they are **publicly accessible** and list **public pages only**, instead of implying they stay behind authentication like the fully authenticated case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913cca4d33d36032db59328327b7d28326944392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->