### PR TITLE
Revert "docs: clarify agent behavior on docs PR comments"

### DIFF
--- a/agent/use-cases.mdx
+++ b/agent/use-cases.mdx
@@ -36,18 +36,6 @@ Share a pull request link with the agent to address reviewer comments and code r
 
 For example: `@mintlify Address the review comments on this PR: [PR link]`.
 
-You can also mention `@mintlify` directly in a comment on an open documentation pull request. The agent checks out that pull request's branch and pushes new commits to it, rather than opening a separate pull request. This keeps all related changes and review history in a single pull request.
-
-When triggered from a pull request comment, the agent uses the pull request's diff, title, description, and existing review comments as context. You can use this flow to:
-
-- Apply suggestions from a specific reviewer (for example, `@mintlify Apply the changes @username requested in their review`).
-- Resolve outstanding review threads (for example, `@mintlify Address the unresolved comments on this PR`).
-- Iterate on the existing changes (for example, `@mintlify Also update the code samples to match the new parameter names`).
-
-After the agent finishes, it adds a comment to the pull request summarizing what it changed and links to the new commits.
-
-Comments on pull requests from forks are not supported because the agent cannot push to fork branches. For changes to fork pull requests, share the pull request link with the agent in your dashboard or Slack so it can open a follow-up pull request against your repository instead.
-
 ## Generate code examples
 
 Prompt the agent to generate code examples for features throughout your docs or on specific pages.

--- a/es/agent/use-cases.mdx
+++ b/es/agent/use-cases.mdx
@@ -46,18 +46,6 @@ Comparte con el agente el enlace de la solicitud de extracción para atender los
 
 Por ejemplo: `@mintlify Address the review comments on this PR: [PR link]`.
 
-También puedes mencionar a `@mintlify` directamente en un comentario en una solicitud de extracción de documentación abierta. El agente revisa la rama de esa solicitud de extracción y envía nuevos commits a esa misma rama, en lugar de abrir una solicitud de extracción separada. Esto mantiene todos los cambios y el historial de revisión relacionados en una sola solicitud de extracción.
-
-Cuando se activa desde un comentario en una solicitud de extracción, el agente usa como contexto el diff, el título, la descripción y los comentarios de revisión existentes de esa solicitud. Puedes usar este flujo para:
-
-- Aplicar las sugerencias de un revisor específico (por ejemplo, `@mintlify Apply the changes @username requested in their review`).
-- Resolver hilos de revisión pendientes (por ejemplo, `@mintlify Address the unresolved comments on this PR`).
-- Iterar sobre los cambios existentes (por ejemplo, `@mintlify Also update the code samples to match the new parameter names`).
-
-Cuando el agente termina, agrega un comentario en la solicitud de extracción que resume lo que cambió e incluye enlaces a los nuevos commits.
-
-No se admiten los comentarios en solicitudes de extracción desde forks porque el agente no puede enviar cambios a las ramas de un fork. Para realizar cambios en solicitudes de extracción desde forks, comparte el enlace de la solicitud con el agente desde otra superficie (como Slack o el panel) para que pueda abrir una solicitud de extracción de seguimiento en tu repositorio.
-
 <div id="generate-code-examples">
   ## Generar ejemplos de código
 </div>


### PR DESCRIPTION
Reverts mintlify/docs#6245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only revert with no runtime, API, or security impact.
> 
> **Overview**
> Reverts the documentation added in mintlify/docs#6245 that explained how the Mintlify agent behaves when you mention `@mintlify` on open documentation pull requests.
> 
> **Removes** from `agent/use-cases.mdx` and `es/agent/use-cases.mdx` the extra guidance under **Address pull request review feedback**: commenting on the PR (same-branch commits vs. a new PR), what context the agent uses (diff, title, description, review comments), example prompts for reviewers and unresolved threads, post-run summary comments, and the fork-PR limitation with the workaround via dashboard or Slack.
> 
> Those sections now only keep the short “share a PR link” flow and the example `@mintlify Address the review comments on this PR: [PR link]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e15e8cc61157e00d9d05f86a334aea26d545e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->