### PR TITLE
Document custom hostname setup for Cloudflare-proxied domains

### DIFF
--- a/customize/custom-domain.mdx
+++ b/customize/custom-domain.mdx
@@ -49,6 +49,8 @@ CNAME | docs | cname.mintlify.builders
   Do not add or change your `CNAME` until both verification `TXT` records show as verified in your dashboard. Each appears with a green check when DNS is correct. The dashboard verifies `TXT` records before certificate provisioning can complete. Switching `CNAME` too early commonly breaks HTTPS until provisioning finishes.
 
   If you migrate an existing domain and want zero downtime, publish the verification `TXT` records first and wait until they show verified and TLS has pre-provisioned before pointing `CNAME` at Mintlify.
+
+  This pre-validation flow does not work for domains proxied through Cloudflare. See [Cloudflare-proxied domains](#cloudflare-proxied-domains).
 </Warning>
 
 ### Verification TXT records
@@ -87,6 +89,18 @@ If your domain uses CAA (Certification Authority Authorization) records, you mus
 ### Reserved paths
 
 Mintlify reserves the `/.well-known/acme-challenge` path for certificate validation. You cannot redirect or rewrite this path. If you have configured redirects or rewrites for this path, certificate provisioning fails.
+
+### Cloudflare-proxied domains
+
+If your domain is already proxied through Cloudflare (the proxy status shows an orange cloud), the verification `TXT` records cannot show as verified before you update your `CNAME`. This happens even when the records resolve correctly with tools like `dig` or DNSChecker. Cloudflare's proxy prevents the verification from completing until traffic for the hostname routes to Mintlify.
+
+For Cloudflare-proxied domains, follow this order instead:
+
+1. Add the verification `TXT` records at your DNS provider.
+2. Update your `CNAME` record to point to `cname.mintlify.builders` without waiting for the `TXT` records to show as verified.
+3. Wait for verification and TLS provisioning to complete. Your site may briefly serve an invalid certificate during provisioning.
+
+If you need zero downtime during migration, set the `CNAME` record's proxy status to **DNS only** (gray cloud) instead. This allows the standard pre-validation flow to complete before you switch traffic.
 
 ### Provider-specific settings
 

--- a/customize/custom-domain.mdx
+++ b/customize/custom-domain.mdx
@@ -94,7 +94,7 @@ Mintlify reserves the `/.well-known/acme-challenge` path for certificate validat
 
 If your domain is already proxied through Cloudflare (the proxy status shows an orange cloud), the verification `TXT` records cannot show as verified before you update your `CNAME`. This happens even when the records resolve correctly with tools like `dig` or DNSChecker. Cloudflare's proxy prevents the verification from completing until traffic for the hostname routes to Mintlify.
 
-For Cloudflare-proxied domains, follow this order instead:
+For Cloudflare-proxied domains, follow these steps:
 
 1. Add the verification `TXT` records at your DNS provider.
 2. Update your `CNAME` record to point to `cname.mintlify.builders` without waiting for the `TXT` records to show as verified.


### PR DESCRIPTION
## Summary
A customer whose domain was already proxied through Cloudflare (orange cloud) was blocked setting up their custom domain. The docs tell users to wait until both verification TXT records show as verified before updating the CNAME, but that pre-validation never completes for Cloudflare-proxied domains — even when the records resolve correctly via dig or DNSChecker.

This PR adds a "Cloudflare-proxied domains" section to [customize/custom-domain.mdx](customize/custom-domain.mdx) explaining:
- Why TXT pre-validation does not complete for proxied domains
- The setup order to follow instead (add TXT records, update the CNAME without waiting, then let verification and TLS provisioning complete)
- The DNS-only (gray cloud) alternative for zero-downtime migrations

It also links to the new section from the existing warning so proxied users don't get stuck waiting on verification.

## Test Plan
- Confirm the in-page anchor in the warning resolves to the new "Cloudflare-proxied domains" heading
- Review the proxied-domain setup steps for technical accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to custom domain guidance; no application or infrastructure code is modified.
> 
> **Overview**
> Documents why **Cloudflare-proxied (orange cloud)** custom domains cannot complete TXT pre-validation before the `CNAME` points at Mintlify, and gives an alternate setup path so users are not blocked by the existing “wait for green checks” guidance.
> 
> The existing **Warning** now links to a new **Cloudflare-proxied domains** section. That section explains the proxy limitation, lists steps to add TXT records, update `CNAME` to `cname.mintlify.builders` without waiting on dashboard verification, and notes possible brief invalid TLS during provisioning. It also describes using **DNS only** (gray cloud) for zero-downtime migration via the standard pre-validation flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a45fad8097e6883fdfd3908f3cd4a8a788960a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->