### PR TITLE
chore: style edits for assistant skills

### DIFF
--- a/assistant/customize.mdx
+++ b/assistant/customize.mdx
@@ -14,8 +14,6 @@ Add a `.mintlify/Assistant.md` file at the root of your documentation project to
 
 Instructions in an `Assistant.md` file add to the assistant's system prompt. They do not replace or override the assistant's default instructions.
 
-Use [assistant skills](/assistant/skills) for topic-specific guidance that the assistant loads only when a question matches, instead of adding it to `Assistant.md`.
-
 To remove the custom instructions, remove the `Assistant.md` file.
 
 Use `Assistant.md` to:
@@ -26,6 +24,10 @@ Use `Assistant.md` to:
 - Specify terminology preferences
 - Restrict or scope the assistant's focus areas
 - Provide version-specific guidance
+
+<Tip>
+  Use assistant [skills](/assistant/skills) for topic-specific guidance that the assistant loads only when a user asks a relevant question.
+</Tip>
 
 ## Example `Assistant.md` file
 

--- a/assistant/customize.mdx
+++ b/assistant/customize.mdx
@@ -14,7 +14,7 @@ Add a `.mintlify/Assistant.md` file at the root of your documentation project to
 
 Instructions in an `Assistant.md` file add to the assistant's system prompt. They do not replace or override the assistant's default instructions.
 
-For deep, topic-specific guidance the assistant should pull in only when a question matches, use [assistant skills](/assistant/skills) instead of adding to `Assistant.md`.
+Use [assistant skills](/assistant/skills) for topic-specific guidance that the assistant loads only when a question matches, instead of adding it to `Assistant.md`.
 
 To remove the custom instructions, remove the `Assistant.md` file.
 

--- a/assistant/skills.mdx
+++ b/assistant/skills.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Add assistant skills"
-description: "Add Markdown guides that the assistant loads on demand to answer specific questions with your team's guidance."
+description: "Tune the assistant's responses with topic-specific Markdown guides that the assistant loads on demand to answer specific questions with your team's guidance."
 keywords: ["assistant", "skills", "loadSkill", "guides", "system prompt"]
 ---
 
-Skills are Markdown guides that give the assistant your team's guidance on specific topics. The assistant sees a catalog of your skills and loads a guide only when a user's question matches it, so you can provide curated answers for specific topics without adding context to every response.
+Skills are Markdown files that direct the assistant's responses on specific topics. The assistant has access to any skills you add to your project in the `.mintlify/assistant/skills/` directory. It loads a skill only when a user's question matches it, so you can provide curated answers for specific topics without adding context to every response.
 
 Use skills to:
 
@@ -14,9 +14,9 @@ Use skills to:
 
 ## Add a skill
 
-Add a `skill.md` file inside a directory named for the skill's slug under `.mintlify/assistant/skills/`:
+Add a `skill.md` file inside a directory named for the skill under `.mintlify/assistant/skills/`:
 
-```text
+```text Example directory structure
 .mintlify/
 └── assistant/
     └── skills/
@@ -26,9 +26,9 @@ Add a `skill.md` file inside a directory named for the skill's slug under `.mint
             └── skill.md
 ```
 
-Each `skill.md` file needs YAML frontmatter with a `name` and `description`, followed by the guide content:
+Each `skill.md` file needs YAML frontmatter with a `name` and `description`, followed by the skill instructions:
 
-```markdown .mintlify/assistant/skills/migrate-to-v3/skill.md
+```markdown .mintlify/assistant/skills/migrate-to-v3/skill.md example skill file
 ---
 name: Migrate to SDK v3
 description: Step-by-step guide for upgrading from SDK v2 to v3, including breaking changes, code mods, and rollout checklist.
@@ -43,28 +43,30 @@ Follow these steps to upgrade an existing v2 integration to v3.
 ...
 ```
 
-The assistant uses the `name` and `description` to decide whether to load a skill, so write descriptions that state when the guide applies. Keep the body focused: the assistant truncates skill content at approximately 6,000 tokens.
+The assistant uses the `name` and `description` to decide when to load a skill, so write descriptions that state when the skill applies. Keep the instructions concise. The assistant truncates skill content at approximately 6,000 tokens.
 
 <Note>
-  After you add or change a `skill.md` file, publish your docs to make the skill available to the assistant.
+  After you add or change a `skill.md` file, redeploy your site to make the skill available to the assistant.
 </Note>
 
 ## How the assistant uses skills
 
-The assistant lists every available skill by name, slug, and description in its system prompt. When a user's question matches a skill, the assistant loads the guide and treats it as team-authored guidance that takes precedence over general search results. The assistant can load up to three skills per response.
+The assistant lists every available skill by name, slug, and description in its system prompt. When a user's question matches a skill description, the assistant loads the skill and treats it as high priority guidance that takes precedence over general search results.
 
-On follow-up messages, the assistant removes previously loaded skill content from the conversation history to keep context small. It reloads a skill if it needs it again.
+The assistant can load up to three skills per response.
+
+On follow-up messages, the assistant removes previously loaded skill content from the conversation history to preserve the context window. It reloads a skill if it needs it again.
 
 Skills work alongside [custom assistant instructions](/assistant/customize) in `.mintlify/Assistant.md`. Use `Assistant.md` for tone, persona, and rules that apply to every response. Use skills for topic-specific guidance that the assistant should load only when relevant.
 
 ## Write effective skills
 
-- Give each skill a distinct `description`. Overlapping descriptions make it harder for the assistant to pick the right skill.
-- Use a unique, URL-safe slug for each directory name. Slugs must contain only lowercase letters, numbers, and hyphens. Publishing skips duplicate slugs and logs a warning.
-- Structure guides with clear headings and numbered steps.
-- Keep guides self-contained. The assistant loads one skill at a time, so a guide should not depend on another skill to make sense.
-- Prefer prose and code samples over screenshots. The assistant only reads the Markdown body.
+- Give each skill a distinct `description`. Overlapping descriptions make it harder for the assistant to load the right skill.
+- Use a unique, URL-safe slug for each directory name. Slugs must contain only lowercase letters, numbers, and hyphens. You cannot publish skills with duplicate slugs.
+- Structure skills with clear headings and numbered steps.
+- Keep skills self-contained. The assistant loads one skill at a time, so a skill should not depend on another skill.
+- Use prose and code samples. Do not use screenshots.
 
 ## Disable skills
 
-Skills are enabled by default when at least one `skill.md` file is present. To remove all skills, delete the `.mintlify/assistant/skills/` directory and publish your docs. To turn off the skills feature for your deployment, contact [support](mailto:support@mintlify.com).
+Skills are enabled by default when at least one `skill.md` file is present. To remove all skills, delete the `.mintlify/assistant/skills/` directory and redeploy your site. To turn off the skills feature for your deployment, contact [support](mailto:support@mintlify.com).

--- a/assistant/skills.mdx
+++ b/assistant/skills.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Add assistant skills"
-description: "Author expert Markdown guides that the AI assistant loads on demand to answer questions with your team's hand-written, opinionated guidance."
+description: "Add Markdown guides that the assistant loads on demand to answer specific questions with your team's guidance."
 keywords: ["assistant", "skills", "loadSkill", "guides", "system prompt"]
 ---
 
-Skills are team-authored Markdown guides that live alongside your documentation. The assistant sees a catalog of your skills in its system prompt and loads the full guide only when a user's question clearly matches one, so you can supply expert, curated answers for the questions that matter most without bloating every response.
+Skills are Markdown guides that give the assistant your team's guidance on specific topics. The assistant sees a catalog of your skills and loads a guide only when a user's question matches it, so you can provide curated answers for specific topics without adding context to every response.
 
-Use skills when:
+Use skills to:
 
-- A topic needs a specific, opinionated answer that generic search results don't produce reliably.
-- You want to encode internal playbooks, troubleshooting flows, or migration guides that aren't structured as regular documentation pages.
-- You want to shape how the assistant walks users through multi-step or nuanced procedures.
+- Provide specific answers for topics where search results alone are unreliable.
+- Encode playbooks, troubleshooting flows, or migration guides that aren't structured as documentation pages.
+- Guide users through multi-step or nuanced procedures.
 
 ## Add a skill
 
-Create a skill by adding a `skill.md` file inside a slug-named directory under `.mintlify/assistant/skills/`:
+Add a `skill.md` file inside a directory named for the skill's slug under `.mintlify/assistant/skills/`:
 
-```
+```text
 .mintlify/
 └── assistant/
     └── skills/
@@ -26,7 +26,7 @@ Create a skill by adding a `skill.md` file inside a slug-named directory under `
             └── skill.md
 ```
 
-Each `skill.md` file needs YAML frontmatter with a `name` and `description`, followed by the full guide content:
+Each `skill.md` file needs YAML frontmatter with a `name` and `description`, followed by the guide content:
 
 ```markdown .mintlify/assistant/skills/migrate-to-v3/skill.md
 ---
@@ -43,30 +43,28 @@ Follow these steps to upgrade an existing v2 integration to v3.
 ...
 ```
 
-The assistant uses `name` and `description` to decide whether to load the skill, so write descriptions that clearly state when the guide applies. Keep the body focused: skill content is truncated at roughly 6,000 tokens when loaded.
+The assistant uses the `name` and `description` to decide whether to load a skill, so write descriptions that state when the guide applies. Keep the body focused: the assistant truncates skill content at approximately 6,000 tokens.
 
 <Note>
-  Skills are discovered on your next documentation update. After you add or change a `skill.md` file, publish your docs to make the skill available to the assistant.
+  After you add or change a `skill.md` file, publish your docs to make the skill available to the assistant.
 </Note>
 
 ## How the assistant uses skills
 
-- The assistant lists every available skill (name, slug, and description) in its system prompt.
-- When a user's question matches a skill, the assistant calls the `loadSkill` tool with the skill's slug and uses the returned guide as authoritative context.
-- The assistant can load up to three skills per response.
-- Loaded skill content is treated as team-authored guidance and takes precedence over general search results.
-- On follow-up turns, previously loaded skill content is removed from the conversation history to keep the context small; the assistant reloads a skill if it needs it again.
+The assistant lists every available skill by name, slug, and description in its system prompt. When a user's question matches a skill, the assistant loads the guide and treats it as team-authored guidance that takes precedence over general search results. The assistant can load up to three skills per response.
 
-Skills work alongside [custom assistant instructions](/assistant/customize) in `.mintlify/Assistant.md`. Use `Assistant.md` for global tone, persona, and rules; use skills for deep, topic-specific guidance the assistant should pull in only when relevant.
+On follow-up messages, the assistant removes previously loaded skill content from the conversation history to keep context small. It reloads a skill if it needs it again.
 
-## Skill authoring tips
+Skills work alongside [custom assistant instructions](/assistant/customize) in `.mintlify/Assistant.md`. Use `Assistant.md` for tone, persona, and rules that apply to every response. Use skills for topic-specific guidance that the assistant should load only when relevant.
 
-- Give each skill a distinct, unambiguous `description`. Overlapping descriptions make it harder for the assistant to pick the right skill.
-- Use a unique, URL-safe slug for each directory name. Slugs must contain only lowercase letters, numbers, and hyphens. Duplicate slugs are skipped with a warning during publishing.
-- Structure guides with clear headings and numbered steps. Assistants follow procedural content more reliably when it's explicit.
-- Keep guides self-contained. The assistant loads one skill at a time, so it should not require another skill to make sense.
+## Write effective skills
+
+- Give each skill a distinct `description`. Overlapping descriptions make it harder for the assistant to pick the right skill.
+- Use a unique, URL-safe slug for each directory name. Slugs must contain only lowercase letters, numbers, and hyphens. Publishing skips duplicate slugs and logs a warning.
+- Structure guides with clear headings and numbered steps.
+- Keep guides self-contained. The assistant loads one skill at a time, so a guide should not depend on another skill to make sense.
 - Prefer prose and code samples over screenshots. The assistant only reads the Markdown body.
 
 ## Disable skills
 
-Skills are enabled by default when at least one `skill.md` file is present. To turn skills off entirely for your deployment, contact [support](mailto:support@mintlify.com) to disable the assistant skills feature. Removing the `.mintlify/assistant/skills/` directory and republishing also clears the catalog.
+Skills are enabled by default when at least one `skill.md` file is present. To remove all skills, delete the `.mintlify/assistant/skills/` directory and publish your docs. To turn off the skills feature for your deployment, contact [support](mailto:support@mintlify.com).


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording and layout changes with no runtime or product behavior changes.
> 
> **Overview**
> **`assistant/customize.mdx`** moves the pointer to [skills](/assistant/skills) out of inline prose into a **Tip** component, framed as topic-specific guidance loaded only when a question matches.
> 
> **`assistant/skills.mdx`** is a broader editorial pass: refreshed frontmatter description, tighter intro and “use skills” bullets, clearer file-structure and `skill.md` examples, and wording that says **redeploy** instead of “publish your docs” / “discovered on your next documentation update.” The **How the assistant uses skills** section is rewritten as short paragraphs (no bullet list) and no longer names the `loadSkill` tool explicitly. **Skill authoring tips** is renamed **Write effective skills** with simplified bullets. **Disable skills** now documents deleting `.mintlify/assistant/skills/` and redeploying before contacting support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c87ec74111263142981d4119548842dfad59fef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->