### PR TITLE
Document additional discovery methods

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -116,6 +116,8 @@ Mintlify hosts a discovery document at `/.well-known/mcp` for agents and tools t
 | `servers[].name` | Identifier for the server entry. |
 | `servers[].authentication` | Authentication method for the server entry. |
 
+For agent-readiness, the same discovery document is also available at `/.well-known/mcp.json`. Mintlify additionally serves an MCP server card at `/.well-known/mcp/server-card.json` and a list of server cards at `/.well-known/mcp/server-cards.json`. All discovery endpoints are served automatically and don't require configuration.
+
 ### Enable authenticated MCP
 
 If your documentation requires authentication, your MCP server requires users to authenticate before connecting. When a user adds your MCP server URL to their AI tool, they must log in with their existing credentials. After authenticating, a redirect sends them back to their tool. The MCP server only returns content each user has permission to access based on their [user groups](/deploy/authentication-setup).

--- a/ai/skillmd.mdx
+++ b/ai/skillmd.mdx
@@ -191,3 +191,17 @@ The `name` field is a URL-safe slug derived from the `name` in your `skill.md` f
 ### Individual skill files
 
 `GET /.well-known/skills/{name}/skill.md` returns the `skill.md` file for a specific skill identified by its slugified name from the index.
+
+## Agent card
+
+Mintlify hosts an [Agent-to-Agent (A2A)](https://a2aproject.github.io/A2A/latest/) agent card at `/.well-known/agent-card.json`. The agent card is a standardized JSON document that helps A2A-compatible agents discover your documentation site and available skills in a single request.
+
+`GET /.well-known/agent-card.json` returns a JSON document following the A2A agent card 0.2.0 schema. Each entry in the `skills` array corresponds to a skill from your skills discovery endpoints.
+
+A2A-compatible agents fetch `/.well-known/agent-card.json` to discover your site by name and description, follow `documentationUrl` to retrieve human-readable content, and iterate over `skills` to fetch each `skill.md` file.
+
+<Note>
+  If you use a [reverse proxy](/deploy/reverse-proxy), configure it to forward `/.well-known/agent-card.json` to your Mintlify subdomain.
+</Note>
+
+The agent card complements [MCP](/ai/model-context-protocol) by providing a lightweight discovery layer that does not require establishing a session.


### PR DESCRIPTION
## Documentation changes

A2A cards and more endpoints for agent-readiness.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no product or security behavior changes.
> 
> **Overview**
> Documents **agent-readiness discovery** endpoints that Mintlify already serves, so readers know how to find MCP and skills without dashboard setup.
> 
> On **MCP**, the discovery section now notes that `/.well-known/mcp` is also available at `/.well-known/mcp.json`, plus MCP server card URLs at `/.well-known/mcp/server-card.json` and `/.well-known/mcp/server-cards.json`, and states that these endpoints need no configuration.
> 
> On **skill.md**, a new **Agent card** section describes `GET /.well-known/agent-card.json` (A2A agent card 0.2.0), how A2A agents use it with `documentationUrl` and per-skill fetches, reverse-proxy forwarding for that path, and that the card is a session-free discovery complement to MCP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900cb89946bc81982ed42398c51f957ee8a630d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->