### PR TITLE
Add OneTrust test integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -572,6 +572,12 @@
     "ga4": {
       "measurementId": "G-RCYWHL7EQ7"
     },
+    "onetrust": {
+      "domainScript": "96e22fd8-d619-4cdd-a3c6-d51529d21faf-test"
+    },
+    "heap": {
+      "appId": "1234567890"
+    },
     "posthog": {
       "apiKey": "phc_eNuN6Ojnk9O7uWfC17z12AK85fNR0BY6IiGVy0Gfwzw"
     }


### PR DESCRIPTION
## Summary
- Add Auth0 OneTrust test domain script to docs integrations
- Add a fake Heap app ID for consent-gating smoke testing

## Test Plan
- Validated docs.json with jq
- Prebuilt docs locally with the OneTrust branch client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site integration config only; test IDs and no application logic changes.
> 
> **Overview**
> Adds **OneTrust** and **Heap** entries under `integrations` in `docs.json` so the docs site can exercise consent-gated analytics in a test setup.
> 
> **OneTrust** is configured with the Auth0 test `domainScript` (`…-test`). **Heap** uses placeholder app ID `1234567890` for smoke testing that analytics stays blocked until consent is granted. Existing `ga4` and `posthog` integrations are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1425a4575ed6ea654b9ca69582424ee0ca3b7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->