### PR TITLE
Remove Pro plan mentions

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -2024,15 +2024,9 @@ noindex: true
     ![AI Widget](/images/changelog/widget.png)
   </Frame>
 
-  For `Pro` users, we introduced Mintlify Widget, an extension of your docs to answer your users' questions when and where they asked. You can add this AI-powered chatbot to any web page: your landing page, inside your product, or on your existing documentation pages.
+  We introduced Mintlify Widget, an extension of your docs to answer your users' questions when and where they asked. You can add this AI-powered chatbot to any web page: your landing page, inside your product, or on your existing documentation pages.
 
   - [Read the blog announcement](https://mintlify.com/blog/widget)
-
-  ## Pro Plan
-
-  We also updated our pricing plans for better customizability and scale.
-
-  - [Read the blog announcement](https://mintlify.com/blog/pro-plan)
 
   ## API Playground Code Example Sync
 

--- a/migration-services/pro.mdx
+++ b/migration-services/pro.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Migration services"
-description: "Learn about the Pro plan migration process from your existing documentation platform, including delivery timelines and quality assurance steps."
+description: "Learn about the Enterprise plan migration process from your existing documentation platform, including delivery timelines and quality assurance steps."
 ---
 
-Your Pro plan includes migration services to transfer your documentation to Mintlify. This guide covers the migration process, delivery timelines, and our quality assurance approach.
+Your Enterprise plan includes migration services to transfer your documentation to Mintlify. This guide covers the migration process, delivery timelines, and our quality assurance approach.
 
 ## What to expect for your migration
 


### PR DESCRIPTION
## What changed

The Pro plan no longer exists; migration services are now an Enterprise plan feature. This removes Pro plan references from the docs:

- **`migration-services/pro.mdx`** — frontmatter `description` and intro line now reference the **Enterprise plan** instead of the Pro plan.
- **`changelog.mdx`** (July 2024 entry) — removed the **`## Pro Plan`** section (pricing-plans update + blog link) and dropped the "For `Pro` users," qualifier from the AI Widget entry.

## Notes

- Translations (`es/`, `zh/`, `fr/`) were intentionally left untouched — per the repo CLAUDE.md, only English content is edited and translations regenerate automatically after merge.
- Example user-group enums like `["free", "pro", "enterprise"]` in `create/personalization.mdx` and `deploy/authentication-setup.mdx` were left as-is — they're sample group names, not references to Mintlify's plan.

## Areas for review

- The `migration-services/pro.mdx` file slug (`pro`) and the `pro-migrations` Typeform link are unchanged to avoid breaking external links. Flag if you'd like the page renamed/redirected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only documentation updates with no product, auth, or API behavior changes.
> 
> **Overview**
> **Docs now reflect that migration services are an Enterprise feature**, not Pro. On **`migration-services/pro.mdx`**, the frontmatter `description` and opening paragraph say **Enterprise plan** instead of Pro (the URL slug `pro` is unchanged).
> 
> In **`changelog.mdx`** (July 2024), the **Pro Plan** subsection (pricing update + blog link) is removed, and the AI Widget blurb no longer says it was for **Pro** users—Widget is described as a general Mintlify introduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db586415dd7d6a1a96aaa937c7e3d269c58025f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->