### PR TITLE
Update docs for auth config page redesign

### DIFF
--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -5,16 +5,16 @@ keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 ---
 
 <Info>
-  Authentication requires an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
-</Info>
+  Authenticated (Mintlify Auth) is available on all plans.
 
-<Warning>
-  Authentication is only available for sites hosted on a custom domain or Mintlify subdomain (for example, `docs.example.com` or `example.mintlify.dev`). Authentication is **not supported** when using a [custom basepath](/deploy/docs-subpath) (for example, `example.com/docs`).
-</Warning>
+  Password, OAuth, and JWT authentication require an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
+</Info>
 
 Authentication requires users to log in before accessing your content.
 
 You can configure full authentication for all pages or partial authentication where some pages are public and others are protected.
+
+Authentication is only available for sites hosted on a custom domain or Mintlify subdomain. For example, `docs.example.com` or `example.mintlify.app`. Authentication is **not supported** for sites with a [custom subpath](/deploy/docs-subpath). For example, `example.com/docs`.
 
 ## Configure authentication
 

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -5,7 +5,7 @@ keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 ---
 
 <Info>
-  Authenticated (Mintlify Auth) is available on all plans.
+  Authentication with Mintlify Auth is available on all plans.
 
   Password, OAuth, and JWT authentication require an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
 </Info>
@@ -35,9 +35,10 @@ Select the handshake method that you want to configure.
 <Steps>
   <Step title="Create a password.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Set site visibility to **Private**.
-    3. Select **Password**.
+    2. In the **Authentication method** section, set site visibility to **Private**.
+    3. Click **Password**.
     4. Enter a secure password.
+    5. Click **Save changes**.
 
     After you save, your site redeploys. When it finishes deploying, anyone who visits your site must enter the password to access your content.
   </Step>
@@ -52,18 +53,18 @@ You host your documentation at `docs.foo.com` and you need basic access control 
 
 **Create a strong password** in your dashboard. **Share credentials** with authorized users.
 </Tab>
-<Tab title="Authenticated">
-### Authenticated prerequisites
+<Tab title="Mintlify Auth">
+### Mintlify Auth prerequisites
 
 * Everyone who needs to access your documentation must be a member of your Mintlify organization.
 
-### Authenticated setup
+### Mintlify Auth setup
 
 <Steps>
   <Step title="Enable Mintlify authentication.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Set site visibility to **Private**.
-    3. Select **Authenticated**.
+    2. In the **Authentication method** section, set site visibility to **Private**.
+    3. Click **Authenticated**.
     4. Click **Save changes**.
 
     After you save, your site redeploys. When it finishes deploying, anyone who visits your site must log in to your Mintlify organization to access your content.
@@ -75,7 +76,7 @@ You host your documentation at `docs.foo.com` and you need basic access control 
   </Step>
 </Steps>
 
-### Authenticated example
+### Mintlify Auth example
 
 You host your documentation at `docs.foo.com` and your entire team has access to your dashboard. You want to restrict access to team members only.
 
@@ -94,9 +95,10 @@ You host your documentation at `docs.foo.com` and your entire team has access to
 <Steps>
   <Step title="Configure your OAuth settings.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Set site visibility to **Private**.
-    3. Select **Custom**, then select the **OAuth** tab.
-    4. Configure these fields:
+    2. In the **Authentication method** section, set site visibility to **Private**.
+    3. Click **Custom**
+    4. Click **OAuth**.
+    5. Configure these fields:
       * **Authorization URL**: Your OAuth endpoint.
       * **Client ID**: Your OAuth 2.0 client identifier.
       * **Client Secret**: Your OAuth 2.0 client secret.
@@ -169,12 +171,13 @@ You host your documentation at `docs.foo.com` and you have an existing OAuth ser
 <Steps>
   <Step title="Generate a private key.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Set site visibility to **Private**.
-    3. Select **Custom**, then select the **JWT** tab.
-    4. Enter the URL of your existing login flow.
-    5. Click **Save changes**.
-    6. Click **Generate new key**.
-    7. Store your key securely where it can be accessed by your backend.
+    2. In the **Authentication method** section, set site visibility to **Private**.
+    3. Click **Custom**
+    4. Click **JWT**.
+    5. Enter the URL of your existing login flow.
+    6. Click **Save changes**.
+    7. Click **Generate new key**.
+    8. Store your key securely where it can be accessed by your backend.
 
     After you generate a private key, your site redeploys. When it finishes deploying, anyone who visits your site must log in to your JWT authentication system to access your content.
   </Step>

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -1,13 +1,11 @@
 ---
 title: "Authentication setup"
-description: "Configure user authentication for your site with OAuth, JWT, password, or shared links to control access to pages and API references."
+description: "Configure user authentication for your site with OAuth, JWT, password, or Mintlify Auth to control access to pages and API references."
 keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
 ---
 
 <Info>
-  Mintlify dashboard authentication is available on all plans.
-
-  Password, OAuth, and JWT authentication require an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
+  Authentication requires an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
 </Info>
 
 <Warning>
@@ -37,10 +35,11 @@ Select the handshake method that you want to configure.
 <Steps>
   <Step title="Create a password.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Enable authentication.
-    3. In the **Password Protection** section, enter a secure password
+    2. Set site visibility to **Private**.
+    3. Select **Password**.
+    4. Enter a secure password.
 
-    After you enter a password, your site redeploys. When it finishes deploying, anyone who visits your site must enter the password to access your content.
+    After you save, your site redeploys. When it finishes deploying, anyone who visits your site must enter the password to access your content.
   </Step>
   <Step title="Distribute access.">
     Securely share the password and documentation URL with authorized users.
@@ -53,21 +52,21 @@ You host your documentation at `docs.foo.com` and you need basic access control 
 
 **Create a strong password** in your dashboard. **Share credentials** with authorized users.
 </Tab>
-<Tab title="Mintlify dashboard">
-### Mintlify dashboard prerequisites
+<Tab title="Authenticated">
+### Authenticated prerequisites
 
 * Everyone who needs to access your documentation must be a member of your Mintlify organization.
 
-### Mintlify dashboard setup
+### Authenticated setup
 
 <Steps>
-  <Step title="Enable Mintlify dashboard authentication.">
+  <Step title="Enable Mintlify authentication.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Enable authentication.
-    3. In the **Custom Authentication** section, click **Mintlify Auth**.
-    4. Click **Enable Mintlify Auth**.
+    2. Set site visibility to **Private**.
+    3. Select **Authenticated**.
+    4. Click **Save changes**.
 
-    After you enable Mintlify authentication, your site redeploys. When it finishes deploying, anyone who visits your site must log in to your Mintlify organization to access your content.
+    After you save, your site redeploys. When it finishes deploying, anyone who visits your site must log in to your Mintlify organization to access your content.
   </Step>
   <Step title="Add authorized users.">
     1. In your dashboard, go to [Members](https://app.mintlify.com/settings/organization/members).
@@ -76,7 +75,7 @@ You host your documentation at `docs.foo.com` and you need basic access control 
   </Step>
 </Steps>
 
-### Mintlify dashboard example
+### Authenticated example
 
 You host your documentation at `docs.foo.com` and your entire team has access to your dashboard. You want to restrict access to team members only.
 
@@ -95,8 +94,8 @@ You host your documentation at `docs.foo.com` and your entire team has access to
 <Steps>
   <Step title="Configure your OAuth settings.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Enable authentication.
-    3. In the **Custom Authentication** section, click **OAuth**.
+    2. Set site visibility to **Private**.
+    3. Select **Custom**, then select the **OAuth** tab.
     4. Configure these fields:
       * **Authorization URL**: Your OAuth endpoint.
       * **Client ID**: Your OAuth 2.0 client identifier.
@@ -170,8 +169,8 @@ You host your documentation at `docs.foo.com` and you have an existing OAuth ser
 <Steps>
   <Step title="Generate a private key.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
-    2. Enable authentication.
-    3. In the **Custom Authentication** section, click **JWT**.
+    2. Set site visibility to **Private**.
+    3. Select **Custom**, then select the **JWT** tab.
     4. Enter the URL of your existing login flow.
     5. Click **Save changes**.
     6. Click **Generate new key**.


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to dashboard click paths and naming; no product or security behavior changes in code.
> 
> **Overview**
> Updates **`deploy/authentication-setup.mdx`** so setup steps match the redesigned Authentication product page: site visibility is set to **Private** under **Authentication method**, then users pick **Password**, **Authenticated** (Mintlify Auth), or **Custom** → OAuth/JWT instead of a global “Enable authentication” plus **Password Protection** / **Custom Authentication** sections.
> 
> Renames the **Mintlify dashboard** tab and copy to **Mintlify Auth**, refreshes the meta description and plan callout wording, and moves custom-domain/subpath limits out of a `<Warning>` into inline prose (including `example.mintlify.app` instead of `mintlify.dev`). OAuth and JWT flows keep the same technical fields; only dashboard navigation and save/redeploy language change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4864de828d260f8e13202e3672c36de88241ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->