### PR TITLE
Rename `Mintlify auth` to `private`

### DIFF
--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Authentication setup"
-description: "Configure user authentication for your site with OAuth, JWT, password, or Mintlify Auth to control access to pages and API references."
-keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password']
+description: "Configure user authentication for your site to control access to pages and API references. Make pages private to your Mintlify organization, or use password, OAuth, or JWT authentication."
+keywords: ['authentication', 'auth', 'OAuth', 'JWT', 'password', 'private']
 ---
 
 <Info>
-  Authentication with Mintlify Auth is available on all plans.
+  Private authentication for your Mintlify organization is available on all plans.
 
-  Password authentication is available on the [Pro plan and above](https://mintlify.com/pricing?ref=authentication).
+  Password authentication requires a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=authentication).
 
   OAuth and JWT authentication require an [Enterprise plan](https://mintlify.com/pricing?ref=authentication).
 </Info>
@@ -19,8 +19,6 @@ You can configure full authentication for all pages or partial authentication wh
 Authentication is only available for sites hosted on a custom domain or Mintlify subdomain. For example, `docs.example.com` or `example.mintlify.site`. Authentication is **not supported** for sites with a [custom subpath](/deploy/docs-subpath). For example, `example.com/docs`.
 
 ## Configure authentication
-
-Select the handshake method that you want to configure.
 
 <Tabs>
 <Tab title="Password">
@@ -55,15 +53,15 @@ You host your documentation at `docs.foo.com` and you need basic access control 
 
 **Create a strong password** in your dashboard. **Share credentials** with authorized users.
 </Tab>
-<Tab title="Mintlify Auth">
-### Mintlify Auth prerequisites
+<Tab title="Private authentication">
+### Private authentication prerequisites
 
-* Everyone who needs to access your documentation must be a member of your Mintlify organization.
+* Everyone who needs to access your site must be a member of your Mintlify organization.
 
-### Mintlify Auth setup
+### Private authentication setup
 
 <Steps>
-  <Step title="Enable Mintlify authentication.">
+  <Step title="Enable private authentication.">
     1. In your dashboard, go to [Authentication](https://app.mintlify.com/products/authentication).
     2. In the **Authentication method** section, set site visibility to **Private**.
     3. Click **Authenticated**.
@@ -78,11 +76,11 @@ You host your documentation at `docs.foo.com` and you need basic access control 
   </Step>
 </Steps>
 
-### Mintlify Auth example
+### Private example
 
 You host your documentation at `docs.foo.com` and your entire team has access to your dashboard. You want to restrict access to team members only.
 
-**Enable Mintlify authentication** in your dashboard settings.
+**Enable private authentication** in your dashboard settings.
 
 **Verify team access** by checking that all team members are active in your organization.
 </Tab>


### PR DESCRIPTION
## Documentation changes

Aligns docs with UI redesign

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only terminology and copy updates with no product or code behavior changes.
> 
> **Overview**
> Renames the **Mintlify Auth** authentication option to **Private authentication** across `authentication-setup.mdx` so terminology matches the UI redesign.
> 
> Updates frontmatter (description, `private` keyword), plan callouts (private auth on all plans; password on Pro or Enterprise), and the auth tab plus all related headings, steps, and examples. Removes the intro line about choosing a handshake method before the tabs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4908b1953036db77222725b93dd3c0979dad7a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->