### PR TITLE
chore: remove geist mono

### DIFF
--- a/fonts.css
+++ b/fonts.css
@@ -1,15 +1,13 @@
 /* Import the same fonts used on mintlify.com */
 
 /* Inter Variable Font - matching the main site */
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
-
-/* Geist Mono for code - matching the main site */
-@import url('https://fonts.googleapis.com/css2?family=Geist+Mono:ital,wght@0,100..900;1,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
 /* Override Mintlify's default font variables to match main site */
 :root {
-  --font-inter: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-geist-mono: 'Geist Mono', 'Menlo', 'Monaco', 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Courier New', monospace;
+  --font-inter: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
 }
 
 /* Apply fonts to body and common elements with explicit OpenType features */
@@ -20,21 +18,9 @@ body {
   font-variant-ligatures: normal;
 }
 
-/* Code elements */
-code,
-pre,
-.code,
-.hljs {
-  font-family: var(--font-geist-mono);
-}
-
 /* Ensure proper font weight and style support */
 .font-inter {
   font-family: var(--font-inter);
-}
-
-.font-mono {
-  font-family: var(--font-geist-mono);
 }
 
 /* Fix for true italics instead of synthetic slanted text */
@@ -46,7 +32,15 @@ i,
 }
 
 /* Explicitly disable stylistic alternates that might cause character differences */
-h1, h2, h3, h4, h5, h6, p, span, div {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+span,
+div {
   font-feature-settings: "ss01" 0, "ss02" 0, "ss03" 0; /* Disable common stylistic sets */
   font-variant-alternates: normal;
 }


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS with no logic or data changes; code blocks will use Mintlify’s default mono font instead of Geist Mono.
> 
> **Overview**
> **Stops loading and applying Geist Mono** in the docs’ custom stylesheet so monospace/code no longer mirrors mintlify.com’s mono stack.
> 
> The **Google Fonts import for Geist Mono**, the **`--font-geist-mono` variable**, rules that set **`code` / `pre` / `.code` / `.hljs`** to that font, and the **`.font-mono` helper** are all removed. **Inter** imports, body typography, italic handling, and stylistic-alternate overrides are unchanged aside from minor formatting (quote style, multiline selectors, file newline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d778f27cdb47ca84dbd53be4e434bb520bea8fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->