### PR TITLE
Update plan gates

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -6,10 +6,6 @@ keywords: ["automation", "automate", "AI", "autoupdate", "maintenance"]
 
 import SkillMcpPrompt from "/snippets/skill-mcp-prompt.mdx";
 
-<Info>
-  The agent is available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=agent).
-</Info>
-
 The agent is an AI tool that creates pull requests with proposed changes to your documentation based on your prompts. When you send a request, the agent:
 
 - **Researches**: Searches and reads your existing documentation, any connected repositories, relevant context, and the web.

--- a/api/preview/trigger.mdx
+++ b/api/preview/trigger.mdx
@@ -5,10 +5,6 @@ keywords: ["preview", "preview deployment", "branch preview", "staging"]
 
 ---
 
-<Info>
-  Preview deployments are available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=preview-deployments).
-</Info>
-
 Use this endpoint to programmatically create or update a preview deployment for a Git branch. If a preview already exists for the specified branch, the endpoint triggers a redeployment instead of creating a duplicate.
 
 The response includes a `statusId` that you can pass to [Get deployment status](/api/update/status) to track the deployment progress.

--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -85,17 +85,17 @@ If you have unused credits at the end of the month, up to half of your credit al
 
 By default, overages are disabled. With overages disabled, the assistant is unavailable once you reach your credit allowance and remains unavailable until your allowance resets. You can enable overages to keep the assistant available beyond your package allowance. If you enable overages, each credit beyond your allowance incurs an overage charge, but occasional overages may be cheaper than upgrading to a higher package depending on your usage.
 
-### Enable the assistant on the Hobby plan
+### Manage credits on the starter plan
 
-If you're on the Hobby plan, you can add the assistant to your site by purchasing a credit package without upgrading to Pro. The assistant is enabled as soon as your purchase completes and remains active for as long as you have an active credit package.
+Starter plan users receive 5,000 trial credits. To keep the assistant enabled after using your trial credits, purchase a credit package.
 
-To purchase a credit package on the Hobby plan:
+To purchase a credit package on the starter plan:
 
 1. Go to the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
 2. In the **Credit packages** section, select a package from the dropdown menu.
 3. Confirm the change to be redirected to checkout.
 
-To stop the assistant, downgrade your credit package to the lowest tier. Your plan returns to Hobby and the assistant is disabled at the end of the current billing cycle.
+To disable the assistant, downgrade your credit package to the lowest tier. The assistant then becomes disabled at the end of your current billing cycle.
 
 ### Change your assistant package
 

--- a/assistant/index.mdx
+++ b/assistant/index.mdx
@@ -6,7 +6,7 @@ boost: 3
 ---
 
 <Info>
-  The assistant is included on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=assistant) and enabled by default for those plans. Hobby plan users can [purchase a credit package](/assistant/configure#manage-billing) to add the assistant to their site.
+  The assistant is included on all plans and enabled by default. Starter plan users receive 5,000 trial credits. [Purchase a credit package](/assistant/configure#manage-billing) to continue after the trial.
 </Info>
 
 ## About the assistant

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -595,7 +595,7 @@ noindex: true
 
   Automate documentation tasks with [workflows](/workflows). Set up scheduled or event-triggered automations that run the agent to update your documentation.
 
-  Workflows are in beta and currently available on [Enterprise plans](https://mintlify.com/pricing). Available on Pro plans soon.
+  Workflows are in beta and available on all plans.
 
   ## Comments and suggestions
 

--- a/dashboard/security-contact.mdx
+++ b/dashboard/security-contact.mdx
@@ -5,7 +5,7 @@ keywords: ["security", "notifications", "compliance"]
 ---
 
 <Info>
-  Security contact is available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=security-contact).
+  Security contact is available on [Enterprise plans](https://mintlify.com/pricing?ref=security-contact).
 </Info>
 
 List a security contact in your dashboard to receive security-related communications about your organization.

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Authentication setup"
-description: "Set up user authentication for your documentation site with OAuth, JWT, or shared links to control access to pages and API references."
+description: "Set up user authentication for your site with OAuth, JWT, or shared links to control access to pages and API references."
 keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 ---
 
 <Info>
-  [Pro plans](https://mintlify.com/pricing?ref=authentication) include password authentication.
+  Mintlify dashboard authentication is available on all plans.
 
-  [Enterprise plans](https://mintlify.com/pricing?ref=authentication) include all authentication methods.
+  Password, OAuth, and JWT authentication require an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
 </Info>
 
 <Warning>
-  Authentication is only available for documentation hosted on a custom domain or Mintlify subdomain (for example, `docs.example.com` or `example.mintlify.dev`). Authentication is **not supported** when using a [custom basepath](/deploy/docs-subpath) (for example, `example.com/docs`).
+  Authentication is only available for sites hosted on a custom domain or Mintlify subdomain (for example, `docs.example.com` or `example.mintlify.dev`). Authentication is **not supported** when using a [custom basepath](/deploy/docs-subpath) (for example, `example.com/docs`).
 </Warning>
 
-Authentication requires users to log in before accessing your documentation.
+Authentication requires users to log in before accessing your content.
 
-When you enable authentication, users must log in to access any content. You can configure specific pages or groups as public while keeping other pages protected.
+You can configure full authentication for all pages or partial authentication where some pages are public and others are protected.
 
 ## Configure authentication
 

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -4,10 +4,6 @@ description: "Get unique preview URLs for each pull request so reviewers can see
 keywords: ["preview URLs", "pull request previews", "branch previews", "staging environments"]
 ---
 
-<Info>
-  Preview deployments are available on [Pro and Enterprise plans](https://mintlify.com/pricing?ref=preview-deployments).
-</Info>
-
 Preview deployments let you see how changes to your docs look before merging to production. Each preview creates a shareable URL that updates automatically as you push new changes. 
 
 Preview URLs are publicly viewable by default. Share a preview link with anyone who needs to review your changes.

--- a/guides/assistant-embed.mdx
+++ b/guides/assistant-embed.mdx
@@ -21,7 +21,7 @@ Users can use the widget to get help with your product without leaving your appl
 
 ## Prerequisites
 
-- [Mintlify Pro or Enterprise plan](https://mintlify.com/pricing)
+- The Mintlify assistant enabled
 - Your domain name, which appears at the end of your dashboard URL. For example, if your dashboard URL is `https://app.mintlify.com/org-name/domain-name`, your domain name is `domain-name`
 - An [assistant API key](https://app.mintlify.com/settings/organization/api-keys)
 - Node.js v18 or higher and npm installed

--- a/guides/custom-frontend.mdx
+++ b/guides/custom-frontend.mdx
@@ -89,7 +89,7 @@ This guide walks you through setting up a headless Mintlify project with the sta
     
     Your subdomain is the domain name of your project. It is the part of your dashboard URL after the organization name. For example, if your dashboard URL is `https://app.mintlify.com/org-name/domain-name`, your subdomain is `domain-name`.
 
-    If you have a Pro or Enterprise plan, generate an assistant API key on the [API keys](https://app.mintlify.com/settings/organization/api-keys) page of your dashboard. The assistant API key starts with `mint_dsc_`.
+    Generate an assistant API key on the [API keys](https://app.mintlify.com/settings/organization/api-keys) page of your dashboard. The assistant API key starts with `mint_dsc_`.
   </Step>
 
   <Step title="Start the dev server">
@@ -165,10 +165,6 @@ Key files to customize:
 | `src/styles/` | Global styles, typography, and color scheme |
 
 ## Connect search and assistant
-
-<Note>
-  The assistant is available on [Pro and Enterprise plans](https://mintlify.com/pricing).
-</Note>
 
 The starter template includes search and assistant components that connect to Mintlify's APIs using the environment variables you configure during setup.
 

--- a/guides/custom-frontend.mdx
+++ b/guides/custom-frontend.mdx
@@ -19,7 +19,7 @@ This guide walks you through setting up a headless Mintlify project with the sta
 | Mintlify components | Included | Use components like `<Card>`, `<Steps>`, and `<Tabs>` in your MDX files without importing them. |
 | Content processing | Included | The `@mintlify/astro` integration reads your `docs.json` and MDX files and processes them at build time. |
 | Search | Included | The `SearchBar` component connects to Mintlify's search API using your project subdomain. |
-| AI assistant | Included | The `Assistant` component provides an AI chat interface powered by your content. Available on [Pro and Enterprise plans](https://mintlify.com/pricing). |
+| AI assistant | Included | The `Assistant` component provides an AI chat interface powered by your content. |
 | Layouts and styling | Custom build | Header, footer, sidebar, table of contents, page templates, and all CSS. The starter template includes examples built with Tailwind CSS. |
 | Routing and navigation | Custom build | A catch-all Astro route renders each page. Use `resolvePageData()` and `unwrapNav()` from `@mintlify/astro/helpers` to resolve navigation state from `docs.json`. |
 | Deployment and hosting | Custom build | Deploy your Astro site to any hosting provider. |

--- a/optimize/feedback.mdx
+++ b/optimize/feedback.mdx
@@ -67,7 +67,7 @@ Enable email collection so users can optionally provide their email address when
 View email addresses submitted with feedback in the [feedback dashboard](https://app.mintlify.com/products/analytics/v2/feedback) alongside the feedback content.
 
 <Note>
-  If you disable telemetry in your `docs.json` file, feedback features are not available on your documentation pages.
+  If you disable telemetry in your `docs.json` file, feedback features are not available.
 </Note>
 
 ## Manage feedback


### PR DESCRIPTION
## Documentation changes

This PR updates the plan gating information for Starter/Enterprise plans.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to pricing and feature availability copy; no application or security logic changes.
> 
> **Overview**
> This PR **realigns plan and feature gates** across Mintlify docs to match **Starter** vs **Enterprise** (and drops several **Pro/Enterprise** callouts).
> 
> **Broader availability:** The **assistant** is described as on **all plans** with **5,000 trial credits** on Starter and credit packages to continue; **workflows** (changelog) are **all plans**; **agent** and **preview deployment API** pages no longer lead with Pro/Enterprise **Info** blocks; **preview deployments** overview drops the plan banner (password-protected previews remain Enterprise elsewhere).
> 
> **Tighter or clarified gates:** **Security contact** moves from Pro/Enterprise to **Enterprise only**. **Authentication** splits **Mintlify dashboard auth** (all plans) from **password, OAuth, and JWT** (**Enterprise**), with copy shifting from “documentation” to **site/content** and clearer **full vs partial** auth.
> 
> **Starter billing copy:** `assistant/configure` renames **Hobby → starter**, documents trial credits, and retitles the credit-purchase section.
> 
> **Guides:** **Assistant embed** and **custom frontend** drop Pro/Enterprise prerequisites; headless assistant is “included” without a plan link.
> 
> **Minor:** Feedback note when telemetry is off; embed/custom-frontend assistant setup wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb1360362f83a9ddb3f8cc991f09510cd834828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->