### PR TITLE
docs: document the download-spec contextual option

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -151,6 +151,18 @@ The `x-default` extension supports `apiKey` and `http` bearer security scheme ty
 
 You can also use `x-default` on any schema property in your OpenAPI specification to set a default value in the API playground without affecting the `default` field in the schema definition.
 
+## Let visitors download your spec
+
+Opt into a "Download API spec" entry in the [page context menu](/organize/settings-structure#contextual) by adding `"download-spec"` to `contextual.options` in your `docs.json`:
+
+```json
+"contextual": {
+  "options": ["copy", "download-spec", "chatgpt", "claude"]
+}
+```
+
+When enabled, clicking the option downloads your OpenAPI spec directly. Deployments with multiple specs receive them bundled as `api-specs.zip`. The option is hidden for deployments behind `auth` or `userAuth` to prevent leaking spec contents from authenticated docs.
+
 ## Customize your endpoint pages
 
 Customize your endpoint pages by adding the `x-mint` extension to your OpenAPI specification. The `x-mint` extension gives you additional control over how your API documentation generates and displays.

--- a/docs.json
+++ b/docs.json
@@ -554,6 +554,7 @@
   "contextual": {
     "options": [
       "copy",
+      "download-spec",
       "chatgpt",
       "claude",
       "add-mcp",

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -640,7 +640,7 @@ Contextual menu for page actions and AI tool integrations.
 
 Actions available in the contextual menu. The first item is the default action.
 
-**Type:** array of `"assistant"` | `"copy"` | `"view"` | `"chatgpt"` | `"claude"` | `"perplexity"` | `"grok"` | `"aistudio"` | `"devin"` | `"windsurf"` | `"mcp"` | `"add-mcp"` | `"cursor"` | `"vscode"` | `"devin-mcp"` | object
+**Type:** array of `"assistant"` | `"copy"` | `"view"` | `"download-spec"` | `"chatgpt"` | `"claude"` | `"perplexity"` | `"grok"` | `"aistudio"` | `"devin"` | `"windsurf"` | `"mcp"` | `"add-mcp"` | `"cursor"` | `"vscode"` | `"devin-mcp"` | object
 
 Custom option object fields:
 

--- a/organize/settings-structure.mdx
+++ b/organize/settings-structure.mdx
@@ -385,6 +385,7 @@ The contextual menu gives users quick access to AI tools and page actions. It ap
   - `"cursor"` — Install your hosted MCP server in Cursor
   - `"devin"` — Send the current page to Devin
   - `"devin-mcp"` — Install your hosted MCP server in Devin
+  - `"download-spec"` — Download the deployment's OpenAPI specs (single file, or zipped if multiple)
   - `"grok"` — Send the current page to Grok
   - `"mcp"` — Copy your MCP server URL to the clipboard
   - `"perplexity"` — Send the current page to Perplexity


### PR DESCRIPTION
## Summary

- Adds \`\"download-spec\"\` to the contextual options docs in two places:
  - \`organize/settings-structure.mdx\` — alphabetical bullet in the built-in options list with a one-line description matching the existing entries.
  - \`organize/settings-reference.mdx\` — added to the type union under \`contextual.options\`.

## Wider context

Implements the user-facing docs for the new contextual menu option introduced by:
- [mintlify/mint#7968](https://github.com/mintlify/mint/pull/7968) — validation enum (merged).
- [mintlify/mint#7960](https://github.com/mintlify/mint/pull/7960) — context-menu handler + proxy route.
- [mintlify/server#5530](https://github.com/mintlify/server/pull/5530) — \`/openapi-spec-download\` endpoint that backs the action.

Per the docs CLAUDE.md, only the English copies are updated — translations are handled automatically when this lands.

## Test plan

- [ ] \`mint broken-links\` reports no new issues.
- [ ] \`vale\` reports no new issues on the changed files.
- [ ] Preview render: the bullet appears in alphabetical order between \`devin-mcp\` and \`grok\`; the type union in the reference table reads cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus adding the option to the Mintlify docs site's own docs.json; no application logic.
> 
> **Overview**
> Documents the **`download-spec`** contextual menu option so sites can offer a **Download API spec** action from the page context menu.
> 
> Adds configuration guidance in **`api-playground/openapi-setup.mdx`** (enable via `contextual.options`, single-spec download vs **`api-specs.zip`** for multiple specs, and that the option is **hidden** when docs use **`auth`** or **`userAuth`**). Updates **`organize/settings-structure.mdx`** and **`organize/settings-reference.mdx`** so `"download-spec"` appears in the built-in options list and the **`contextual.options`** type union. Turns the option on in this repo’s **`docs.json`** alongside existing contextual actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3836a8c2b3e12f4e022a1ead2285a415a6bd671e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->