### PR TITLE
add more technical terms to default vale dict

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -100,6 +100,7 @@ ctx
 Cursor
 cURL
 customizability
+Datadog
 debounce[ds]?
 (?i)deduplic(ated?|ation)
 desc
@@ -164,9 +165,11 @@ GitHub
 GitLab
 Golang
 GraphQL
+gRPC
 Grok
 GTM
 gui
+hardcod(e[ds]?|ing)
 hCaptcha
 headless
 (?i)heatmaps?
@@ -185,6 +188,7 @@ HubSpot
 ICO
 IDE
 IdP
+idempoten(t|cy|ce)
 IDs
 iframes?
 Imgix
@@ -240,7 +244,7 @@ macOS
 md
 MDX
 measurementId
-(?i)Memoize
+(?i)memoiz(e[ds]?|ation)
 Mermaid
 (?i)metadata
 metatags?
@@ -379,6 +383,7 @@ SEO
 serverless
 sessionRecording
 setup
+shard(s|ing)?
 Shiki
 shortcodes?
 sidebars?


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated 

Adds the following terms to the Vale vocabulary to prevent false positive spell-check warnings:
- idempoten(t|cy|ce)
- Datadog
- gRPC
- hardcod(e[ds]?|ing)
- shard(s|ing)?
- (?i)memoiz(e[ds]?|ation) (updated from (?i)Memoize to also cover memoization)

Closes ENG-7239

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation lint configuration only; no runtime, auth, or application logic changes.
> 
> **Overview**
> Extends the Mintlify Vale **accept** vocabulary so common technical terms stop triggering spelling false positives.
> 
> New entries include **Datadog**, **gRPC**, **idempoten(t|cy|ce)**, **hardcod(e[ds]?|ing)**, and **shard(s|ing)?**. The memoize rule is broadened from `(?i)Memoize` to `(?i)memoiz(e[ds]?|ation)` so variants like *memoized* and *memoization* are accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559c77c5132d893e46a53e081d852f6bdf1f352c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->