### PR TITLE
Clarify `.mintignore` link checking

### DIFF
--- a/organize/mintignore.mdx
+++ b/organize/mintignore.mdx
@@ -32,7 +32,8 @@ Excluded files:
 - Don't appear in your published documentation.
 - Aren't indexed for search.
 - Aren't accessible to visitors.
-- Do not trigger [broken link checks](/cli/commands#mint-broken-links). Links that point to ignored files break.
+- Don't have their outgoing links checked by [`mint broken-links`](/cli/commands#mint-broken-links).
+- Cause any links pointing to them from other pages to be flagged as broken, since they won't be published.
 
 ## Default ignored patterns
 

--- a/organize/mintignore.mdx
+++ b/organize/mintignore.mdx
@@ -33,7 +33,7 @@ Excluded files:
 - Aren't indexed for search.
 - Aren't accessible to visitors.
 - Don't have their outgoing links checked by [`mint broken-links`](/cli/commands#mint-broken-links).
-- Cause any links pointing to them from other pages to be flagged as broken, since they won't be published.
+- Cause any links pointing to them from other pages to appear as broken by `mint broken-links` checks.
 
 ## Default ignored patterns
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or product behavior impact.
> 
> **Overview**
> Updates the **Exclude files** docs so `.mintignore` link-checking behavior is spelled out in two bullets instead of one confusing line.
> 
> Ignored files **no longer** have their **outgoing** links validated by [`mint broken-links`](/cli/commands#mint-broken-links). Any **links from other pages to ignored files** are reported as broken by that command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172ce92ffa106b0fd711846d3f1cd1b33f3458d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->