### PR TITLE
docs(agent): note Enterprise Grid workspace install for Slack app

### DIFF
--- a/agent/slack.mdx
+++ b/agent/slack.mdx
@@ -28,6 +28,12 @@ keywords: ["Slack integration", "Slack bot", "team collaboration", "agent integr
   You can install the Slack agent even if you don't have a Mintlify-hosted deployment. The agent still works for question answering and conversations; features that open pull requests require a connected repository.
 </Note>
 
+<Warning>
+  On Slack Enterprise Grid, installing the app to your organization is not enough. You must also install it to the specific workspace where you want to use the agent. If you skip this step, the agent appears available at the org level but does not respond in your workspace.
+
+  To add the app to a workspace, open your org's app management page at a URL like `https://app.slack.com/manage/<your-org-id>/integrations/installed`, find the `mintlify` app, and install it to your workspace.
+</Warning>
+
 ### Reconnect or reinstall the agent
 
 If you must reauthorize the agent—for example, to grant new permissions after a Slack scope update or to recover from a revoked token—reinstall the app from your Mintlify dashboard.


### PR DESCRIPTION
## What

Adds a warning to the "Connect your Slack workspace" section of `agent/slack.mdx`: on Slack Enterprise Grid, installing the app to the org is not enough — you must also install it to the specific workspace, or the agent appears available at the org level but never responds in the workspace.

Includes the workspace-level install path (`https://app.slack.com/manage/<your-org-id>/integrations/installed`), with the org ID generalized so it applies to any reader.

## Why

Real gotcha hit on Enterprise Grid — silent failure with no error, so it's worth flagging visually with a `<Warning>`.

English-only per repo convention (translations auto-generated on merge).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **`<Warning>`** under **Connect your Slack workspace** in `agent/slack.mdx` for **Slack Enterprise Grid**: org-level install alone is insufficient—the app must also be installed on each workspace where the agent should reply, or it looks connected but never responds.
> 
> The warning points readers to the org integrations page (`https://app.slack.com/manage/<your-org-id>/integrations/installed`) to install `mintlify` on the target workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5acd7541533944fcd78b65ff0e5c934bfd2c5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->