### PR TITLE
docs: document per-page canonical URL frontmatter field

### DIFF
--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -19,12 +19,14 @@ You can fully customize your site's meta tags by adding the `metatags` field to 
 Mintlify generates the following meta tags for every page. You can override these meta tags by specifying them in your `docs.json` or a page's frontmatter.
 
 **Basic metadata:**
+
 - `charset: utf-8` - Character encoding
 - `og:type: website` - Open Graph type
 - `og:site_name` - Your documentation site name
 - `twitter:card: summary_large_image` - Twitter card type
 
 **Page-specific metadata:**
+
 - `title` - Page title, formatted as "Page Title - Site Name"
 - `og:title` - Open Graph title, defaults to page title
 - `twitter:title` - Twitter title, falls back to `og:title`, then page title
@@ -33,19 +35,23 @@ Mintlify generates the following meta tags for every page. You can override thes
 - `twitter:description` - Twitter description, falls back to `og:description`, then page description
 
 **URL and canonical:**
+
 - `canonical` - Automatically built from page URL
 - `og:url` - Set to canonical URL
 
 **SEO and indexing:**
+
 - `robots` - Generated from page metadata
 - `noindex` - Generated from page metadata
 - `keywords` - Generated from page metadata
 
 **Images:**
+
 - `og:image` - Open Graph image, `og:image:width` set to 1200 and `og:image:height` 630
 - `twitter:image` - Twitter image, `twitter:image:width` set to 1200 and `twitter:image:height` 630
 
 **Browser and app metadata:**
+
 - `applicationName` - Your documentation site name
 - `generator: Mintlify` - Identifies the site generator as Mintlify
 - `apple-mobile-web-app-title` - iOS home screen app name
@@ -83,7 +89,6 @@ To use a custom background image while keeping the auto-generated logo, title, a
 ```
 
 See [`thumbnails`](/organize/settings-appearance#thumbnails) for the full list of customization options.
-
 
 **Static OG image for all pages**
 
@@ -127,7 +132,11 @@ To set default meta tags for all pages, add the `metatags` field to your `docs.j
 
 ### Set a canonical URL
 
-If you're using a custom domain, set the `canonical` meta tag to ensure search engines index your preferred domain. A canonical URL tells search engines which version of your documentation is the primary one. This improves SEO when your documentation is accessible from multiple URLs and prevents issues with duplicate content.
+A canonical URL tells search engines which version of your documentation is the primary one. This improves SEO when your documentation is accessible from multiple URLs and prevents issues with duplicate content.
+
+**Global canonical**
+
+If you're using a custom domain, set the `canonical` meta tag in your `docs.json` to ensure search engines index your preferred domain. Mintlify appends each page's path to this base URL.
 
 ```json
 "seo": {
@@ -135,6 +144,17 @@ If you're using a custom domain, set the `canonical` meta tag to ensure search e
         "canonical": "https://www.your-custom-domain-here.com"
     }
 }
+```
+
+**Per-page canonical**
+
+To set a canonical URL for a specific page, add `canonical` to that page's frontmatter. This overrides the global canonical and any auto-generated canonical for that page. This is useful for versioned documentation where you want older version pages to point to their equivalent on the latest version.
+
+```yaml
+---
+title: "My Page"
+canonical: "https://docs.example.com/latest/my-page"
+---
 ```
 
 <Note>
@@ -146,8 +166,10 @@ If you're using a custom domain, set the `canonical` meta tag to ensure search e
 To set page-specific meta tags, add them to a page's frontmatter.
 
 Page-specific meta tags include:
+
 - `title` - Page title
 - `description` - Page description appears below the title on the page and in some search engine results
+- `canonical` - Canonical URL for this page, overrides the auto-generated canonical
 - `keywords` - Comma-separated keywords
 - `og:title` - Open Graph title for social sharing
 - `og:description` - Open Graph description, falls back to `description`
@@ -167,7 +189,7 @@ Page-specific meta tags include:
 - `robots` - Robots meta tag value
 
 <Tip>
-Twitter meta tags automatically inherit from their Open Graph equivalents. For example, if you set `og:title` but not `twitter:title`, the Twitter card uses your `og:title` value. Set `twitter:title` or `twitter:description` explicitly only when you want different text on Twitter than on other platforms.
+  Twitter meta tags automatically inherit from their Open Graph equivalents. For example, if you set `og:title` but not `twitter:title`, the Twitter card uses your `og:title` value. Set `twitter:title` or `twitter:description` explicitly only when you want different text on Twitter than on other platforms.
 </Tip>
 
 ```mdx
@@ -184,11 +206,12 @@ keywords: ["keyword1", "keyword2"]
 
 <Note>
   You must wrap meta tags with colons in quotes. For example, `og:title: "Social media title"`.
-  
+
   You must format the `keywords` field as a YAML array. For example, `keywords: ["keyword1", "keyword2", "keyword3"]`.
 </Note>
 
 ## Common meta tags reference
+
 Below is a comprehensive list of meta tags you can add to your `docs.json`. These meta tags help improve your site's SEO, social sharing, and browser compatibility.
 
 <Tip>
@@ -296,10 +319,11 @@ You can preview how your meta tags appear on different platforms using [metatags
 Mintlify automatically generates a `sitemap.xml` file and a `robots.txt` file. You can view your sitemap by appending `/sitemap.xml` to your documentation site's URL.
 
 By default, Mintlify indexes only the pages you include in your `docs.json` navigation. It excludes [hidden pages](/organize/hidden-pages) that exist in your repository but are not listed in your navigation from:
-  - Search engine sitemaps
-  - Internal documentation search
-  - [AI assistant](/assistant/index) context
-  - [MCP server](/ai/model-context-protocol) search results
+
+- Search engine sitemaps
+- Internal documentation search
+- [AI assistant](/assistant/index) context
+- [MCP server](/ai/model-context-protocol) search results
 
 To include hidden pages in search indexing, add `seo.indexing` to your `docs.json`:
 
@@ -367,32 +391,32 @@ You can also specify `noindex` for all pages in your docs by setting the `metata
 ## SEO best practices
 
 <AccordionGroup>
-<Accordion title="Write descriptive titles and descriptions">
-- Use clear, descriptive page titles (50-60 characters)
-- Write compelling descriptions (150-160 characters) 
-- Include relevant keywords
-- Make each page title and description unique
-</Accordion>
+  <Accordion title="Write descriptive titles and descriptions">
+    - Use clear, descriptive page titles (50-60 characters)
+    - Write compelling descriptions (150-160 characters)
+    - Include relevant keywords
+    - Make each page title and description unique
+  </Accordion>
 
-<Accordion title="Optimize your content structure">
-- Use proper heading hierarchy (H1 → H2 → H3)
-- Write for humans first, search engines second
-- Include relevant keywords in headings and content
-- Keep URLs short, descriptive, and organized hierarchically
-- Break up long content with subheadings and lists
-</Accordion>
+  <Accordion title="Optimize your content structure">
+    - Use proper heading hierarchy (H1 → H2 → H3)
+    - Write for humans first, search engines second
+    - Include relevant keywords in headings and content
+    - Keep URLs short, descriptive, and organized hierarchically
+    - Break up long content with subheadings and lists
+  </Accordion>
 
-<Accordion title="Internal linking strategy">
-- Link to related pages within your documentation
-- Use descriptive anchor text instead of "click here"
-- Create topic clusters by linking related concepts
-- Use the automatic cross-referencing features
-</Accordion>
+  <Accordion title="Internal linking strategy">
+    - Link to related pages within your documentation
+    - Use descriptive anchor text instead of "click here"
+    - Create topic clusters by linking related concepts
+    - Use the automatic cross-referencing features
+  </Accordion>
 
-<Accordion title="Image SEO">
-- Use descriptive filenames for images
-- Always include alt text for accessibility and SEO
-- Optimize image file sizes for faster loading
-- Use relevant images that support your content
-</Accordion>
+  <Accordion title="Image SEO">
+    - Use descriptive filenames for images
+    - Always include alt text for accessibility and SEO
+    - Optimize image file sizes for faster loading
+    - Use relevant images that support your content
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Adds documentation for the `canonical` frontmatter field on individual MDX pages
- Updates the "Set a canonical URL" section to cover both global (docs.json) and per-page (frontmatter) canonical options
- Adds `canonical` to the page-specific meta tags list

## Test Plan
- Visit the SEO docs page and verify the "Set a canonical URL" section shows both the global and per-page examples
- Verify `canonical` appears in the page-specific meta tags list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the SEO guide with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Updates **`optimize/seo.mdx`** to document **per-page `canonical` frontmatter** and clarify how canonical URLs work alongside global settings.
> 
> The **Set a canonical URL** section is split into **Global canonical** (`docs.json` `seo.metatags`) and **Per-page canonical** (frontmatter that overrides global and auto-generated URLs), including a YAML example and a versioned-docs use case. **`canonical`** is added to the page-specific meta tags list.
> 
> Other edits are **docs formatting only**: spacing under auto-generated meta tag headings, list structure for hidden-page indexing exclusions, accordion bullet indentation in SEO best practices, and small note/tip tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0348aad9ce668ea2cd9bd6fe86f10676a68d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->