### PR TITLE
Document sourceRef navigation for multi-repo

### DIFF
--- a/deploy/multi-repo.mdx
+++ b/deploy/multi-repo.mdx
@@ -154,7 +154,17 @@ Nested `navigation.products` configurations are not supported inside individual 
 
 ## Reference navigation from another source
 
-Use `sourceRef` when you want to place another repository's navigation at a specific location in the base source's `docs.json`, instead of letting Mintlify add the repository as a separate top-level product section.
+Use `sourceRef` to place another repository's navigation at a specific location in the base source's `docs.json`. If you don't use `sourceRef`, Mintlify adds each repository as a separate top-level product section.
+
+### Requirements
+
+- The referenced repository must be configured as a source in the same multi-repository deployment.
+- `sourceRef` values must use `owner/repo` format. Mount paths and repository names by themselves are not supported.
+- The referenced source must define a similar navigation pattern as the main source. For example, a `sourceRef` inside `anchors` requires the referenced source to define `navigation.anchors`.
+- `sourceRef` entries cannot form a cycle. A source cannot reference itself, and two sources cannot reference each other.
+- `sourceRef` must appear inside a navigation array. It is not valid at the top level of `navigation`.
+
+### Usage
 
 Add a `sourceRef` entry to a navigation array in the base source's `docs.json`. The value must be the repository's `owner/repo` identifier.
 
@@ -162,7 +172,9 @@ Add a `sourceRef` entry to a navigation array in the base source's `docs.json`. 
 { "sourceRef": "acme/api-docs" }
 ```
 
-For example, you can combine anchors from multiple repositories into one anchor navigation:
+`sourceRef` is supported inside `anchors`, `tabs`, `groups`, `pages`, `products`, and arrays under `navigation.global`.
+
+For example, to combine anchors from multiple repositories into a single anchor navigation:
 
 ```json
 {
@@ -181,16 +193,6 @@ For example, you can combine anchors from multiple repositories into one anchor 
 ```
 
 If `acme/api-docs` defines its own `navigation.anchors`, Mintlify replaces the `sourceRef` entry with those anchors and prefixes their paths with the referenced source's URL path.
-
-`sourceRef` is supported inside navigation arrays, including `anchors`, `tabs`, `groups`, `pages`, `products`, and arrays under `navigation.global`.
-
-### Requirements
-
-- `sourceRef` values must use `owner/repo` format. Mount paths and repository names by themselves are not supported.
-- The referenced repository must be configured as a source in the same multi-repository deployment.
-- The referenced source must define a navigation array under the same key as the parent array. For example, a `sourceRef` inside `anchors` requires the referenced source to define `navigation.anchors`.
-- `sourceRef` entries cannot form a cycle. A source cannot reference itself, and two sources cannot reference each other.
-- `sourceRef` must appear inside a navigation array. It is not valid at the top level of `navigation`.
 
 ## Removing a repository source
 

--- a/deploy/multi-repo.mdx
+++ b/deploy/multi-repo.mdx
@@ -152,6 +152,46 @@ Keep each source's navigation scoped to that repository. For example, pages in t
 
 Nested `navigation.products` configurations are not supported inside individual source repositories.
 
+## Reference navigation from another source
+
+Use `sourceRef` when you want to place another repository's navigation at a specific location in the base source's `docs.json`, instead of letting Mintlify add the repository as a separate top-level product section.
+
+Add a `sourceRef` entry to a navigation array in the base source's `docs.json`. The value must be the repository's `owner/repo` identifier.
+
+```json
+{ "sourceRef": "acme/api-docs" }
+```
+
+For example, you can combine anchors from multiple repositories into one anchor navigation:
+
+```json
+{
+  "navigation": {
+    "anchors": [
+      {
+        "anchor": "Guides",
+        "pages": ["quickstart"]
+      },
+      {
+        "sourceRef": "acme/api-docs"
+      }
+    ]
+  }
+}
+```
+
+If `acme/api-docs` defines its own `navigation.anchors`, Mintlify replaces the `sourceRef` entry with those anchors and prefixes their paths with the referenced source's URL path.
+
+`sourceRef` is supported inside navigation arrays, including `anchors`, `tabs`, `groups`, `pages`, `products`, and arrays under `navigation.global`.
+
+### Requirements
+
+- `sourceRef` values must use `owner/repo` format. Mount paths and repository names by themselves are not supported.
+- The referenced repository must be configured as a source in the same multi-repository deployment.
+- The referenced source must define a navigation array under the same key as the parent array. For example, a `sourceRef` inside `anchors` requires the referenced source to define `navigation.anchors`.
+- `sourceRef` entries cannot form a cycle. A source cannot reference itself, and two sources cannot reference each other.
+- `sourceRef` must appear inside a navigation array. It is not valid at the top level of `navigation`.
+
 ## Removing a repository source
 
 You can remove a repository source from the [Git settings page](https://app.mintlify.com/settings/deployment/git-settings) in your dashboard. When only one repository source remains, Mintlify removes the source URL path and treats the remaining repository as the root source for the deployment.


### PR DESCRIPTION
## Summary
- document sourceRef navigation for multi-repository deployments
- clarify that sourceRef values must use owner/repo format
- add an anchor navigation example for inlining another source's navigation

## Testing
- docs-only change; not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to multi-repo deployment guidance; no runtime or config code changes.
> 
> **Overview**
> Adds a **Reference navigation from another source** section to `deploy/multi-repo.mdx` describing how **`sourceRef`** inlines another repo’s navigation into the base source’s `docs.json` instead of only showing each source as a separate top-level product.
> 
> Documents **requirements** (`owner/repo` format, matching navigation shapes, no cycles, must live inside a navigation array) and **usage**, including where `sourceRef` is allowed and an **anchors** example that merges another source’s anchors with URL path prefixing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 031c03decd0ac1eda1c0268dba60349613f20423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->