### PR TITLE
docs: add indexing comparison table to hidden pages

### DIFF
--- a/organize/hidden-pages.mdx
+++ b/organize/hidden-pages.mdx
@@ -96,7 +96,7 @@ By default, hidden pages don't appear in indexing for search engines, documentat
 
 The following table summarizes how each property affects page visibility and indexing:
 
-| Property | Sidebar Navigation | Site Search | Sitemap | Search Engine Indexing | AI Assistant Context |
+| Property | Sidebar navigation | Site search | Sitemap | Search engine indexing | AI assistant context |
 |---|---|---|---|---|---|
 | `hidden: true` | Hidden | Excluded | Excluded | Excluded | Excluded |
 | `noindex: true` | Visible | Included | Included | Excluded | Excluded |

--- a/organize/hidden-pages.mdx
+++ b/organize/hidden-pages.mdx
@@ -94,6 +94,15 @@ To hide a tab, add the `hidden` property for the tab in your `docs.json` file:
 
 By default, hidden pages don't appear in indexing for search engines, documentation site search, or as AI assistant context. You have two ways to include hidden content in search and indexing.
 
+The following table summarizes how each property affects page visibility and indexing:
+
+| Property | Sidebar Navigation | Site Search | Sitemap | Search Engine Indexing | AI Assistant Context |
+|---|---|---|---|---|---|
+| `hidden: true` | ❌ Hidden | ❌ Excluded | ❌ Excluded | ❌ Excluded | ❌ Excluded |
+| `noindex: true` | ✅ Visible | ✅ Included | ✅ Included | ❌ Excluded | ❌ Excluded |
+| `searchable: true` (on hidden tab/group) | ❌ Hidden | ✅ Included | ✅ Included | ✅ Included | ✅ Included |
+| `seo.indexing: "all"` (in `docs.json`) | ❌ Hidden | ✅ Included | ✅ Included | ✅ Included | ✅ Included |
+
 ### Include all hidden pages
 
 To include every hidden page across your site in search, sitemaps, and AI context, add the `seo` property to your `docs.json`:

--- a/organize/hidden-pages.mdx
+++ b/organize/hidden-pages.mdx
@@ -98,10 +98,10 @@ The following table summarizes how each property affects page visibility and ind
 
 | Property | Sidebar Navigation | Site Search | Sitemap | Search Engine Indexing | AI Assistant Context |
 |---|---|---|---|---|---|
-| `hidden: true` | ❌ Hidden | ❌ Excluded | ❌ Excluded | ❌ Excluded | ❌ Excluded |
-| `noindex: true` | ✅ Visible | ✅ Included | ✅ Included | ❌ Excluded | ❌ Excluded |
-| `searchable: true` (on hidden tab/group) | ❌ Hidden | ✅ Included | ✅ Included | ✅ Included | ✅ Included |
-| `seo.indexing: "all"` (in `docs.json`) | ❌ Hidden | ✅ Included | ✅ Included | ✅ Included | ✅ Included |
+| `hidden: true` | Hidden | Excluded | Excluded | Excluded | Excluded |
+| `noindex: true` | Visible | Included | Included | Excluded | Excluded |
+| `searchable: true` (on hidden tab/group) | Hidden | Included | Included | Included | Included |
+| `seo.indexing: "all"` (in `docs.json`) | Hidden | Included | Included | Included | Included |
 
 ### Include all hidden pages
 


### PR DESCRIPTION
## What changed
Added a comparison table to the "Search, SEO, and AI indexing" section of `organize/hidden-pages.mdx`.

## Why
The section explained the behavior of `hidden`, `noindex`, `searchable`, and `seo.indexing` properties across multiple paragraphs. A table makes it significantly faster to scan and compare behaviors at a glance.

## What the table covers
- 4 properties: `hidden: true`, `noindex: true`, `searchable: true`, `seo.indexing: "all"`
- 5 scenarios: Sidebar Navigation, Site Search, Sitemap, Search Engine Indexing, AI Assistant Context

## How to verify
Visit the live preview and navigate to:
`/organize/hidden-pages` → "Search, SEO, and AI indexing" section

<img width="958" height="416" alt="image" src="https://github.com/user-attachments/assets/9ca5b43e-b719-4c9c-9b3d-24e584009316" />


Closes #5961

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime or configuration behavior changes; table content matches existing guidance on the same page.
> 
> **Overview**
> Adds a **comparison table** at the start of the **Search, SEO, and AI indexing** section in `organize/hidden-pages.mdx`, right after the introductory paragraph.
> 
> The table maps **`hidden: true`**, **`noindex: true`**, **`searchable: true`** (on hidden tabs/groups), and **`seo.indexing: "all"`** to five outcomes: sidebar navigation, site search, sitemap, search engine indexing, and AI assistant context. It condenses behavior that was already described in the surrounding sections into a scannable reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49b3514a1c76dee0729cd6cd85c2834be1c5d80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->