### PR TITLE
Update API docs icon to file-braces

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -316,7 +316,7 @@
               },
               {
                 "group": "API docs",
-                "icon": "file-json",
+                "icon": "file-braces",
                 "pages": [
                   "guides/migrating-from-mdx"
                 ]


### PR DESCRIPTION
## Summary
This change updates the icon associated with the API docs section in the documentation navigation.

## Changes
* Updated the `icon` property for the "API docs" group in `docs.json` from "file-json" to "file-braces".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single navigation icon string in docs.json with no runtime, auth, or content behavior impact.
> 
> **Overview**
> Updates the **Guides** tab navigation so the **API docs** sidebar group uses the `file-braces` Lucide icon instead of `file-json`, matching the **Document APIs** group on the main Documentation tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eee468e3183fc8aaf1849c8667a201fc96ecce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->