### PR TITLE
AX test — do not merge: add temporary redirect

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -478,5 +478,10 @@
     {
       "source": "/guides/use-workflows",
       "destination": "/guides/use-automations"
+    },
+    {
+      "source": "/ax-test-do-not-merge",
+      "destination": "/",
+      "permanent": false
     }
   ]


### PR DESCRIPTION
AX (agent-experience) test PR — DO NOT MERGE.

Adds a single temporary redirect `/ax-test-do-not-merge` -> `/` (non-permanent) to docs.json to validate the Admin MCP checkout -> update_config -> save flow. Trivially reversible via remove_redirect. Safe to close without merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test redirect with an explicit do-not-merge path; no auth, data, or production behavior changes beyond a harmless temporary route.
> 
> **Overview**
> Adds a **temporary, non-permanent** redirect in `redirects.json`: `/ax-test-do-not-merge` → `/` (`permanent: false`).
> 
> This is an **agent-experience (AX) test** to validate the Admin MCP checkout → update_config → save flow; it is **not intended to merge** and can be removed with `remove_redirect`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b861885594605fc88ca7fce36db6907f08563f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->