### PR TITLE
Clarify enterprise support tiers, SLAs, and coverage hours

### DIFF
--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -94,7 +94,6 @@ For customers who have purchased Enterprise Support (Advanced Slack Support or D
     Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. Advanced Slack Support includes:
 
     - **Dedicated Slack channel** with AI-powered issue detection and automatic routing to our support inbox
-    - **Binding SLA commitments** with defined priority-based response and resolution times
     - **Expedited bug escalation** to the Mintlify engineering team
   </Accordion>
 

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -12,11 +12,7 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 
 Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
 
-### Enterprise support (add-on)
-
-Enterprise support is a paid add-on available in two forms: **Advanced Slack Support** and **Dedicated CSM**. Both tiers include the same priority-based SLA response time commitments (see table below), and differ in how issues are routed to our team.
-
-#### Advanced Slack Support
+### Advanced Slack Support (add-on)
 
 We set up a dedicated Slack channel for your team. An AI tool monitors the channel, detects support-related messages, and automatically routes them into our support inbox where our team responds.
 
@@ -28,7 +24,7 @@ We set up a dedicated Slack channel for your team. An AI tool monitors the chann
 
 **Best for:** Teams that need faster, structured response times without requiring a dedicated point of contact.
 
-#### Dedicated CSM
+### Dedicated CSM (add-on)
 
 You get an assigned Customer Success Manager who owns your dedicated Slack channel. Your CSM responds to questions directly and manually escalates issues to the support team when needed — enabling faster internal coordination and resolution by working alongside support in real time.
 
@@ -42,9 +38,9 @@ You get an assigned Customer Success Manager who owns your dedicated Slack chann
 
 **Best for:** Teams that need fast resolution, a named point of contact, and a strategic partner.
 
-### Enterprise SLA response times
+### SLA response times
 
-For customers who have purchased Enterprise Support (Advanced Slack Support or Dedicated CSM), Mintlify will use commercially reasonable efforts to meet the following service levels:
+Both add-ons include the same priority-based SLA commitments. Mintlify will use commercially reasonable efforts to meet the following service levels:
 
 | Priority | Definition | Initial Response | Target Resolution |
 |---|---|---|---|

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -10,7 +10,7 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 
 ### Standard support (included)
 
-Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly — **there are no binding SLA commitments at this tier.**
+Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
 
 ### Enterprise support (add-on)
 

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -1,99 +1,120 @@
 ---
 title: "Advanced support"
 description: "Get premium support with faster response times, a dedicated customer success manager, and priority assistance for your documentation site."
-keywords: ["support", "CSM", "enterprise"]
+keywords: ["support", "CSM", "enterprise", "SLA"]
 ---
 
-## Support options
+## Support tiers
 
-- All customers receive support via dashboard or support@mintlify.com (24 hour response)
-- Enterprise plan customers can add Advanced Slack support (24-hour response) or a dedicated CSM (4-hour response + strategic partnership)
+Mintlify offers three support tiers. The right tier depends on the level of commitment, response time, and relationship you need.
 
 ### Standard support (included)
 
-Included with all Pro and Enterprise plans. Submit tickets through the dashboard or email support@mintlify.com. First response within 24-48 hours.
+Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly — **there are no binding SLA commitments at this tier.**
 
-### Advanced Slack support (add-on)
+### Enterprise support (add-on)
 
-Get a dedicated Slack channel with our support team for faster troubleshooting.
+Enterprise support is a paid add-on available in two forms: **Advanced Slack Support** and **Dedicated CSM**. Both tiers include the same priority-based SLA response time commitments (see table below), and differ in how issues are routed to our team.
+
+#### Advanced Slack Support
+
+We set up a dedicated Slack channel for your team. An AI tool monitors the channel, detects support-related messages, and automatically routes them into our support inbox where our team responds.
 
 **What you get:**
-- Slack channel for your team and Mintlify support engineers
-- 24-hour first response SLA
+- Dedicated Slack channel connected to our support team
+- Automatic AI-powered issue detection and routing to our support inbox
+- Priority-based SLA response times (see table below)
 - Expedited bug escalation to the Mintlify engineering team
 
-**Best for:** Teams that need faster response times but don't require strategic partnership or scheduled check-ins.
+**Best for:** Teams that need faster, structured response times without requiring a dedicated point of contact.
 
-### Dedicated CSM (add-on)
+#### Dedicated CSM
 
-Get an assigned Customer Success Manager who knows your team, setup, and goals.
+You get an assigned Customer Success Manager who owns your dedicated Slack channel. Your CSM responds to questions directly and manually escalates issues to the support team when needed — enabling faster internal coordination and resolution by working alongside support in real time.
 
 **What you get:**
-- Assigned CSM as your primary contact
-- 4-hour first response SLA (9 AM-5 PM PST for US customers, 24 hours international)
-- Dedicated Slack channel
-- Monthly check-ins
-- Quarterly business reviews
+- Assigned CSM as your primary contact and channel owner
+- Manual escalation to the support team with direct internal coordination
+- Priority-based SLA response times (see table below)
+- Monthly check-ins and quarterly business reviews
 - Shared feature request tracker with direct product team escalation
 - Priority bug and incident escalation
 
-**Best for:** Teams that need fast responses, proactive guidance, and influence over the product roadmap.
+**Best for:** Teams that need fast resolution, a named point of contact, and a strategic partner.
+
+### Enterprise SLA response times
+
+For customers who have purchased Enterprise Support (Advanced Slack Support or Dedicated CSM), Mintlify will use commercially reasonable efforts to meet the following service levels:
+
+| Priority | Definition | Initial Response | Target Resolution |
+|---|---|---|---|
+| **P0 – Critical** | Complete service outage or security incident | 15 minutes | 1 hour |
+| **P1 – High** | Major functionality blocked with no available workaround | 1 hour | 3 hours |
+| **P2 – Medium** | Partial degradation or functionality issue with a workaround | 6 hours | 48 hours |
+| **P3 – Low** | Minor issues, cosmetic bugs, or general product inquiries | 12 hours | 96 hours |
+
+<Note>
+**P0 is the only priority level with 24/7 response coverage.** P0 incidents (complete service outage or security incident) are managed directly by Mintlify engineering. We publish real-time status updates and incident progress at [status.mintlify.com](https://status.mintlify.com).
+
+**P1–P3 response times apply during Mintlify business hours only: 9 AM–5 PM PT, Monday–Friday, excluding US holidays.**
+</Note>
 
 ## FAQ
 
 ### Dedicated CSM
 
 <AccordionGroup>
-  <Accordion title="What's the difference between a dedicated CSM and standard support?">
-    We deliver standard support via the dashboard or support@mintlify.com with a 24-48 hour response SLA. A Dedicated CSM includes both a primary point of contact and a dedicated Slack channel. The main differences are:
+  <Accordion title="What's the difference between a Dedicated CSM and Advanced Slack Support?">
+    Both tiers include the same priority-based SLA response time commitments. The difference is in how your issues reach our team:
 
-    - **Response time:** 4 hours for US customers during business hours versus 24-48 hours for standard support
-    - **Relationship:** One person who knows your setup versus a support team rotation
-    - **Proactive engagement:** Monthly check-ins and QBRs versus reactive support
-    - **Product influence:** Direct escalation to the product team and input on the roadmap
-    - **Strategic planning:** Quarterly business reviews and success planning
+    - **Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
+    - **Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
+
+    The Dedicated CSM tier also includes monthly check-ins, quarterly business reviews, and a shared feature request tracker with direct product team access.
   </Accordion>
 
-  <Accordion title="Why is a dedicated CSM priced at a premium?">
-    You're getting a person who knows your team, your setup, and your goals—not a support queue. This includes:
+  <Accordion title="What's the difference between a Dedicated CSM and standard support?">
+    Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. A Dedicated CSM includes:
 
-    - 4-hour response SLA (versus 24-48 hours for standard support)
-    - Monthly check-ins and quarterly business reviews
-    - Direct influence on what we build
-    - Priority escalation for bugs and incidents
-    - Curated feature updates and enablement materials
-
-    This is premium, high-touch service calibrated for teams where fast resolution and strategic partnership matter. If you want faster support without the full CSM relationship, our advanced Slack support option gives you a dedicated channel with 24-hour response times at a lower price point.
+    - **Binding SLA commitments** with defined priority-based response and resolution times
+    - **Dedicated Slack channel** with an assigned CSM as your primary contact
+    - **Proactive engagement:** Monthly check-ins and quarterly business reviews
+    - **Product influence:** Direct escalation to the product team and roadmap input
   </Accordion>
 
   <Accordion title="How does feature request tracking work?">
-    Every dedicated CSM customer gets a shared Google Sheet tracker where you can:
-
-    - Submit feature requests with context and priority
-    - See status updates as requests move through review and development
-    - Track which features have been shipped
-    - Provide feedback and additional details as features are scoped
-
-    Your CSM reviews this tracker regularly and escalates priority items directly to our product team.
+    Every Dedicated CSM customer gets a shared tracker where you can submit feature requests with context and priority, see status updates as requests move through review and development, and provide feedback as features are scoped. Your CSM reviews this regularly and escalates priority items directly to our product team.
   </Accordion>
 </AccordionGroup>
 
-### Advanced Slack support
+### Advanced Slack Support
 
 <AccordionGroup>
-  <Accordion title="What's the difference between advanced Slack support and standard support?">
-    We deliver standard support (included with Pro and Enterprise plans) via the dashboard or support@mintlify.com with a 24-48 hour response SLA. Advanced Slack support includes:
+  <Accordion title="What's the difference between Advanced Slack Support and standard support?">
+    Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. Advanced Slack Support includes:
 
-    - Dedicated Slack channel versus email/dashboard support
-    - 24-hour response SLA versus 24-48 hours for standard support
-    - Expedited bug escalation to the Mintlify engineering team
+    - **Dedicated Slack channel** with AI-powered issue detection and automatic routing to our support inbox
+    - **Binding SLA commitments** with defined priority-based response and resolution times
+    - **Expedited bug escalation** to the Mintlify engineering team
   </Accordion>
 
-  <Accordion title="Why is advanced Slack support priced separately?">
-    You're getting a dedicated Slack channel with our support team plus expedited engineering escalation for bugs and incidents—not email support with 24-48 hour response times. This is premium support for teams that need faster answers without the full strategic CSM relationship.
+  <Accordion title="How does the AI routing work?">
+    When you send a message in your dedicated Slack channel, our AI tool detects whether it's a support-related issue and automatically routes it to our support inbox. This ensures your issues are captured and triaged without requiring manual intervention.
+  </Accordion>
+</AccordionGroup>
+
+### SLAs and coverage hours
+
+<AccordionGroup>
+  <Accordion title="What counts as a P0 incident?">
+    A P0 is a complete service outage or security incident affecting your Mintlify deployment. P0 classification is determined by Mintlify. We monitor our systems continuously and proactively open P0 incidents when the criteria are met. Real-time status is always available at [status.mintlify.com](https://status.mintlify.com).
+  </Accordion>
+
+  <Accordion title="What are Mintlify business hours?">
+    Business hours for P1–P3 SLA commitments are **9 AM–5 PM PT, Monday–Friday, excluding US public holidays.** P0 incidents are covered 24/7 and handled by Mintlify engineering.
   </Accordion>
 </AccordionGroup>
 
 ## Get started
 
-Contact your Mintlify account team to add advanced Slack support or a dedicated CSM, or email gtm@mintlify.com.
+Contact your Mintlify account team to add Advanced Slack Support or a Dedicated CSM, or email gtm@mintlify.com.


### PR DESCRIPTION
## Summary

- Replaces vague 24h/4h response time claims with the full P0–P3 SLA table (matches contract language)
- Explicitly states that Standard Support has no binding SLA — best effort only
- Frames both add-ons under an "Enterprise Support" umbrella with a clear explanation of how each one works:
  - **Advanced Slack Support**: AI tool detects and routes messages to the support inbox
  - **Dedicated CSM**: CSM owns the channel, responds directly, and manually escalates to support
- Adds a clear callout that P0 is the **only** 24/7 commitment (handled by engineering, not support) and that P1–P3 apply during business hours only (9 AM–5 PM PT, Mon–Fri)
- New FAQ accordion section covering what counts as a P0 and what "business hours" means

## Why

Our contracts reference "Enterprise Support" SLA terms but the docs page didn't define those terms clearly or accurately. This caused a mismatch between what sales was committing to and what the support team could actually deliver. This PR aligns the docs with our actual support model.

## Test plan
- [ ] Preview the page and verify the SLA table renders correctly
- [ ] Confirm the Note callout renders with the business hours and P0 language
- [ ] Confirm all accordion sections expand correctly
- [ ] Check that links to status.mintlify.com are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to customer-facing support commitments; no application code or runtime behavior is affected.
> 
> **Overview**
> **Aligns the Advanced support docs with contract-style enterprise SLAs** by replacing simple “24h / 4h” response claims with a shared **P0–P3** table (initial response + target resolution) for both add-ons, and stating that **Standard support is best-effort with no binding SLA**.
> 
> The page is reframed as **three support tiers**, with clearer differentiation: **Advanced Slack Support** (AI detection/routing into the support inbox) vs **Dedicated CSM** (named owner, direct replies, manual escalation). A **Note** callout clarifies that **only P0 is 24/7** (engineering + status page) and **P1–P3 apply in business hours** (9 AM–5 PM PT, Mon–Fri). FAQs are reorganized and expanded (tier comparisons, AI routing, P0 definition, business hours); pricing/premium rationale accordions are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ba567e653a7a119040f640a463bb43300858dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->