### PR TITLE
Update gated product info for pro plan

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -6,6 +6,10 @@ keywords: ["automation", "automate", "AI", "autoupdate", "maintenance"]
 
 import SkillMcpPrompt from "/snippets/skill-mcp-prompt.mdx";
 
+<Info>
+  The agent is available on the [Pro plan and above](https://mintlify.com/pricing?ref=agent). Every Pro plan includes 10,000 credits per month shared across the assistant, agent, and automations. See [Credits](/credits) for more information about credit tiers and options.
+</Info>
+
 The agent is an AI tool that creates pull requests with proposed changes to your documentation based on your prompts. When you send a request, the agent:
 
 - **Researches**: Searches and reads your existing documentation, any connected repositories, relevant context, and the web.

--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -7,7 +7,7 @@ keywords: ["automation", "automate", "AI", "autoupdate", "maintenance"]
 import SkillMcpPrompt from "/snippets/skill-mcp-prompt.mdx";
 
 <Info>
-  The agent is available on the [Pro plan and above](https://mintlify.com/pricing?ref=agent). Every Pro plan includes 10,000 credits per month shared across the assistant, agent, and automations. See [Credits](/credits) for more information about credit tiers and options.
+  The agent requires a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=agent).
 </Info>
 
 The agent is an AI tool that creates pull requests with proposed changes to your documentation based on your prompts. When you send a request, the agent:

--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -5,6 +5,10 @@ keywords: ["REST API", "endpoints", "API keys"]
 boost: 3
 ---
 
+<Info>
+  The REST API is available on the [Pro plan and above](https://mintlify.com/pricing?ref=api). [Static export](/api/static-export/overview) endpoints require an Enterprise plan.
+</Info>
+
 The Mintlify REST (Representational State Transfer) API enables you to programmatically interact with your documentation, trigger updates, embed AI-powered chat experiences, and export analytics data.
 
 ## Endpoints

--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -6,7 +6,7 @@ boost: 3
 ---
 
 <Info>
-  The REST API is available on the [Pro plan and above](https://mintlify.com/pricing?ref=api). [Static export](/api/static-export/overview) endpoints require an Enterprise plan.
+  The REST API requires a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=api).
 </Info>
 
 The Mintlify REST (Representational State Transfer) API enables you to programmatically interact with your documentation, trigger updates, embed AI-powered chat experiences, and export analytics data.

--- a/automations/index.mdx
+++ b/automations/index.mdx
@@ -6,6 +6,10 @@ keywords: ["automation", "automate", "cron", "agent", "automations"]
 boost: 5
 ---
 
+<Info>
+  Automations are available on the [Pro plan and above](https://mintlify.com/pricing?ref=automations). Every Pro plan includes 10,000 credits per month shared across the assistant, agent, and automations. See [Credits](/credits) for more information about credit tiers and options.
+</Info>
+
 Automations run the agent automatically on a schedule or in response to changes in a repository. Each automation defines a prompt for the agent and a trigger for when to run it. Automations support both GitHub and GitLab repositories with the same triggers, predefined automations, and update modes. Throughout this guide, "pull request" also refers to GitLab merge requests unless noted otherwise.
 
 When an automation runs, the agent reads your project content and any connected repositories, then follows the prompt to make updates.

--- a/automations/index.mdx
+++ b/automations/index.mdx
@@ -7,7 +7,7 @@ boost: 5
 ---
 
 <Info>
-  Automations are available on the [Pro plan and above](https://mintlify.com/pricing?ref=automations). Every Pro plan includes 10,000 credits per month shared across the assistant, agent, and automations. See [Credits](/credits) for more information about credit tiers and options.
+  Automations require a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=automations).
 </Info>
 
 Automations run the agent automatically on a schedule or in response to changes in a repository. Each automation defines a prompt for the agent and a trigger for when to run it. Automations support both GitHub and GitLab repositories with the same triggers, predefined automations, and update modes. Throughout this guide, "pull request" also refers to GitLab merge requests unless noted otherwise.

--- a/deploy/export.mdx
+++ b/deploy/export.mdx
@@ -4,6 +4,10 @@ description: "Export your documentation site as a self-contained zip archive for
 keywords: ["export", "offline", "zip", "static site", "distribution", "mint export"]
 ---
 
+<Info>
+  Offline exports require an [Enterprise plan](https://mintlify.com/pricing?ref=offline-export).
+</Info>
+
 Use `mint export` to package your entire documentation site into a self-contained zip archive. Recipients can unzip and view the docs in their browser without an internet connection, a Mintlify account, or any build tools—they only need [Node.js](https://nodejs.org) installed.
 
 This is useful when you need to distribute documentation to users who can't access your live site, such as for on-premise customers, air-gapped environments, or internal compliance reviews.

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -5,7 +5,7 @@ keywords: ["preview URLs", "pull request previews", "branch previews", "staging 
 ---
 
 <Info>
-  Preview deployments are available on the [Pro plan and above](https://mintlify.com/pricing?ref=preview-deployments).
+  Preview deployments require a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=preview-deployments).
 </Info>
 
 Preview deployments let you see how changes to your docs look before merging to production. Each preview creates a shareable URL that updates automatically as you push new changes. 
@@ -87,10 +87,6 @@ Restrict preview access to authenticated members of your Mintlify organization.
   </Frame>
 
 ### Password-protect an individual preview
-
-<Info>
-  Password-protected previews are available on [Enterprise plans](https://mintlify.com/pricing?ref=preview-deployments).
-</Info>
 
 Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when creating a manual preview and is not shown when organization authentication is already enabled for your deployment.
 

--- a/optimize/analytics.mdx
+++ b/optimize/analytics.mdx
@@ -6,7 +6,7 @@ boost: 3
 ---
 
 <Info>
-  Analytics are available on the [Pro plan and above](https://mintlify.com/pricing?ref=analytics).
+  Analytics require a [Pro or Enterprise plan](https://mintlify.com/pricing?ref=analytics).
 </Info>
 
 The [analytics](https://app.mintlify.com/products/analytics/v2/) page in your dashboard shows data about visitors to your docs, how they interact with the assistant, what they search for, and their feedback. Use this information to identify which pages are most valuable to your users and track trends over time.

--- a/optimize/analytics.mdx
+++ b/optimize/analytics.mdx
@@ -5,6 +5,10 @@ keywords: ["analytics","metrics","page views","traffic","trends","insights"]
 boost: 3
 ---
 
+<Info>
+  Analytics are available on the [Pro plan and above](https://mintlify.com/pricing?ref=analytics).
+</Info>
+
 The [analytics](https://app.mintlify.com/products/analytics/v2/) page in your dashboard shows data about visitors to your docs, how they interact with the assistant, what they search for, and their feedback. Use this information to identify which pages are most valuable to your users and track trends over time.
 
 ## Filter by AI or human visitors


### PR DESCRIPTION
## Documentation changes


---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only plan and pricing messaging updates with no product or code behavior changes.
> 
> **Overview**
> Adds top-of-page **`<Info>`** callouts on **agent**, **REST API**, **automations**, **analytics**, and **offline export** docs so readers see plan requirements before the main content. Pro-tier features use **Pro or Enterprise** links with page-specific `ref` query params; offline export stays **Enterprise-only**.
> 
> On **preview deployments**, the intro callout is reworded from “available on the Pro plan and above” to **“require a Pro or Enterprise plan”** for consistency. The separate **Enterprise-only** `<Info>` block under password-protected previews is **removed**, so that section no longer repeats plan gating in a second callout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56755240658ea5f890c8d242d60557906592075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->