### PR TITLE
docs: remove false RTL support claim from i18n FAQ

### DIFF
--- a/guides/internationalization.mdx
+++ b/guides/internationalization.mdx
@@ -743,7 +743,4 @@ Yes. Navigation labels—group names, tab titles, anchor text—should match the
 Code itself should not be translated—variable names, function calls, and syntax are language-agnostic. Comments within code blocks can be translated if they explain concepts users need to understand. Instructions surrounding code blocks should be fully translated.
 </Accordion>
 
-<Accordion title="Does Mintlify support right-to-left languages like Arabic or Hebrew?">
-Yes. Arabic (`ar`) and Hebrew (`he`) are in the supported language codes list. Mintlify handles RTL layout automatically when these language codes are configured. Test your documentation in RTL to verify that navigation, tables, and code blocks display correctly.
-</Accordion>
 </AccordionGroup>


### PR DESCRIPTION
Removes the FAQ entry claiming Mintlify handles RTL layout automatically for Arabic and Hebrew — this is not currently supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime, auth, or data impact.
> 
> **Overview**
> Removes the internationalization FAQ accordion that stated Mintlify **automatically handles RTL layout** for Arabic (`ar`) and Hebrew (`he`). The guide still lists those language codes in the supported-languages expander; only the incorrect product-capability claim is dropped so docs match current behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507a440b93954a1840c1aa9dbaab6955dfa2aaa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->