### PR TITLE
Feedback resolution 2026 06 08

### DIFF
--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -272,8 +272,8 @@ Client credentials authenticate against the `/authed/mcp` endpoint and return al
 
     ```bash Claude Code
     claude mcp add --transport http \
-      --header "Authorization: Bearer ACCESS_TOKEN" \
-      my-docs https://your-docs.com/authed/mcp
+      my-docs https://your-docs.com/authed/mcp \
+      --header "Authorization: Bearer ACCESS_TOKEN"
     ```
     </CodeGroup>
   </Step>

--- a/ai/model-context-protocol.mdx
+++ b/ai/model-context-protocol.mdx
@@ -19,7 +19,7 @@ Your search MCP server exposes tools for AI applications to search and retrieve 
 
 ### How MCP servers work
 
-When an AI application connects to your search MCP server, it can search your content and retrieve full pages in response to a user's prompt. This avoids relying on information from training data or generic web searches. Your search MCP server provides access to all indexed content on your Mintlify site.
+When an AI application connects to your search MCP server, it can search your content and retrieve full pages as Markdown in response to a user's prompt. This avoids relying on information from training data or generic web searches. Your search MCP server provides access to all indexed content on your Mintlify site.
 
 - AI applications can proactively search your content while generating a response even if not explicitly asked to search for an answer.
 - AI applications determine when to use the available tools based on the context of the conversation and the relevance of your content.

--- a/assistant/index.mdx
+++ b/assistant/index.mdx
@@ -15,7 +15,7 @@ The assistant answers questions about your documentation through natural languag
 
 The assistant uses tool calling to answer questions. When users ask questions, the assistant:
 
-* **Searches and retrieves** relevant content from your documentation to provide accurate answers.
+* **Searches and retrieves** relevant content from your documentation as Markdown to provide accurate answers.
 * **Builds context** from the page a user is viewing when they ask questions.
 * **Cites sources** and provides navigable links to take users directly to referenced pages.
 * **Returns detailed API information** when answering questions about your API, including methods, parameters, request bodies, and response schemas from your OpenAPI specifications.

--- a/components/panel.mdx
+++ b/components/panel.mdx
@@ -11,6 +11,10 @@ If a page has a `<Panel>` component, any [RequestExample](/components/examples#r
 
 The components in a `<Panel>` replace a page's table of contents.
 
+<Note>
+  The side panel is not displayed on pages using `mode: "wide"`, `mode: "center"`, or `mode: "custom"`. This applies to `<Panel>` components and to OpenAPI-generated request and response examples.
+</Note>
+
 ````mdx
 <Panel>
   <Info>Pin info to the side panel. Or add any other component.</Info>

--- a/components/panel.mdx
+++ b/components/panel.mdx
@@ -9,11 +9,7 @@ You can use the `<Panel>` component to customize the right side panel of a page 
 
 If a page has a `<Panel>` component, any [RequestExample](/components/examples#requestexample) and [ResponseExample](/components/examples#responseexample) components must be inside `<Panel>`.
 
-The components in a `<Panel>` replace a page's table of contents.
-
-<Note>
-  The side panel is not displayed on pages using `mode: "wide"`, `mode: "center"`, or `mode: "custom"`. This applies to `<Panel>` components and to OpenAPI-generated request and response examples.
-</Note>
+The components in a `<Panel>` replace a page's table of contents. Page modes that suppress the table of contents (`mode: "wide"`, `mode: "center"`, and `mode: "custom"`) also suppress the `<Panel>` component.
 
 ````mdx
 <Panel>

--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -191,7 +191,7 @@ Embed external content using iframe elements:
 ```
 
 <Tip>
-  Wrap iframes in a [Frame](/components/frames) component to keep them within the text column width and prevent overflow.
+  Wrap iframes in a [frame](/components/frames) component to keep them within the text column width and prevent overflow.
 
   ```html
   <Frame>

--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -188,6 +188,20 @@ Embed external content using iframe elements:
 ></iframe>
 ```
 
+<Tip>
+  Wrap iframes in a [Frame](/components/frames) component to keep them within the text column width and prevent overflow.
+
+  ```html
+  <Frame>
+    <iframe 
+      src="https://example.com/embed" 
+      title="Embedded content"
+      className="w-full h-96 rounded-xl"
+    ></iframe>
+  </Frame>
+  ```
+</Tip>
+
 ## Related resources
 
 <Card title="Frame component reference" icon="frame" horizontal href="/components/frames">

--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -23,8 +23,10 @@ Add images to provide visual context, examples, or decoration to your documentat
 Use [Markdown syntax](https://www.markdownguide.org/basic-syntax/#images) to add images to your documentation:
 
 ```mdx
-![Alt text describing the image](/path/to/image.png)
+![Alt text describing the image](/images/screenshot.png)
 ```
+
+Image paths are root-relative from your docs repository. For example, if your image is at `images/screenshot.png` in your repository, the path is `/images/screenshot.png`. Relative paths (for example, `./screenshot.png`) are not supported.
 
 <Tip>
   Always include descriptive alt text to improve accessibility and SEO. The alt text should clearly describe what the image shows.

--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -13,15 +13,18 @@ When you change the path of a file in your docs folder, it also changes the URL 
   Redirects **cannot** include URL anchors like `path#anchor` or query parameters like `path?query=value`.
 </Note>
 
-Set up redirects by adding the `redirects` field to your `docs.json` file.
+Set up redirects by adding the `redirects` field at the top level of your `docs.json` file.
 
-```json
-"redirects": [
-  {
-    "source": "/source/path",
-    "destination": "/destination/path"
-  }
-]
+```json docs.json
+{
+  "name": "My docs",
+  "redirects": [
+    {
+      "source": "/source/path",
+      "destination": "/destination/path"
+    }
+  ]
+}
 ```
 
 This redirects `/source/path` to `/destination/path`.

--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -13,7 +13,7 @@ When you change the path of a file in your docs folder, it also changes the URL 
   Redirects **cannot** include URL anchors like `path#anchor` or query parameters like `path?query=value`.
 </Note>
 
-Set up redirects by adding the `redirects` field at the top level of your `docs.json` file.
+Add the `redirects` field to the top level of your `docs.json` file to set up redirects.
 
 ```json docs.json
 {

--- a/create/text.mdx
+++ b/create/text.mdx
@@ -101,7 +101,7 @@ Links help users navigate between pages and access external resources. Use descr
 
 ### Internal links
 
-Link to other pages in your documentation using root-relative paths:
+Link to other pages in your documentation using root-relative paths. Omit the file extension (`.mdx` or `.md`). Relative paths and paths with extensions do not work in production.
 
 ```mdx
 [Quickstart](/quickstart)

--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -347,7 +347,7 @@ Multiple instances of these elements can appear on a page. Use these as `value` 
 
 Custom JS lets you add custom executable code globally. It is the equivalent of adding a `<script>` tag with JS code into every page.
 
-Mintlify includes any `.js` file inside your content directory on every page of your documentation site. For example, you can add the following `ga.js` file to enable [Google Analytics](https://marketingplatform.google.com/about/analytics) across the entire documentation.
+Mintlify includes any `.js` file inside your content directory on every page of your documentation site. Custom JavaScript files run after the page becomes interactive and cannot be scoped to specific pages. For example, you can add the following `ga.js` file to enable [Google Analytics](https://marketingplatform.google.com/about/analytics) across the entire documentation.
 
 ```js
 window.dataLayer = window.dataLayer || [];

--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -347,7 +347,7 @@ Multiple instances of these elements can appear on a page. Use these as `value` 
 
 Custom JS lets you add custom executable code globally. It is the equivalent of adding a `<script>` tag with JS code into every page.
 
-Mintlify includes any `.js` file inside your content directory on every page of your documentation site. Custom JavaScript files run after the page becomes interactive and cannot be scoped to specific pages. For example, you can add the following `ga.js` file to enable [Google Analytics](https://marketingplatform.google.com/about/analytics) across the entire documentation.
+Mintlify includes any `.js` file inside your content directory on every page of your documentation site. Custom JavaScript files run after the page becomes interactive. You cannot scope them to specific pages. For example, you can add the following `ga.js` file to enable [Google Analytics](https://marketingplatform.google.com/about/analytics) across the entire documentation.
 
 ```js
 window.dataLayer = window.dataLayer || [];

--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -66,6 +66,16 @@ export const Counter = () => {
 <Counter />
 ```
 
+## Constraints
+
+React components in Mintlify run in a sandboxed MDX environment with the following constraints:
+
+- **React hooks are pre-injected**: `useState`, `useEffect`, `useRef`, `useCallback`, `useMemo`, `useContext`, and `useReducer` are available without importing them.
+- **No external npm packages**: Third-party packages (for example, `lodash`, `axios`, `date-fns`) cannot be imported. Use browser built-ins or write the logic inline.
+- **No default exports**: Use named exports (`export const MyComponent = ...`). Default exports (`export default`) are not supported.
+- **No cross-snippet imports**: Snippet files cannot import other snippet files. Import all dependencies directly in the parent MDX file.
+- **No JSON imports**: Importing `.json` files is not supported.
+
 ## Import components
 
 Component files must be in the `/snippets/` folder. Learn more about [reusable snippets](/create/reusable-snippets).

--- a/integrations/analytics/plausible.mdx
+++ b/integrations/analytics/plausible.mdx
@@ -16,8 +16,8 @@ Add your site's domain to `docs.json` to send analytics to Plausible.
 ```json Analytics options in docs.json
 "integrations": {
     "plausible": {
-        "domain": "required - your documentation domain",
-        "server": "optional - your self-hosted Plausible server URL"
+        "domain": "your-documentation-domain",
+        "server": "optional - your self-hosted Plausible server hostname"
     }
 }
 ```
@@ -31,3 +31,13 @@ Add your site's domain to `docs.json` to send analytics to Plausible.
 ```
 
 </CodeGroup>
+
+### Configuration options
+
+<ParamField path="domain" type="string" required>
+  Your documentation site's domain. For example, `docs.example.com`. Do not include `https://`.
+</ParamField>
+
+<ParamField path="server" type="string">
+  The hostname of your self-hosted Plausible instance. For example, `plausible.example.com`. Only required if you self-host Plausible. Omit this field to use `plausible.io`. Do not include `https://`.
+</ParamField>

--- a/integrations/analytics/posthog.mdx
+++ b/integrations/analytics/posthog.mdx
@@ -7,7 +7,7 @@ boost: 3
 
 Add the following to your `docs.json` file to send analytics to PostHog.
 
-You only need to include `apiHost` if you are self-hosting PostHog. We send events to `https://app.posthog.com` by default.
+You only need to include `apiHost` if you are self-hosting PostHog. By default, Mintlify proxies events through `https://ph.mintlify.com` to your PostHog project.
 
 <CodeGroup>
 
@@ -38,7 +38,7 @@ You only need to include `apiHost` if you are self-hosting PostHog. We send even
 </ParamField>
 
 <ParamField path="apiHost" type="string">
-  The URL of your PostHog instance. Only required if you are self-hosting PostHog. Defaults to `https://app.posthog.com`.
+  The URL of your PostHog instance. Only required if you are self-hosting PostHog. Defaults to `https://ph.mintlify.com` (Mintlify's PostHog proxy).
 </ParamField>
 
 <ParamField path="sessionRecording" type="boolean" default="true">

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -112,7 +112,7 @@ title: "Default page title"
 
 ### Wide
 
-Wide mode hides the table of contents. Use this mode for pages without headings or if you want extra horizontal space. Every theme supports wide mode.
+Wide mode hides the side panel, which includes the table of contents, `<Panel>` components, and API request/response examples. Use this mode for pages without headings or if you want extra horizontal space. Every theme supports wide mode.
 
 ```yaml
 ---

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -112,7 +112,7 @@ title: "Default page title"
 
 ### Wide
 
-Wide mode hides the side panel, which includes the table of contents, `<Panel>` components, and API request/response examples. Use this mode for pages without headings or if you want extra horizontal space. Every theme supports wide mode.
+Wide mode hides the side panel, which includes the table of contents, `<Panel>` components, and API request and response examples. Use this mode for pages without headings or if you want extra horizontal space. Every theme supports wide mode.
 
 ```yaml
 ---

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -83,7 +83,13 @@ Find your exact URL on the **Overview** page of your [dashboard](https://app.min
         See [Install the CLI](/cli/install) for full details and troubleshooting.
       </Step>
       <Step title="Clone your repository">
-        If you haven't already cloned your repository locally, follow the instructions in [Clone your repository](/cli/install#clone-your-repository).
+        If you haven't already cloned your repository locally, clone it using Git:
+
+        ```bash
+        git clone <your-repository-url>
+        ```
+
+        If your repository is in Mintlify's private organization, see [Clone to your own repository](/deploy/github#clone-to-your-own-repository) to move it to your account first.
       </Step>
       <Step title="Edit a page">
         Open `index.mdx` in your preferred editor and update the description in the frontmatter:


### PR DESCRIPTION
## Documentation changes

Had Claude Code `/goal` through all feedback then polished it up. Not convinced this was actually all of our feedback, but interesting PoC

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MDX documentation-only edits with no application code or runtime behavior changes.
> 
> **Overview**
> This PR polishes Mintlify docs from user feedback: clearer behavior notes for **AI/MCP**, **layout**, **authoring**, and **integrations**.
> 
> **AI & search:** Search MCP and the assistant now explicitly say retrieved pages come back as **Markdown**. The authenticated **Claude Code** `mcp add` example puts the server URL before the `--header` flag.
> 
> **Layout & components:** `<Panel>` is documented as hidden whenever TOC is suppressed (`wide`, `center`, `custom`). **Wide mode** is described as hiding the whole side panel (TOC, Panel, API examples), not just the TOC.
> 
> **Authoring:** Images must use **root-relative** paths; relative paths are called out as unsupported. Iframes get a **Frame** wrapper tip. Internal links must omit `.mdx`/`.md` and avoid relative paths in production. **Redirects** show a full top-level `docs.json` example. **Quickstart** adds inline `git clone` and a pointer for repos in Mintlify’s private org.
> 
> **Customization:** Custom **JS** runs after the page is interactive and applies globally. New **React** constraints cover pre-injected hooks, no npm/default exports/cross-snippet/JSON imports.
> 
> **Analytics:** **PostHog** defaults to Mintlify’s `https://ph.mintlify.com` proxy (not `app.posthog.com`). **Plausible** gains `ParamField` reference for `domain` and `server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c29573e2cb08a78d6ab29e8ac7954f299746eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->