### PR TITLE
fix(text): correct LaTeX styling config key (styles.latex -> styling.latex)

### DIFF
--- a/create/text.mdx
+++ b/create/text.mdx
@@ -164,7 +164,7 @@ For longer quotes or multiple paragraphs:
 
 ## Mathematical expressions
 
-Mintlify supports LaTeX for rendering mathematical expressions and equations. You can override automated detection by configuring `styles.latex` in your `docs.json` [settings](/organize/settings-appearance#styling).
+Mintlify supports LaTeX for rendering mathematical expressions and equations. You can override automated detection by configuring `styling.latex` in your `docs.json` [settings](/organize/settings-appearance#styling).
 
 ### Inline math
 

--- a/es/create/text.mdx
+++ b/es/create/text.mdx
@@ -197,7 +197,7 @@ Para citas largas o de varios párrafos:
   ## Expresiones matemáticas
 </div>
 
-Ofrecemos compatibilidad con LaTeX para representar expresiones y ecuaciones matemáticas. Puedes anular la detección automática configurando `styles.latex` en `docs.json` en tus [ajustes](/es/organize/settings-appearance#styling).
+Ofrecemos compatibilidad con LaTeX para representar expresiones y ecuaciones matemáticas. Puedes anular la detección automática configurando `styling.latex` en `docs.json` en tus [ajustes](/es/organize/settings-appearance#styling).
 
 <div id="inline-math">
   ### Matemáticas en línea

--- a/fr/create/text.mdx
+++ b/fr/create/text.mdx
@@ -197,7 +197,7 @@ Pour des citations plus longues ou plusieurs paragraphes :
   ## Expressions mathématiques
 </div>
 
-Nous prenons en charge LaTeX pour le rendu des expressions et équations mathématiques. Vous pouvez remplacer la détection automatique en configurant `styles.latex` dans le fichier `docs.json` de vos [paramètres](/fr/organize/settings-appearance#styling).
+Nous prenons en charge LaTeX pour le rendu des expressions et équations mathématiques. Vous pouvez remplacer la détection automatique en configurant `styling.latex` dans le fichier `docs.json` de vos [paramètres](/fr/organize/settings-appearance#styling).
 
 <div id="inline-math">
   ### Mathématiques en ligne

--- a/zh/create/text.mdx
+++ b/zh/create/text.mdx
@@ -197,7 +197,7 @@ mint broken-links
   ## 数学表达式
 </div>
 
-我们支持使用 LaTeX 渲染数学表达式和公式。你可以在 `docs.json` 的 [settings](/zh/organize/settings-appearance#styling) 中配置 `styles.latex`，以覆盖自动检测。
+我们支持使用 LaTeX 渲染数学表达式和公式。你可以在 `docs.json` 的 [settings](/zh/organize/settings-appearance#styling) 中配置 `styling.latex`，以覆盖自动检测。
 
 <div id="inline-math">
   ### 行内数学


### PR DESCRIPTION
## What

The **Format text** page documents the LaTeX toggle as `styles.latex`, but the canonical config key is `styling.latex` (see `organize/settings-appearance.mdx`, where `styling.latex` is a boolean under `styling`; the settings reference lists it too). Readers who set `styles.latex` get no effect.

## Fix

Correct `styles.latex` → `styling.latex` on the Format text page and the es/fr/zh translations that carry the same typo. No other `styles.` references touched, and the `#styling` anchor link still resolves.

Closes #6107

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix; no runtime, config schema, or application code changes.
> 
> **Overview**
> Fixes a documentation typo on the **Format text** page: the LaTeX override is documented as **`styling.latex`** in `docs.json` (under the `styling` object), not `styles.latex`. Readers who followed the old key would see no effect.
> 
> The same one-line correction is applied in the **es**, **fr**, and **zh** translations of that page. Links to `#styling` on the appearance settings page are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fb7996b4be970d7ed7d327ccb56852b784c0f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->