### PR TITLE
Add redirect for bare /api-reference to /api/introduction

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -140,6 +140,10 @@
       "destination": "/api/assistant/*"
     },
     {
+      "source": "/api-reference",
+      "destination": "/api/introduction"
+    },
+    {
       "source": "/api-reference/*",
       "destination": "/api/*"
     },


### PR DESCRIPTION
The existing wildcard redirect `/api-reference/*` → `/api/*` does not match the bare `/api-reference` path, so `mintlify.com/docs/api-reference` 404s (it was linked from the landing page navbar/footer). This adds an exact-match redirect to `/api/introduction`.

Companion to mintlify/landing#578, which fixes the links at the source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single redirect rule in docs config with no auth, data, or application logic changes.
> 
> **Overview**
> Fixes **404s** for `mintlify.com/docs/api-reference` by adding an **exact-match** redirect from `/api-reference` to `/api/introduction` in `redirects.json`.
> 
> The existing `/api-reference/*` → `/api/*` rule only matches paths with a trailing segment, so the bare path was never redirected. The new entry is placed **before** the wildcard so it takes precedence for that URL only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2249efafa5b1a83bbdf36e041b3085cf65ff4a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->