### PR TITLE
Document Mixpanel data residency region option

### DIFF
--- a/integrations/analytics/mixpanel.mdx
+++ b/integrations/analytics/mixpanel.mdx
@@ -10,12 +10,19 @@ Add the following to your `docs.json` file to send analytics to Mixpanel.
 ```json Analytics options in docs.json
 "integrations": {
     "mixpanel": {
-        "projectToken": "YOUR_MIXPANEL_PROJECT_TOKEN"
+        "projectToken": "YOUR_MIXPANEL_PROJECT_TOKEN",
+        "region": "eu"
     }
 }
 ```
 
 Replace `YOUR_MIXPANEL_PROJECT_TOKEN` with your Mixpanel project token. You can find this in your [Mixpanel project settings](https://mixpanel.com/settings/project).
+
+## Data residency
+
+Use the optional `region` property to send analytics to Mixpanel's regional servers for data residency compliance. Accepted values are `us` (default), `eu`, and `in`. If you omit `region`, analytics are sent to Mixpanel's US servers.
+
+Set `region` to match the data residency you configured for your Mixpanel project. A mismatch between this value and your project's region prevents events from being recorded.
 
 ## Tracked events
 


### PR DESCRIPTION
Documents the optional `region` property (`us` | `eu` | `in`) on the Mixpanel integration page, so customers can route analytics to the correct regional servers for data residency compliance. Adds the property to the `docs.json` example and a short "Data residency" section covering accepted values and the US default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Mixpanel integration page with no runtime or configuration code modified in this diff.
> 
> **Overview**
> Updates the Mixpanel integration docs so customers can configure **data residency** via an optional `region` field in `docs.json`.
> 
> The `docs.json` example now includes `"region": "eu"` alongside `projectToken`. A new **Data residency** section explains that `region` accepts `us` (default), `eu`, and `in`, routes events to the matching Mixpanel regional servers, and must align with the project's configured residency or events may not be recorded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ad91eea7e4b5826486e85c50c404eb592cd89d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->