### PR TITLE
Add auth info to markdown export page

### DIFF
--- a/ai/markdown-export.mdx
+++ b/ai/markdown-export.mdx
@@ -60,6 +60,16 @@ Agents submit feedback by posting to the endpoint with the page path and feedbac
 
 Use agent feedback to improve your pages for agents based on what they find incorrect, outdated, or confusing.
 
+## Authentication
+
+Markdown export respects the same authentication rules as the HTML version of each page.
+
+| Authentication mode | Behavior |
+|-----------|----------|
+| No authentication | All `.md` URLs are publicly accessible. |
+| Partial authentication | `.md` URLs for public pages are publicly accessible. `.md` URLs for protected pages require authentication and respect user group restrictions. |
+| Full authentication | All `.md` URLs require authentication and respect user group restrictions. |
+
 ## Keyboard shortcut
 
 Press <kbd>Command</kbd> + <kbd>C</kbd> (<kbd>Ctrl</kbd> + <kbd>C</kbd> on Windows) to copy a page as Markdown to your clipboard.


### PR DESCRIPTION
## Documentation changes

Adds auth behavior to Markdown export page so it's discoverable in context and not only on the auth page.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no product or security logic changes.
> 
> **Overview**
> Adds an **Authentication** section to `ai/markdown-export.mdx` so readers see how Markdown export behaves alongside other export features, instead of only on the auth docs.
> 
> The new content states that `.md` URLs follow the same rules as HTML, with a table for **no**, **partial**, and **full** authentication (public access, public vs protected pages, and user group restrictions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4417d706a952214535be7a00587d4f71a542a845. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->