### PR TITLE
Assistant support/sales form fields

### DIFF
--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -24,7 +24,7 @@ Enter one or both of the following addresses:
 - **Support**: For questions the assistant can't resolve from your documentation.
 - **Sales**: For questions about pricing, plans, or purchasing.
 
-When deflection is enabled and the assistant detects a matching question, an in-chat contact form appears with the user's message ready to send to the appropriate team. If the user is signed in, their email is pre-filled. Deflection turns on as soon as at least one address is saved.
+When deflection is enabled and the assistant detects a matching question, an in-chat contact form appears. The form asks for the user's first name, last name, company, company email, and message, then emails the submission to the appropriate team, which can respond directly to the user's email. If the user is signed in, their name, company, and email are pre-filled. Deflection turns on as soon as at least one address is saved.
 
 <Frame>
   <img src="/images/assistant/deflection-light.png" alt="The assistant deflection panel in the dashboard. Assistant deflection is toggled on and support@mintlify.com is set as the deflection email." className="block dark:hidden" />

--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -24,12 +24,7 @@ Enter one or both of the following addresses:
 - **Support**: For questions the assistant can't resolve from your documentation.
 - **Sales**: For questions about pricing, plans, or purchasing.
 
-When deflection is enabled and the assistant detects a matching question, an in-chat contact form appears. The form asks for the user's first name, last name, company, company email, and message, then emails the submission to the appropriate team, which can respond directly to the user's email. If the user is signed in, their name, company, and email are pre-filled. Deflection turns on as soon as at least one address is saved.
-
-<Frame>
-  <img src="/images/assistant/deflection-light.png" alt="The assistant deflection panel in the dashboard. Assistant deflection is toggled on and support@mintlify.com is set as the deflection email." className="block dark:hidden" />
-  <img src="/images/assistant/deflection-dark.png" alt="The assistant deflection panel in the dashboard. Assistant deflection is toggled on and support@mintlify.com is set as the deflection email." className="hidden dark:block" />
-</Frame>
+When you enable deflection and the assistant detects a matching question, an in-chat contact form appears. The form asks for the user's first name, last name, company, company email, and a message. Mintlify emails the submission to the appropriate team, which can respond directly to the user's email.
 
 ## Search domains
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to assistant deflection behavior; no application or security impact.
> 
> **Overview**
> Updates **Set deflection emails** in `assistant/configure.mdx` so it matches the current in-chat deflection flow.
> 
> The section now states that the contact form collects **first name, last name, company, company email, and message**, and that Mintlify emails submissions to the configured support or sales address so teams can reply directly. It no longer describes a pre-filled user message, signed-in email pre-fill, or activation when an address is saved.
> 
> The deflection dashboard screenshot `<Frame>` is removed from this section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea054edd01459ff6d23f583db0eb14d8ded4fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->