### PR TITLE
Clarify Slack as source in support tier comparison table

### DIFF
--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -11,7 +11,7 @@ Mintlify offers three support tiers. The right tier depends on the level of comm
 | | Standard | Advanced Slack | Dedicated CSM |
 |---|---|---|---|
 | **Tier** | 1 (included) | 2 (add-on) | 3 (add-on) |
-| **How issues reach us** | Email or dashboard | AI routing | CSM escalates manually |
+| **How issues reach us** | Email or dashboard | AI routing from Slack | CSM escalates from Slack |
 | **Response time targets** | Best effort | P0–P3 | P0–P3 |
 | **Named contact** | No | No | Yes |
 | **Monthly check-ins** | No | No | Yes |


### PR DESCRIPTION
## Summary

- Updates the comparison table row "How issues reach us" to say "AI routing from Slack" and "CSM escalates from Slack" instead of the vague "AI routing" / "CSM escalates manually"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy change with no product, API, or runtime behavior impact.
> 
> **Overview**
> Updates the **How issues reach us** row in the support tier comparison table on `advanced-support.mdx` so Tier 2 and Tier 3 explicitly name **Slack** as the intake channel.
> 
> Tier 2 now reads **AI routing from Slack** (was **AI routing**). Tier 3 now reads **CSM escalates from Slack** (was **CSM escalates manually**). Standard (email or dashboard) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26ebb69a40aef32ba4fc812e51be525d577adb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->