### PR TITLE
Credit pricing tiers

### DIFF
--- a/credits.mdx
+++ b/credits.mdx
@@ -30,10 +30,11 @@ For the most current pricing information, see the [Pricing page](https://mintlif
 **Overages** are charged per additional credit at $0.01 rather than triggering an automatic tier upgrade. You can set usage alerts to receive an email when you reach a certain percentage of your tier limit. Allowing overages can be cheaper than moving up a tier depending on your usage patterns.
 
 <Note>
-  Overages are disabled by default. You must enable them in the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
+  Overages are disabled by default. You must enable them on the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
 </Note>
 
 **Rollovers** carry forward some unused credits to the next month, up to 1.5 times your monthly limit. Rollovers reset if you change tiers.
+**Rollovers** carry forward up to 50% of unused credits to the next month, so the maximum credits available in any month is 1.5 times your monthly limit. Rollovers reset if you change tiers.
 
 Higher tiers offer a lower effective cost per credit. If your usage consistently reaches the top of your current tier, upgrading is more economical than paying ongoing overage charges.
 

--- a/credits.mdx
+++ b/credits.mdx
@@ -12,6 +12,35 @@ Some Mintlify features consume credits.
 
 For the most current pricing information, see the [Pricing page](https://mintlify.com/pricing) or view the [Usage](https://app.mintlify.com/settings/organization/usage) page in your dashboard.
 
+## Pricing tiers
+
+| Monthly credits | Monthly cost | Rollover cap |
+|:----------------|:-------------|:-------------|
+| 5,000 | $0 | 7,500 |
+| 15,250 | $100 | 22,875 |
+| 31,000 | $250 | 46,500 |
+| 57,500 | $500 | 86,250 |
+| 85,000 | $750 | 127,500 |
+| 113,500 | $1,000 | 170,250 |
+| 280,000 | $2,500 | 420,000 |
+| 560,000 | $5,000 | 840,000 |
+| 855,000 | $7,500 | 1,282,500 |
+| 1,155,000 | $10,000 | 1,732,500 |
+
+**Overages** are charged per additional credit at $0.01 rather than triggering an automatic tier upgrade. You can set usage alerts to receive an email when you reach a certain percentage of your tier limit. Allowing overages can be cheaper than moving up a tier depending on your usage patterns.
+
+<Note>
+  Overages are disabled by default. You must enable them in the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
+</Note>
+
+**Rollovers** carry forward some unused credits to the next month, up to 1.5 times your monthly limit. Rollovers reset if you change tiers.
+
+Higher tiers offer a lower effective cost per credit. If your usage consistently reaches the top of your current tier, upgrading is more economical than paying ongoing overage charges.
+
+Upgrades and downgrades take effect immediately and are prorated for the current billing cycle.
+
+For high-volume usage or custom credit packages, [contact sales](mailto:sales@mintlify.com). Custom credit packages are available on enterprise plans only.
+
 ## How credits work
 
 Different features consume different amounts of credits per interaction:
@@ -34,38 +63,6 @@ Workflows also consume credits when they run:
 | Translations | 913 |
 | Typo check | 330 |
 | Writing style | 235 |
-
-## Pricing tiers
-
-| Monthly credits | Price per credit | Monthly cost | Overage rate | Rollover cap |
-|:----------------|:-----------------|:-------------|:-------------|:-------------|
-| 0-250 | Free | $0 | $0.01/credit | None |
-| 251-750 | $0.01 | $125 | $0.01/credit | 1,125 |
-| 751-1,500 | $0.01 | $300 | $0.01/credit | 2,250 |
-| 1,501-3,000 | $0.01 | $633 | $0.01/credit | 4,500 |
-| 3,001-5,000 | $0.01 | $1,045 | $0.01/credit | 7,500 |
-| 5,001-7,500 | $0.01 | $1,523 | $0.01/credit | 11,250 |
-| 7,501-10,000 | $0.01 | $1,950 | $0.01/credit | 15,000 |
-| 10,001-15,000 | $0.01 | $2,802 | $0.01/credit | 22,500 |
-| 15,001-20,000 | $0.01 | $3,555 | $0.01/credit | 30,000 |
-| 20,001-25,000 | $0.01 | $4,207 | $0.01/credit | 37,500 |
-| 25,001-35,000 | $0.01 | $5,560 | $0.01/credit | 52,500 |
-| 35,001-50,000 | $0.01 | $7,462 | $0.01/credit | 75,000 |
-| 50,001+ | $0.01 | $10,465 | $0.01/credit | 112,500 |
-
-**Overages** are charged per additional credit at $0.01 rather than triggering an automatic tier upgrade. You can set usage alerts to receive an email when you reach a certain percentage of your tier limit.
-
-**Rollovers** carry forward some unused credits to the next month, up to 1.5 times your monthly limit. Rollovers reset if you change tiers.
-
-Higher tiers offer a lower effective cost per credit. If your usage consistently reaches the top of your current tier, upgrading is more economical than paying ongoing overage charges.
-
-For high-volume usage or custom credit packages, [contact sales](mailto:sales@mintlify.com). Custom credit packages are available on enterprise plans only.
-
-## Plan management
-
-**Upgrades** take effect immediately and are prorated for the current billing cycle.
-
-**Downgrades** take effect at the start of your next billing cycle.
 
 ## Estimating your usage
 

--- a/credits.mdx
+++ b/credits.mdx
@@ -33,7 +33,6 @@ For the most current pricing information, see the [Pricing page](https://mintlif
   Overages are disabled by default. You must enable them on the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
 </Note>
 
-**Rollovers** carry forward some unused credits to the next month, up to 1.5 times your monthly limit. Rollovers reset if you change tiers.
 **Rollovers** carry forward up to 50% of unused credits to the next month, so the maximum credits available in any month is 1.5 times your monthly limit. Rollovers reset if you change tiers.
 
 Higher tiers offer a lower effective cost per credit. If your usage consistently reaches the top of your current tier, upgrading is more economical than paying ongoing overage charges.


### PR DESCRIPTION
## Documentation changes

This PR updates the pricing tiers from message rates to credit rates

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to public pricing copy; no application code or billing logic is modified in this diff.
> 
> **Overview**
> **Replaces the credit pricing tier documentation** with a new structure: discrete monthly bundles (5,000 free through 1.155M at $10,000) instead of the old range-based table with per-credit and overage columns.
> 
> The **Pricing tiers** section moves up (right after the intro) and the tier table is simplified to **monthly credits**, **monthly cost**, and **rollover cap** only. **Overages** and **rollovers** are clarified (50% rollover / 1.5× monthly cap; overages off by default with a dashboard `<Note>`). **Plan changes** are consolidated: both upgrades and downgrades are documented as **immediate and prorated**, and the separate **Plan management** section is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0633b4938ba90392ec9be88f62a812fa09908379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->