### PR TITLE
docs: copy downloads the API spec on API pages; remove download-spec

### DIFF
--- a/ai/contextual-menu.mdx
+++ b/ai/contextual-menu.mdx
@@ -19,7 +19,7 @@ The contextual menu includes several pre-built options that you can enable by ad
 
 | Option | Identifier | Description |
 |:--------|:------------|:-------------|
-| **Copy page** | `copy` | Copies the current page as Markdown for pasting as context into AI tools |
+| **Copy page** | `copy` | Copies the current page as Markdown for pasting as context into AI tools. On API reference pages, this option appears as **Download spec** and downloads your OpenAPI spec instead (zipped if there are multiple specs). |
 | **View as Markdown** | `view` | Opens the current page as Markdown |
 | **Ask assistant** | `assistant` | Opens the [assistant](/assistant/index) with the current page as context |
 | **Download PDF** | `download-pdf` | Downloads the current page as a PDF. Available on [Enterprise plans](https://mintlify.com/pricing). |
@@ -35,7 +35,6 @@ The contextual menu includes several pre-built options that you can enable by ad
 | **Connect to Cursor** | `cursor` | Installs your hosted MCP server in Cursor |
 | **Connect to VS Code** | `vscode` | Installs your hosted MCP server in VS Code |
 | **Connect to Devin** | `devin-mcp` | Installs your hosted MCP server in Devin |
-| **Download API spec** | `download-spec` | Downloads your deployment's OpenAPI spec. If there are multiple specs, downloads them as a zip archive. Only appears on API reference pages. |
 | **Download PDF** | `download-pdf` | Downloads the current page as a PDF |
 | **Custom options** | Object | Add custom options to the contextual menu |
 
@@ -68,7 +67,6 @@ Add the `contextual` field to your `docs.json` file and specify which options yo
       "cursor",
       "vscode",
       "devin-mcp",
-      "download-spec",
       "download-pdf"
     ]
  }

--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -153,15 +153,15 @@ You can also use `x-default` on any schema property in your OpenAPI specificatio
 
 ## Let visitors download your spec
 
-Opt into a "Download API spec" entry in the [page context menu](/organize/settings-structure#contextual) by adding `"download-spec"` to `contextual.options` in your `docs.json`:
+If the `copy` option is in your [page context menu](/organize/settings-structure#contextual), it appears as **Download spec** on API reference pages and downloads your OpenAPI spec directly:
 
 ```json
 "contextual": {
-  "options": ["copy", "download-spec", "chatgpt", "claude"]
+  "options": ["copy", "chatgpt", "claude"]
 }
 ```
 
-When enabled, clicking the option downloads your OpenAPI spec directly. Deployments with multiple specs receive them bundled as `api-specs.zip`. The option is hidden for deployments behind `auth` or `userAuth` to prevent leaking spec contents from authenticated docs.
+Deployments with multiple specs receive them bundled as `api-specs.zip`. On other pages, `copy` copies the page as Markdown as usual. The download is disabled for deployments behind `auth` or `userAuth` to prevent leaking spec contents from authenticated docs, so `copy` keeps its standard behavior there.
 
 ## Customize your endpoint pages
 

--- a/docs.json
+++ b/docs.json
@@ -557,7 +557,6 @@
   "contextual": {
     "options": [
       "copy",
-      "download-spec",
       "chatgpt",
       "claude",
       "add-mcp",

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -640,7 +640,7 @@ Contextual menu for page actions and AI tool integrations.
 
 Actions available in the contextual menu. The first item is the default action.
 
-**Type:** array of `"assistant"` | `"copy"` | `"view"` | `"download-pdf"` | `"download-spec"` | `"chatgpt"` | `"claude"` | `"perplexity"` | `"grok"` | `"aistudio"` | `"devin"` | `"windsurf"` | `"mcp"` | `"add-mcp"` | `"cursor"` | `"vscode"` | `"devin-mcp"` | object
+**Type:** array of `"assistant"` | `"copy"` | `"view"` | `"download-pdf"` | `"chatgpt"` | `"claude"` | `"perplexity"` | `"grok"` | `"aistudio"` | `"devin"` | `"windsurf"` | `"mcp"` | `"add-mcp"` | `"cursor"` | `"vscode"` | `"devin-mcp"` | object
 
 Custom option object fields:
 

--- a/organize/settings-structure.mdx
+++ b/organize/settings-structure.mdx
@@ -379,14 +379,13 @@ The contextual menu gives users quick access to AI tools and page actions. It ap
   - `"add-mcp"` — Add your MCP server to the user's configuration
   - `"aistudio"` — Send the current page to Google AI Studio
   - `"assistant"` — Open the AI assistant with the current page as context
-  - `"copy"` — Copy the current page as Markdown to the clipboard
+  - `"copy"` — Copy the current page as Markdown to the clipboard. On API reference pages, downloads the deployment's OpenAPI specs instead (single file, or zipped if multiple)
   - `"chatgpt"` — Send the current page to ChatGPT
   - `"claude"` — Send the current page to Claude
   - `"cursor"` — Install your hosted MCP server in Cursor
   - `"devin"` — Send the current page to Devin
   - `"devin-mcp"` — Install your hosted MCP server in Devin
   - `"download-pdf"` — Download the current page as a PDF
-  - `"download-spec"` — Download the deployment's OpenAPI specs (single file, or zipped if multiple)
   - `"grok"` — Send the current page to Grok
   - `"mcp"` — Copy your MCP server URL to the clipboard
   - `"perplexity"` — Send the current page to Perplexity


### PR DESCRIPTION
## Summary

Documents the behavior change from [mint#8351](https://github.com/mintlify/mint/pull/8351): on API reference pages, the `copy` contextual option appears as **Download spec** and downloads the deployment's OpenAPI spec(s). `download-spec` is deprecated — it remains valid in docs.json (ignored when `copy` is present, unchanged standalone) but is no longer documented.

- `ai/contextual-menu.mdx`: copy row notes the API-page behavior; Download API spec row removed; example config updated.
- `organize/settings-structure.mdx` + `settings-reference.mdx`: `download-spec` removed from option lists; `copy` description updated.
- `api-playground/openapi-setup.mdx`: "Let visitors download your spec" section rewritten around `copy`.
- `docs.json`: dropped our own now-redundant `download-spec` entry.

English only — es/fr/zh copies to follow via the localization pipeline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration schema edits in this PR; migration note is that customers should rely on `copy` instead of documenting `download-spec`.
> 
> **Overview**
> Documents a product behavior change: the contextual **`copy`** option now doubles as **Download spec** on API reference pages (OpenAPI file or `api-specs.zip`), while non-API pages still copy Markdown.
> 
> **`download-spec`** is removed from English docs—option lists in `settings-reference.mdx` and `settings-structure.mdx`, the contextual menu table and examples in `ai/contextual-menu.mdx`, and the OpenAPI setup “Let visitors download your spec” section now describe enabling **`copy`** only. Mintlify’s own **`docs.json`** drops the redundant **`download-spec`** entry.
> 
> Localized es/fr/zh copies are explicitly out of scope for this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843955ae30be8f0db4d479abb5e4772cfd59d327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->