### PR TITLE
Document pull request grouping in automations

### DIFF
--- a/automations/index.mdx
+++ b/automations/index.mdx
@@ -26,6 +26,14 @@ Automations support three trigger types.
 
 Each automation has exactly one trigger. You cannot combine trigger types in a single automation.
 
+## Pull request grouping
+
+Automations group related changes into a single pull request instead of opening a separate one for every change. When a later run produces more changes that belong with an open pull request, the agent appends them to that pull request rather than opening a duplicate. How grouping plays out depends on the automation. See [Predefined automations](/automations/reference) for each automation's behavior.
+
+<Note>
+  Draft changelog, Draft improvements from assistant conversations, Draft improvements from user feedback, and custom automations do not group or append. Each run opens its own pull request with the changes from that run.
+</Note>
+
 ## Usage limits
 
 Automation runs count toward your credit usage. The credits a single run consumes depend on the size of the task: how much content the agent reads, how many files it changes, and how long the run takes. Larger context repositories and broader prompts use more credits than narrowly scoped ones.

--- a/automations/reference.mdx
+++ b/automations/reference.mdx
@@ -56,6 +56,8 @@ Maintenance automations automate routine tasks to improve the quality and consis
 
 Running on a content update trigger maintains your content with minimal lag. Running on a schedule is generally more credit-efficient because the agent batches work across multiple changes in a single run. The tradeoff is a delay between when content changes and when the automation acts on it.
 
+Each maintenance automation keeps a single open pull request and appends new fixes to it as content changes, so routine maintenance accumulates in one pull request to review rather than many.
+
 Any enabled maintenance automations run on pull requests created by self-updating content automations. If the maintenance automation identifies required changes, the agent combines the work into a single pull request. For example, if you enable the **Translate content** automation, the agent adds translations to any pull requests opened by the **Update from code changes** automation.
 
 ### Translate content


### PR DESCRIPTION
## Summary
Adds a Pull request grouping section to the automations Overview explaining how related changes are grouped into one pull request and appended to open pull requests, with a note on which automations don't group (changelog, assistant, feedback, and custom).

Adds a tangible line to the Predefined automations reference noting that maintenance automations keep a single open pull request and append new fixes to it.