### PR TITLE
Use starter/ent credit tiers

### DIFF
--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -81,8 +81,6 @@ Changes take up to 10 minutes to propagate.
 
 The assistant runs on credits. Each assistant message consumes credits, where a message is any user interaction with the assistant that receives a response. See [Credit pricing](/credits) for more information.
 
-If you have unused credits at the end of the month, up to half of your monthly allowance rolls over to the next billing cycle.
-
 ### Change your credit tier
 
 1. Go to the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.

--- a/credits.mdx
+++ b/credits.mdx
@@ -16,16 +16,16 @@ For the most current pricing information, see the [Pricing page](https://mintlif
 
 | Monthly credits | Monthly cost | Rollover cap |
 |:----------------|:-------------|:-------------|
-| 5,000 | $0 | 7,500 |
-| 15,250 | $100 | 22,875 |
-| 31,000 | $250 | 46,500 |
-| 57,500 | $500 | 86,250 |
-| 85,000 | $750 | 127,500 |
-| 113,500 | $1,000 | 170,250 |
-| 280,000 | $2,500 | 420,000 |
-| 560,000 | $5,000 | 840,000 |
-| 855,000 | $7,500 | 1,282,500 |
-| 1,155,000 | $10,000 | 1,732,500 |
+| 0 | $0 | 0 |
+| 10,250 | $100 | 15,375 |
+| 26,000 | $250 | 39,000 |
+| 52,500 | $500 | 78,750 |
+| 80,000 | $750 | 120,000 |
+| 108,500 | $1,000 | 162,750 |
+| 275,000 | $2,500 | 412,500 |
+| 555,000 | $5,000 | 832,500 |
+| 850,000 | $7,500 | 1,275,000 |
+| 1,150,000 | $10,000 | 1,725,000 |
 
 **Overages** are charged per additional credit at $0.01 rather than triggering an automatic tier upgrade. You can set usage alerts to receive an email when you reach a certain percentage of your tier limit. Allowing overages can be cheaper than moving up a tier depending on your usage patterns.
 


### PR DESCRIPTION
## Documentation changes

This PR updates the credit pricing tier for the starter/ent credit packages.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only pricing table and copy edits with no product or security impact.
> 
> **Overview**
> Updates **credit pricing** documentation to match new starter/enterprise package tiers.
> 
> The **pricing tiers** table in `credits.mdx` now lists a **$0** tier with **0** monthly credits and rollover (replacing the former **5,000** free tier), and raises monthly credit allotments and rollover caps across paid tiers (e.g. **$100** tier is **10,250** credits / **15,375** rollover cap instead of **15,250** / **22,875**).
> 
> In `assistant/configure.mdx`, the billing section no longer states that up to half of unused monthly credits roll over—rollover details remain on the [Credit pricing](/credits) page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8440e7a2ac1fcab9464fc8026eb279aea814db8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->