### PR TITLE
Remove quarterly business reviews from Dedicated CSM

### DIFF
--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Advanced support"
 description: "Get premium support with faster response times, a dedicated customer success manager, and priority assistance for your documentation site."
-keywords: ["support", "CSM", "enterprise", "SLA"]
+keywords: ["support", "CSM", "enterprise"]
 ---
 
 ## Support tiers
@@ -87,7 +87,7 @@ Both add-ons include the same response time targets. Mintlify will use commercia
 
 <AccordionGroup>
   <Accordion title="What's the difference between Advanced Slack Support and standard support?">
-    Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. Advanced Slack Support includes:
+    Standard support (included with all Enterprise plans) is best-effort with no binding time target commitments. Advanced Slack Support includes:
 
     - **Dedicated Slack channel** with AI-powered issue detection and automatic routing to our support inbox
     - **Expedited bug escalation** to the Mintlify engineering team

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -18,13 +18,13 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 | **Feature request tracking** | — | — | Yes |
 
 <CardGroup cols={3}>
-  <Card title="Tier 1 · Standard" icon="envelope">
+  <Card title="Tier 1 · Standard">
     Included with all plans. Reach us via email or the dashboard. Best-effort response with no time target commitments.
   </Card>
-  <Card title="Tier 2 · Advanced Slack Support" icon="slack">
+  <Card title="Tier 2 · Advanced Slack Support">
     Dedicated Slack channel with AI-powered routing to our support inbox. Includes response time targets for P0–P3 issues.
   </Card>
-  <Card title="Tier 3 · Dedicated CSM" icon="user-tie">
+  <Card title="Tier 3 · Dedicated CSM">
     An assigned CSM owns your channel, responds directly, and escalates to support internally. The highest level of hands-on support we offer.
   </Card>
 </CardGroup>

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -70,7 +70,7 @@ Both add-ons include the same response time targets. Mintlify will use commercia
   </Accordion>
 
   <Accordion title="What's the difference between a Dedicated CSM and standard support?">
-    Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. A Dedicated CSM includes:
+    Standard support (included with all Enterprise plans) is best-effort with no binding time target commitments. A Dedicated CSM includes:
 
     - **Defined response time targets** for initial response and resolution
     - **Dedicated Slack channel** with an assigned CSM as your primary contact

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -18,22 +18,22 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 | **Feature request tracking** | — | — | Yes |
 
 <CardGroup cols={3}>
-  <Card title="Tier 1 · Standard">
+  <Card title="Tier 1 · Standard" icon="headset">
     Included with all plans. Reach us via email or the dashboard. Best-effort response with no time target commitments.
   </Card>
-  <Card title="Tier 2 · Advanced Slack Support">
+  <Card title="Tier 2 · Advanced Slack Support" icon="slack">
     Dedicated Slack channel with AI-powered routing to our support inbox. Includes response time targets for P0–P3 issues.
   </Card>
-  <Card title="Tier 3 · Dedicated CSM">
+  <Card title="Tier 3 · Dedicated CSM" icon="handshake">
     An assigned CSM owns your channel, responds directly, and escalates to support internally. The highest level of hands-on support we offer.
   </Card>
 </CardGroup>
 
-### Standard support (included)
+### Tier 1 — Standard support (included)
 
 Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
 
-### Advanced Slack Support (add-on)
+### Tier 2 — Advanced Slack Support (add-on)
 
 We set up a dedicated Slack channel for your team. An AI tool monitors the channel, detects support-related messages, and automatically routes them into our support inbox where our team responds.
 
@@ -45,7 +45,7 @@ We set up a dedicated Slack channel for your team. An AI tool monitors the chann
 
 **Best for:** Teams that need faster, structured response times without requiring a dedicated point of contact.
 
-### Dedicated CSM (add-on)
+### Tier 3 — Dedicated CSM (add-on)
 
 You get an assigned Customer Success Manager who owns your dedicated Slack channel. Your CSM responds to questions directly and manually escalates issues to the support team when needed. This enables faster internal coordination and resolution by working alongside support in real time.
 
@@ -61,7 +61,7 @@ You get an assigned Customer Success Manager who owns your dedicated Slack chann
 
 ### Response time targets
 
-Both add-ons include the same response time targets. Mintlify will use commercially reasonable efforts to meet the following service levels:
+Tiers 2 and 3 include the same response time targets. Mintlify will use commercially reasonable efforts to meet the following service levels:
 
 | Priority | Definition | Initial response | Target resolution |
 |---|---|---|---|
@@ -78,20 +78,20 @@ Both add-ons include the same response time targets. Mintlify will use commercia
 
 ## FAQ
 
-### Dedicated CSM
+### Tier 3 — Dedicated CSM
 
 <AccordionGroup>
   <Accordion title="What's the difference between a Dedicated CSM and Advanced Slack Support?">
-    Both tiers share the same response time targets. The difference is in how your issues reach our team:
+    Tiers 2 and 3 share the same response time targets. The difference is in how your issues reach our team:
 
-    - **Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
-    - **Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
+    - **Tier 2 — Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
+    - **Tier 3 — Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
 
-    The Dedicated CSM tier also includes monthly check-ins and a shared feature request tracker with direct product team access.
+    Tier 3 also includes monthly check-ins and a shared feature request tracker with direct product team access.
   </Accordion>
 
   <Accordion title="What's the difference between a Dedicated CSM and standard support?">
-    Standard support (included with all Enterprise plans) is best-effort with no binding time target commitments. A Dedicated CSM includes:
+    Tier 1 (Standard support, included with all Enterprise plans) is best-effort with no binding time target commitments. Tier 3 (Dedicated CSM) includes:
 
     - **Defined response time targets** for initial response and resolution
     - **Dedicated Slack channel** with an assigned CSM as your primary contact
@@ -100,17 +100,18 @@ Both add-ons include the same response time targets. Mintlify will use commercia
   </Accordion>
 
   <Accordion title="How does feature request tracking work?">
-    Every Dedicated CSM customer gets a shared tracker where you can submit feature requests with context and priority, see status updates as requests move through review and development, and provide feedback as features are scoped. Your CSM reviews this regularly and escalates priority items directly to our product team.
+    Every Tier 3 customer gets a shared tracker where you can submit feature requests with context and priority, see status updates as requests move through review and development, and provide feedback as features are scoped. Your CSM reviews this regularly and escalates priority items directly to our product team.
   </Accordion>
 </AccordionGroup>
 
-### Advanced Slack Support
+### Tier 2 — Advanced Slack Support
 
 <AccordionGroup>
   <Accordion title="What's the difference between Advanced Slack Support and standard support?">
-    Standard support (included with all Enterprise plans) is best-effort with no binding time target commitments. Advanced Slack Support includes:
+    Tier 1 (Standard support, included with all Enterprise plans) is best-effort with no binding time target commitments. Tier 2 (Advanced Slack Support) includes:
 
     - **Dedicated Slack channel** with AI-powered issue detection and automatic routing to our support inbox
+    - **Response time targets** for P0–P3 issues
     - **Expedited bug escalation** to the Mintlify engineering team
   </Accordion>
 
@@ -133,4 +134,4 @@ Both add-ons include the same response time targets. Mintlify will use commercia
 
 ## Get started
 
-Contact your Mintlify account team to add Advanced Slack Support or a Dedicated CSM, or email gtm@mintlify.com.
+Contact your Mintlify account team to add Advanced Slack Support (Tier 2) or a Dedicated CSM (Tier 3), or email gtm@mintlify.com.

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -18,8 +18,8 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 | **Feature request tracking** | No | No | Yes |
 
 <CardGroup cols={1}>
-  <Card title="Tier 1 · Standard" icon="headset">
-    Included with all plans. Reach us via email or the dashboard. Best-effort response with no time target commitments.
+  <Card title="Tier 1 · Standard" icon="computer">
+    Included with all plans. Reach us via the dashboard. Best-effort response with no time target commitments.
   </Card>
   <Card title="Tier 2 · Advanced Slack Support" icon="slack">
     Dedicated Slack channel with AI-powered routing to our support inbox. Includes response time targets for P0–P3 issues.

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -10,14 +10,14 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 
 | | Standard | Advanced Slack | Dedicated CSM |
 |---|---|---|---|
-| **Tier** | 1 — included | 2 — add-on | 3 — add-on |
+| **Tier** | 1 (included) | 2 (add-on) | 3 (add-on) |
 | **How issues reach us** | Email or dashboard | AI routing | CSM escalates manually |
 | **Response time targets** | Best effort | P0–P3 | P0–P3 |
-| **Named contact** | — | — | Yes |
-| **Monthly check-ins** | — | — | Yes |
-| **Feature request tracking** | — | — | Yes |
+| **Named contact** | No | No | Yes |
+| **Monthly check-ins** | No | No | Yes |
+| **Feature request tracking** | No | No | Yes |
 
-<CardGroup cols={3}>
+<CardGroup cols={1}>
   <Card title="Tier 1 · Standard" icon="headset">
     Included with all plans. Reach us via email or the dashboard. Best-effort response with no time target commitments.
   </Card>
@@ -29,11 +29,11 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
   </Card>
 </CardGroup>
 
-### Tier 1 — Standard support (included)
+### Tier 1: Standard support (included)
 
 Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
 
-### Tier 2 — Advanced Slack Support (add-on)
+### Tier 2: Advanced Slack Support (add-on)
 
 We set up a dedicated Slack channel for your team. An AI tool monitors the channel, detects support-related messages, and automatically routes them into our support inbox where our team responds.
 
@@ -45,9 +45,9 @@ We set up a dedicated Slack channel for your team. An AI tool monitors the chann
 
 **Best for:** Teams that need faster, structured response times without requiring a dedicated point of contact.
 
-### Tier 3 — Dedicated CSM (add-on)
+### Tier 3: Dedicated CSM (add-on)
 
-You get an assigned Customer Success Manager who owns your dedicated Slack channel. Your CSM responds to questions directly and manually escalates issues to the support team when needed. This enables faster internal coordination and resolution by working alongside support in real time.
+You get an assigned Customer Success Manager who owns your dedicated Slack channel. Your CSM responds to questions directly and manually escalates issues to the support team when needed (enabling faster internal coordination and resolution by working alongside support in real time).
 
 **What you get:**
 - Assigned CSM as your primary contact and channel owner
@@ -78,14 +78,14 @@ Tiers 2 and 3 include the same response time targets. Mintlify will use commerci
 
 ## FAQ
 
-### Tier 3 — Dedicated CSM
+### Tier 3: Dedicated CSM
 
 <AccordionGroup>
   <Accordion title="What's the difference between a Dedicated CSM and Advanced Slack Support?">
     Tiers 2 and 3 share the same response time targets. The difference is in how your issues reach our team:
 
-    - **Tier 2 — Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
-    - **Tier 3 — Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
+    - **Tier 2: Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
+    - **Tier 3: Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team (enabling faster internal coordination and resolution).
 
     Tier 3 also includes monthly check-ins and a shared feature request tracker with direct product team access.
   </Accordion>
@@ -104,7 +104,7 @@ Tiers 2 and 3 include the same response time targets. Mintlify will use commerci
   </Accordion>
 </AccordionGroup>
 
-### Tier 2 — Advanced Slack Support
+### Tier 2: Advanced Slack Support
 
 <AccordionGroup>
   <Accordion title="What's the difference between Advanced Slack Support and standard support?">

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -31,7 +31,7 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 
 ### Tier 1: Standard support (included)
 
-Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
+Included with all Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.
 
 ### Tier 2: Advanced Slack Support (add-on)
 

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -8,14 +8,14 @@ keywords: ["support", "CSM", "enterprise"]
 
 Mintlify offers three support tiers. The right tier depends on the level of commitment, response time, and relationship you need.
 
-| | Tier 1 · Standard | Tier 2 · Advanced Slack | Tier 3 · Dedicated CSM |
+| | Standard | Advanced Slack | Dedicated CSM |
 |---|---|---|---|
-| **Availability** | All plans, included | Add-on | Add-on |
-| **How issues reach us** | Email or dashboard | AI routing from your Slack channel | CSM manually escalates |
-| **Response time targets** | Best effort | P0–P3 table | P0–P3 table |
-| **Named contact** | No | No | Yes |
-| **Monthly check-ins** | No | No | Yes |
-| **Feature request tracking** | No | No | Yes |
+| **Tier** | 1 — included | 2 — add-on | 3 — add-on |
+| **How issues reach us** | Email or dashboard | AI routing | CSM escalates manually |
+| **Response time targets** | Best effort | P0–P3 | P0–P3 |
+| **Named contact** | — | — | Yes |
+| **Monthly check-ins** | — | — | Yes |
+| **Feature request tracking** | — | — | Yes |
 
 <CardGroup cols={3}>
   <Card title="Tier 1 · Standard" icon="envelope">

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -32,7 +32,7 @@ You get an assigned Customer Success Manager who owns your dedicated Slack chann
 - Assigned CSM as your primary contact and channel owner
 - Manual escalation to the support team with direct internal coordination
 - Priority-based SLA response times (see table below)
-- Monthly check-ins and quarterly business reviews
+- Monthly check-ins
 - Shared feature request tracker with direct product team escalation
 - Priority bug and incident escalation
 
@@ -66,7 +66,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
     - **Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
     - **Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
 
-    The Dedicated CSM tier also includes monthly check-ins, quarterly business reviews, and a shared feature request tracker with direct product team access.
+    The Dedicated CSM tier also includes monthly check-ins and a shared feature request tracker with direct product team access.
   </Accordion>
 
   <Accordion title="What's the difference between a Dedicated CSM and standard support?">
@@ -74,7 +74,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
 
     - **Binding SLA commitments** with defined priority-based response and resolution times
     - **Dedicated Slack channel** with an assigned CSM as your primary contact
-    - **Proactive engagement:** Monthly check-ins and quarterly business reviews
+    - **Proactive engagement:** Monthly check-ins
     - **Product influence:** Direct escalation to the product team and roadmap input
   </Accordion>
 

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -8,6 +8,27 @@ keywords: ["support", "CSM", "enterprise"]
 
 Mintlify offers three support tiers. The right tier depends on the level of commitment, response time, and relationship you need.
 
+| | Tier 1 · Standard | Tier 2 · Advanced Slack | Tier 3 · Dedicated CSM |
+|---|---|---|---|
+| **Availability** | All plans, included | Add-on | Add-on |
+| **How issues reach us** | Email or dashboard | AI routing from your Slack channel | CSM manually escalates |
+| **Response time targets** | Best effort | P0–P3 table | P0–P3 table |
+| **Named contact** | No | No | Yes |
+| **Monthly check-ins** | No | No | Yes |
+| **Feature request tracking** | No | No | Yes |
+
+<CardGroup cols={3}>
+  <Card title="Tier 1 · Standard" icon="envelope">
+    Included with all plans. Reach us via email or the dashboard. Best-effort response with no time target commitments.
+  </Card>
+  <Card title="Tier 2 · Advanced Slack Support" icon="slack">
+    Dedicated Slack channel with AI-powered routing to our support inbox. Includes response time targets for P0–P3 issues.
+  </Card>
+  <Card title="Tier 3 · Dedicated CSM" icon="user-tie">
+    An assigned CSM owns your channel, responds directly, and escalates to support internally. The highest level of hands-on support we offer.
+  </Card>
+</CardGroup>
+
 ### Standard support (included)
 
 Included with all Pro and Enterprise plans. Reach us through the dashboard or at support@mintlify.com. We do our best to respond and resolve issues quickly.

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -18,13 +18,13 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 | **Feature request tracking** | No | No | Yes |
 
 <CardGroup cols={1}>
-  <Card title="Tier 1 · Standard" icon="computer">
+  <Card title="Tier 1 · Standard" icon="laptop" href="#tier-1-standard-support-included">
     Included with all plans. Reach us via the dashboard. Best-effort response with no time target commitments.
   </Card>
-  <Card title="Tier 2 · Advanced Slack Support" icon="slack">
+  <Card title="Tier 2 · Advanced Slack Support" icon="slack" href="#tier-2-advanced-slack-support-add-on">
     Dedicated Slack channel with AI-powered routing to our support inbox. Includes response time targets for P0–P3 issues.
   </Card>
-  <Card title="Tier 3 · Dedicated CSM" icon="handshake">
+  <Card title="Tier 3 · Dedicated CSM" icon="handshake" href="#tier-3-dedicated-csm-add-on">
     An assigned CSM owns your channel, responds directly, and escalates to support internally. The highest level of hands-on support we offer.
   </Card>
 </CardGroup>

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -19,7 +19,7 @@ We set up a dedicated Slack channel for your team. An AI tool monitors the chann
 **What you get:**
 - Dedicated Slack channel connected to our support team
 - Automatic AI-powered issue detection and routing to our support inbox
-- Priority-based SLA response times (see table below)
+- Priority-based response time targets (see table below)
 - Expedited bug escalation to the Mintlify engineering team
 
 **Best for:** Teams that need faster, structured response times without requiring a dedicated point of contact.
@@ -31,16 +31,16 @@ You get an assigned Customer Success Manager who owns your dedicated Slack chann
 **What you get:**
 - Assigned CSM as your primary contact and channel owner
 - Manual escalation to the support team with direct internal coordination
-- Priority-based SLA response times (see table below)
+- Priority-based response time targets (see table below)
 - Monthly check-ins
 - Shared feature request tracker with direct product team escalation
 - Priority bug and incident escalation
 
 **Best for:** Teams that need fast resolution, a named point of contact, and a strategic partner.
 
-### SLA response times
+### Response time targets
 
-Both add-ons include the same priority-based SLA commitments. Mintlify will use commercially reasonable efforts to meet the following service levels:
+Both add-ons include the same response time targets. Mintlify will use commercially reasonable efforts to meet the following service levels:
 
 | Priority | Definition | Initial response | Target resolution |
 |---|---|---|---|
@@ -61,7 +61,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
 
 <AccordionGroup>
   <Accordion title="What's the difference between a Dedicated CSM and Advanced Slack Support?">
-    Both tiers include the same priority-based SLA response time commitments. The difference is in how your issues reach our team:
+    Both tiers share the same response time targets. The difference is in how your issues reach our team:
 
     - **Advanced Slack Support** uses an AI tool to automatically detect and route support messages from your Slack channel to our support inbox.
     - **Dedicated CSM** gives you an assigned CSM who actively monitors your channel, responds to questions directly, and manually escalates to the support team — enabling faster internal coordination and resolution.
@@ -72,7 +72,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
   <Accordion title="What's the difference between a Dedicated CSM and standard support?">
     Standard support (included with all Pro and Enterprise plans) is best-effort with no binding SLA commitments. A Dedicated CSM includes:
 
-    - **Binding SLA commitments** with defined priority-based response and resolution times
+    - **Defined response time targets** for initial response and resolution
     - **Dedicated Slack channel** with an assigned CSM as your primary contact
     - **Proactive engagement:** Monthly check-ins
     - **Product influence:** Direct escalation to the product team and roadmap input
@@ -98,7 +98,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
   </Accordion>
 </AccordionGroup>
 
-### SLAs and coverage hours
+### Coverage hours
 
 <AccordionGroup>
   <Accordion title="What counts as a P0 incident?">
@@ -106,7 +106,7 @@ Both add-ons include the same priority-based SLA commitments. Mintlify will use 
   </Accordion>
 
   <Accordion title="What are Mintlify business hours?">
-    Business hours for P1–P3 SLA commitments are **9 AM–5 PM PT, Monday–Friday, excluding US public holidays.** P0 incidents are covered 24/7 and handled by Mintlify engineering.
+    P1–P3 response time targets apply during **9 AM–5 PM PT, Monday–Friday, excluding US public holidays.** P0 incidents are covered 24/7 and handled by Mintlify engineering.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

- Removes "quarterly business reviews" from the Dedicated CSM bullet list
- Removes it from two FAQ accordion answers that referenced it

## Why

We don't currently offer quarterly business reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to marketing/support copy with no application or security impact.
> 
> **Overview**
> **`advanced-support.mdx`** is reworked around explicit **Tier 1–3** naming with a comparison table and **CardGroup** navigation, plus FAQ headings aligned to each tier.
> 
> Copy no longer mentions **quarterly business reviews** (Dedicated CSM bullets and two FAQ answers). **Standard support** is described as included with **Enterprise** plans only (replacing Pro and Enterprise in several spots). **SLA** wording is softened to **response time targets** / non-binding language, including the coverage-hours FAQ title change from “SLAs and coverage hours.”
> 
> Tier 2’s standard-vs-advanced FAQ now explicitly lists **P0–P3 response time targets**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c508a64b194416699dbccc3be96cf1f33fa1ba18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->