### PR TITLE
clarify MCP returns MD

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -19,7 +19,7 @@ Your search MCP server exposes tools for AI applications to search and retrieve 
 
 ### How MCP servers work
 
-When an AI application connects to your search MCP server, it can search your content and retrieve full pages in response to a user's prompt. This avoids relying on information from training data or generic web searches. Your search MCP server provides access to all indexed content on your Mintlify site.
+When an AI application connects to your search MCP server, it can search your content and retrieve full pages as Markdown in response to a user's prompt. This avoids relying on information from training data or generic web searches. Your search MCP server provides access to all indexed content on your Mintlify site.
 
 - AI applications can proactively search your content while generating a response even if not explicitly asked to search for an answer.
 - AI applications determine when to use the available tools based on the context of the conversation and the relevance of your content.

--- a/assistant/index.mdx
+++ b/assistant/index.mdx
@@ -15,7 +15,7 @@ The assistant answers questions about your documentation through natural languag
 
 The assistant uses tool calling to answer questions. When users ask questions, the assistant:
 
-* **Searches and retrieves** relevant content from your documentation to provide accurate answers.
+* **Searches and retrieves** relevant content from your documentation as Markdown to provide accurate answers.
 * **Builds context** from the page a user is viewing when they ask questions.
 * **Cites sources** and provides navigable links to take users directly to referenced pages.
 * **Returns detailed API information** when answering questions about your API, including methods, parameters, request bodies, and response schemas from your OpenAPI specifications.


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording; no product or API behavior changes.
> 
> **Overview**
> Clarifies that **search MCP** and the **docs assistant** return retrieved content as **Markdown**, not just generic page content.
> 
> In `ai/model-context-protocol.mdx`, the “How MCP servers work” section now says AI apps can retrieve full pages **as Markdown**. In `assistant/index.mdx`, the tool-calling bullet now says the assistant searches and retrieves docs **as Markdown** for answers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d763a6d34cf4a736a68ccefd89886d9bb2734e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->