### PR TITLE
Move integrations docs from agent to automations

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -25,7 +25,6 @@ Use the agent to:
 - Process and include images, diagrams, and other files from Slack attachments.
 - Search and revise code examples and API references across your docs.
 - Reference source code from any repository that has the Mintlify GitHub App installed.
-- Pull live context from connected apps like Slack, Notion, Linear, and Jira.
 - Automate documentation maintenance with automations.
 - Answer questions about your docs and technical writing topics.
 - Address code review feedback to maintain documentation quality.
@@ -52,9 +51,6 @@ To let an external agent edit your content directly through MCP tool calls, conn
 
 <Card title="Connect Slack" horizontal icon="slack" href="/agent/slack">
 Add the agent to your Slack workspace.
-</Card>
-<Card title="Connect integrations" horizontal icon="plug" href="/agent/integrations">
-Give the agent access to Slack, Notion, Linear, and other tools.
 </Card>
 <Card title="Customize behavior" horizontal icon="wrench" href="/agent/customize">
 Configure the agent with an `AGENTS.md` file.

--- a/agent/slack.mdx
+++ b/agent/slack.mdx
@@ -11,7 +11,7 @@ keywords: ["Slack integration", "Slack bot", "team collaboration", "agent integr
 Use the agent in Slack to update your content, ask questions, and capture team knowledge. Mention the agent in a channel to use it collaboratively, or send it a direct message to use it privately.
 
 <Tip>
-  This page covers adding the agent as a bot to your Slack workspace. To give the agent access to Slack channel content as a data source, see [Agent integrations](/agent/integrations).
+  This page covers adding the agent as a bot to your Slack workspace. To give automations access to Slack channel content as a data source, see [Integrations](/automations/integrations).
 </Tip>
 
 ## Connect your Slack workspace

--- a/automations/integrations.mdx
+++ b/automations/integrations.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Integrations"
+title: "Automation integrations"
+sidebarTitle: "Integrations"
 description: "Connect Slack, Notion, Linear, Jira, Confluence, and other apps so automations can pull live context from the tools your team uses."
 keywords: ["integrations", "Slack", "Notion", "Linear", "Jira", "Confluence", "Salesforce", "Intercom", "Google Calendar", "Google Drive", "HubSpot", "Plain", "context", "automations", "Nango"]
 ---

--- a/automations/integrations.mdx
+++ b/automations/integrations.mdx
@@ -1,17 +1,17 @@
 ---
-title: "Agent integrations"
-description: "Connect Slack, Notion, Linear, Jira, Confluence, and other apps so the agent can pull live context when answering questions and updating content."
-keywords: ["integrations", "Slack", "Notion", "Linear", "Jira", "Confluence", "Salesforce", "Intercom", "Google Calendar", "Google Drive", "HubSpot", "Plain", "context", "Nango"]
+title: "Integrations"
+description: "Connect Slack, Notion, Linear, Jira, Confluence, and other apps so automations can pull live context from the tools your team uses."
+keywords: ["integrations", "Slack", "Notion", "Linear", "Jira", "Confluence", "Salesforce", "Intercom", "Google Calendar", "Google Drive", "HubSpot", "Plain", "context", "automations", "Nango"]
 ---
 
-Agent integrations give the agent access to context from other tools that your team uses. Once connected, the agent can search Slack threads, read Notion pages, look up Linear issues, and pull context from other apps to inform its responses and content updates.
+Integrations give [automations](/automations/index) access to context from other tools that your team uses. Once connected, an automation can search Slack threads, read Notion pages, look up Linear issues, and pull context from other apps to inform its content updates.
 
 ## Connection scope
 
 Integrations connect in one of two ways:
 
-- **Shared integrations** connect once for your entire organization. Anyone on the team can prompt the agent to use them. Slack, Notion, Linear, Jira, Confluence, Salesforce, Intercom, HubSpot, and Plain all connect this way.
-- **Personal integrations** connect per user. Each teammate authorizes their own account, and the agent can only use a personal integration on behalf of the user who connected it. Google Calendar and Google Drive are personal.
+- **Shared integrations** connect once for your entire organization and are available to your automations. Slack, Notion, Linear, Jira, Confluence, Salesforce, Intercom, HubSpot, and Plain all connect this way.
+- **Personal integrations** connect per user. Each teammate authorizes their own account. Google Calendar and Google Drive are personal.
 
 Personal integrations keep user-specific data, like calendar events, scoped to the user who connected the integration instead of shared across the organization.
 
@@ -19,7 +19,7 @@ Personal integrations keep user-specific data, like calendar events, scoped to t
 
 Admins and editors can connect shared integrations on behalf of the organization.
 
-1. Go to the [Agent integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard.
+1. Go to the [Integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard settings.
 2. Find the integration you want to connect.
 3. Click **Connect**.
 4. Follow the OAuth prompts to authorize Mintlify to access your account.
@@ -42,22 +42,19 @@ Some integrations open an additional configuration step before the connection co
 | Salesforce | Shared |
 | Slack | Shared |
 
-## How the agent uses integrations
+## How automations use integrations
 
-The agent uses connected integrations as tools. When you ask the agent a question or give it a task, it can search and retrieve content from your connected apps to build context.
+Automations use connected integrations as tools. When an automation runs, the agent can search and retrieve content from the connected apps you enabled for that automation to build context for its updates.
 
-For example:
-- "Summarize the Slack thread about the v2 API migration and write it up for the knowledge base."
-- "Check the Linear ticket for this feature and document the behavior."
-- "What did the team decide about rate limiting? Check Slack."
+To enable integrations for an automation, open the automation's settings and select the integrations you want the agent to use in the **Available integrations** section. Only integrations already connected for your organization appear in the list. See [Manage automations](/automations/manage#integrations) for details.
 
-The agent only accesses integration data when it's relevant to the request. It does not proactively read from connected apps.
+The agent only accesses integration data when it's relevant to the automation's task. It does not proactively read from connected apps.
 
 ## Permissions and access
 
 Each integration requests the OAuth scopes or API-key permissions it needs to search and retrieve content from the connected app. Mintlify requests read-only scopes wherever the provider offers them.
 
-Review the exact scopes during the OAuth consent screen before authorizing the connection. The consent screen lists every permission the agent receives, and you can revoke the connection at any time from the dashboard or from the connected app's own integrations settings.
+Review the exact scopes during the OAuth consent screen before authorizing the connection. The consent screen lists every permission the integration receives, and you can revoke the connection at any time from the dashboard or from the connected app's own integrations settings.
 
 If your organization restricts which apps users can authorize, ask the relevant admin (such as your Slack or Google Workspace admin) to allow the Mintlify integration before connecting.
 
@@ -83,9 +80,9 @@ To narrow what the agent can see, restrict the connected account's permissions i
 
 ## Data retention after disconnect
 
-When you disconnect an integration, the agent immediately loses the ability to read from that app. Mintlify doesn't retain a durable copy of integration content. The agent fetches data on each request through the live OAuth token or API key, so disconnecting cuts off future access.
+When you disconnect an integration, automations immediately lose the ability to read from that app. Mintlify doesn't retain a durable copy of integration content. The agent fetches data on each run through the live OAuth token or API key, so disconnecting cuts off future access.
 
-Content that appeared in past agent responses or pull requests stays in place (chat transcripts, published pages, PR history). Edit or delete the pages and conversations directly if you also want that content removed.
+Content that appeared in past automation runs or pull requests stays in place (published pages, PR history). Edit or delete the pages directly if you also want that content removed.
 
 ## Troubleshoot a failed connection
 
@@ -93,21 +90,21 @@ If an integration stops working or shows an error in the dashboard, the underlyi
 
 To restore access:
 
-1. Go to the [Agent integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard.
+1. Go to the [Integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard settings.
 2. Find the affected integration and click **Configure**.
 3. Click **Disconnect**.
 4. Click **Connect**.
 5. Complete the OAuth flow.
 
-For API-key providers like Plain, generate a new API key in the source app and paste it into the integration's configuration. If the agent still can't access data after reconnecting, confirm that the authorizing user has permission to view the relevant content in the source app.
+For API-key providers like Plain, generate a new API key in the source app and paste it into the integration's configuration. If automations still can't access data after reconnecting, confirm that the authorizing user has permission to view the relevant content in the source app.
 
 ## Disconnect an integration
 
-1. Go to the [Agent integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard.
+1. Go to the [Integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard settings.
 2. Find the connected integration you want to disconnect.
 3. Click **Configure**.
 4. Click **Disconnect**.
 
-Disconnecting a shared integration removes it for everyone in your organization, and the agent immediately loses access to that tool.
+Disconnecting a shared integration removes it for everyone in your organization, and automations immediately lose access to that tool.
 
-Disconnecting a personal integration only removes your own connection. Other teammates who have connected the same integration keep their access, and the agent can still use the integration on their behalf.
+Disconnecting a personal integration only removes your own connection. Other teammates who have connected the same integration keep their access.

--- a/automations/manage.mdx
+++ b/automations/manage.mdx
@@ -65,9 +65,9 @@ You can add up to 10 context repositories per automation. For each GitHub reposi
 
 ### Integrations
 
-For custom automations and the **Update from code changes** automation, you can enable connected [agent integrations](/agent/integrations). The agent then pulls context from tools like Slack, Notion, or Linear when the automation runs.
+For custom automations and the **Update from code changes** automation, you can enable connected [integrations](/automations/integrations). The agent then pulls context from tools like Slack, Notion, or Linear when the automation runs.
 
-To enable integrations for an automation, open its settings and select the integrations you want the agent to use in the **Available integrations** section. Only integrations already connected for your organization appear in the list. See [Agent integrations](/agent/integrations) for more information on connecting integrations.
+To enable integrations for an automation, open its settings and select the integrations you want the agent to use in the **Available integrations** section. Only integrations already connected for your organization appear in the list. Connect integrations on the [Integrations](https://app.mintlify.com/settings/organization/integrations) page in your dashboard settings. See [Integrations](/automations/integrations) for more information.
 
 ### Slack notifications
 

--- a/automations/reference.mdx
+++ b/automations/reference.mdx
@@ -34,7 +34,7 @@ When you run the automation on a schedule, the agent reads all merged source cod
 
 When you run the automation on every source code pull request, the agent opens a content update pull request whenever you merge a code change that requires content updates. Use the push-based variant when you want content updates to appear as soon as code ships, rather than batched on a schedule.
 
-You can enable [agent integrations](/agent/integrations) for this automation to give the agent additional context from tools like Slack or Linear when determining what to update.
+You can enable [integrations](/automations/integrations) for this automation to give the agent additional context from tools like Slack or Linear when determining what to update.
 
 ### Draft changelog
 

--- a/docs.json
+++ b/docs.json
@@ -105,7 +105,6 @@
                     "root": "agent/index",
                     "pages": [
                       "agent/slack",
-                      "agent/integrations",
                       "agent/customize",
                       "agent/effective-prompts",
                       "agent/use-cases"
@@ -118,6 +117,7 @@
                       "automations/index",
                       "automations/reference",
                       "automations/manage",
+                      "automations/integrations",
                       "automations/create"
                     ]
                   },

--- a/redirects.json
+++ b/redirects.json
@@ -1,5 +1,21 @@
 [
     {
+      "source": "/agent/integrations",
+      "destination": "/automations/integrations"
+    },
+    {
+      "source": "/es/agent/integrations",
+      "destination": "/es/automations/integrations"
+    },
+    {
+      "source": "/fr/agent/integrations",
+      "destination": "/fr/automations/integrations"
+    },
+    {
+      "source": "/zh/agent/integrations",
+      "destination": "/zh/automations/integrations"
+    },
+    {
       "source": "/guides/windsurf",
       "destination": "/guides/devin-desktop"
     },


### PR DESCRIPTION
## Summary

Slack agent integrations are deprecated — integrations now serve the Automations product and are managed from **Settings → Integrations** in the dashboard.

- Moves `/agent/integrations` to `/automations/integrations`, rewritten around how automations use integrations and where to connect them (`https://app.mintlify.com/settings/organization/integrations`).
- Adds redirects for `/agent/integrations` (plus es/fr/zh variants) and updates `docs.json` navigation (page now sits in the Automations group).
- Updates links and copy in `agent/index.mdx`, `agent/slack.mdx`, `automations/manage.mdx`, and `automations/reference.mdx`; removes the agent capability bullet about pulling live context from connected apps.
- Translated pages (es/fr/zh) are left for the translation pipeline.

Companion PRs: mintlify/server#6422 (removes Slack agent integration access) and mintlify/mint#8888 (moves the integrations UI to settings).

## Test plan

- [x] `mint validate` passes
- [x] `mint broken-links` passes
- [ ] Confirm `/agent/integrations` redirects to `/automations/integrations` on preview

Made with [Cursor](https://cursor.com)