### PR TITLE
Clarify redirect anchor restriction applies to sources only

### DIFF
--- a/create/redirects.mdx
+++ b/create/redirects.mdx
@@ -10,7 +10,7 @@ When you change the path of a file in your docs folder, it also changes the URL 
 ## Redirects
 
 <Note>
-  Redirects **cannot** include URL anchors like `path#anchor` or query parameters like `path?query=value`.
+  Redirect **sources** cannot include URL anchors like `path#anchor` or query parameters like `path?query=value`. Destinations may include anchors (e.g. `/destination/path#section`).
 </Note>
 
 Add the `redirects` field to the top level of your `docs.json` file to set up redirects.

--- a/fr/create/redirects.mdx
+++ b/fr/create/redirects.mdx
@@ -12,7 +12,7 @@ Lorsque vous modifiez le chemin d'un fichier dans votre dossier docs, l'URL de c
 </div>
 
 <Note>
-  Les redirections **ne peuvent pas** inclure des ancres d'URL telles que `path#anchor` ni des paramètres de requête tels que `path?query=value`.
+  Les **sources** de redirection ne peuvent pas inclure des ancres d'URL telles que `path#anchor` ni des paramètres de requête tels que `path?query=value`. Les destinations peuvent inclure des ancres (par exemple `/destination/path#section`).
 </Note>
 
 Ajoutez le champ `redirects` au niveau racine de votre fichier `docs.json` pour configurer des redirections.
@@ -44,7 +44,6 @@ Par défaut, les redirections sont permanentes (308). Pour utiliser une redirect
 ```
 
 Les codes 307 et 308 conservent tous deux la méthode HTTP de la requête d'origine (contrairement à 301 et 302), ce qui les rend adaptés à la redirection des requêtes POST.
-
 
 <div id="wildcard-redirects">
   ### Redirections avec joker

--- a/zh/create/redirects.mdx
+++ b/zh/create/redirects.mdx
@@ -12,7 +12,7 @@ boost: 3
 </div>
 
 <Note>
-  重定向**不能**包含像 `path#anchor` 这样的 URL 锚点，或像 `path?query=value` 这样的查询参数。
+  重定向的**来源路径**不能包含像 `path#anchor` 这样的 URL 锚点，或像 `path?query=value` 这样的查询参数。目标路径可以包含锚点（例如 `/destination/path#section`）。
 </Note>
 
 在 `docs.json` 文件的顶层添加 `redirects` 字段即可设置重定向。


### PR DESCRIPTION
Clarifies that the anchor/query parameter restriction in redirects only applies to source paths, not destinations. Destinations can include `#anchor` fragments. Updated English, French, and Chinese versions.

Prompted by customer report (T-36771).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and markdown fixes; no product or runtime behavior changes.
> 
> **Overview**
> Updates the redirects **Note** in English, French, and Chinese so it no longer reads as if anchors/query strings are forbidden on both sides of a rule. It now states that **sources** cannot use `#anchor` or `?query=`, while **destinations** may include anchors (with an example path).
> 
> Also fixes the broken `mint broken-links` code fence closing in all three locales (stray `-` before the closing fence). The French page drops one blank line before the wildcard section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb89abc0d0f75633ef2f27d9885a8d04f6bd09c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->