### PR TITLE
editor docs clean up

### DIFF
--- a/editor/configurations.mdx
+++ b/editor/configurations.mdx
@@ -7,6 +7,8 @@ boost: 3
 
 Configure your site's branding, appearance, and features from the **Site configurations** panel in the web editor. Configuration changes sync in real time with other editors on the same branch, so your team always sees the latest settings.
 
+To open the panel, click the <Icon icon="sliders-horizontal" /> configurations icon in the editor toolbar.
+
 <Frame>
   <img
     src="/images/editor/configurations-light.png"

--- a/editor/index.mdx
+++ b/editor/index.mdx
@@ -47,8 +47,20 @@ keywords: ["editor", "visual", "collaborative", "web editor"]
   Reorder pages and manage site structure.
 </Card>
 
-<Card title="Configurations" icon="settings" horizontal href="/editor/configurations">
+<Card title="Live preview" icon="play" horizontal href="/editor/live-preview">
+  Preview your site in real time as you edit without waiting for a build.
+</Card>
+
+<Card title="Configurations" icon="sliders-horizontal" horizontal href="/editor/configurations">
   Configure your site's branding, colors, and features.
+</Card>
+
+<Card title="Settings" icon="settings" horizontal href="/editor/settings">
+  Configure AI instructions and publishing defaults for your deployment.
+</Card>
+
+<Card title="Git essentials" icon="git-merge" horizontal href="/editor/git-essentials">
+  Understand the Git concepts behind the editor: branches, commits, pull requests, and merges.
 </Card>
 
 <Card title="Keyboard shortcuts" icon="keyboard" horizontal href="/editor/keyboard-shortcuts">

--- a/editor/pages.mdx
+++ b/editor/pages.mdx
@@ -86,12 +86,6 @@ When editing a code block in visual mode, you can:
 - **Wrap**: Toggle line wrapping in the code block settings.
 - **Expandable**: Make the code block collapsible so readers can expand it on demand.
 
-## Review changes before publishing
-
-Open the publish menu and click any changed file to enter diff view. The editor highlights differences between your draft and the last published version. In visual mode you see a visual diff; in source mode you see a text diff.
-
-Click **Exit diff** or press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> (macOS) or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> (Windows) to return to editing.
-
 ## Manage pages
 
 - **Move**: Drag and drop pages to reorder them in navigation.

--- a/editor/tutorial.mdx
+++ b/editor/tutorial.mdx
@@ -39,7 +39,7 @@ This tutorial walks you through a complete content update using the editor. You'
 
   </Step>
   <Step title="Publish your branch">
-    When you're ready for review, publish your branch to create a pull request. A pull request is a proposal to merge your changes into the branch that builds your live site. Your changes only go live if the pull request is approved and merged.
+    When you're ready for review, create a pull request from your branch. A pull request is a proposal to merge your changes into the branch that builds your live site. Your changes only go live if the pull request is approved and merged.
 
     1. Click **Publish** in the toolbar to open the publish menu.
         <Frame>
@@ -47,8 +47,11 @@ This tutorial walks you through a complete content update using the editor. You'
           <img src="/images/editor/publish-menu-dark.png" alt="The publish menu opened in the editor toolbar." className="hidden dark:block" />
         </Frame>
     1. Optionally, click any changed file in the list to view and compare your edits against the published version.
-    1. Click **Save in branch** to commit your changes to the branch.
     1. Click **Create pull request**. Add a title and description, then click **Publish pull request**.
+
+    <Note>
+      You can also click **Save in branch** to commit your changes without opening a pull request yet. This is useful if you want to keep editing before requesting review.
+    </Note>
 
     After the pull request is created, a preview deployment builds automatically. The publish menu shows the preview URL, a temporary link where your changes render exactly as they would on your live site. Share this URL with your reviewers.
   </Step>

--- a/redirects.json
+++ b/redirects.json
@@ -440,10 +440,6 @@
       "destination": "/organize/settings"
     },
     {
-      "source": "/editor/git-essentials",
-      "destination": "/editor/branching-and-publishing"
-    },
-    {
       "source": "/editor/publish",
       "destination": "/editor/branching-and-publishing"
     },


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to editor pages and one redirect removal; no runtime or product behavior changes.
> 
> **Overview**
> **Editor overview** now surfaces **Live preview**, **Settings**, and **Git essentials** as separate cards, and the **Configurations** card uses the `sliders-horizontal` icon to match the toolbar.
> 
> **Configurations** adds a one-line instruction for opening **Site configurations** via that toolbar icon.
> 
> **Create and edit pages** drops the standalone “Review changes before publishing” section so diff/review guidance isn’t duplicated (diff remains under **Diff view** and the publish menu).
> 
> The **tutorial** publish step emphasizes **Create pull request** first and moves **Save in branch** into an optional note for committing without opening a PR yet.
> 
> **Redirects** removes the rule that sent `/editor/git-essentials` to branching-and-publishing, so **Git essentials** keeps its own URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc697437b1266da41036c04da3d9b08782e3597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->