### PR TITLE
Document where to declare imports for nested snippets

### DIFF
--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -4,7 +4,7 @@ description: "Create reusable content snippets with variables to maintain consis
 keywords: ["content snippets", "reusable content", "variables"]
 ---
 
-One of the core principles of software development is DRY (Don't Repeat Yourself), which applies to documentation too. If you find yourself repeating the same content in multiple places, create a custom snippet for that content. Snippets contain content that you can import into other files to reuse. You control where the snippet appears on a page. If you ever need to update the content, you only need to edit the snippet rather than every file where the snippet is used.
+One of the core principles of software development is DRY (Don't Repeat Yourself), which applies to documentation too. If you find yourself repeating the same content in multiple places, create a custom snippet for that content. Snippets contain content that you can import into other files to reuse. You control where the snippet appears on a page. If you ever need to update the content, you only need to edit the snippet rather than every file where the snippet appears.
 
 <Note>
   Snippets are not currently supported in the web editor. To use snippets, edit your MDX files locally with the CLI or push snippet imports directly to your repository.
@@ -33,13 +33,16 @@ Import snippets into pages using either an absolute or relative path.
 
 ### Import text
 
-1. Add content to your snippet file that you want to reuse.
+<Steps>
+  <Step title="Add content to your snippet file">
+    Add the content you want to reuse.
 
     ```mdx shared/my-snippet.mdx wrap
     Hello world! This is my content I want to reuse across pages.
     ```
-
-2. Import the snippet into your destination file using either an absolute or relative path.
+  </Step>
+  <Step title="Import the snippet into your destination file">
+    Use either an absolute or relative path.
 
     <CodeGroup>
 
@@ -70,6 +73,8 @@ Import snippets into pages using either an absolute or relative path.
     ```
 
     </CodeGroup>
+  </Step>
+</Steps>
 
 ### Nested snippets
 
@@ -77,7 +82,9 @@ Snippets can import other snippets. Declare the import in the snippet file that 
 
 Each file resolves its own imports. Imports declared on a page do not apply to the content of snippets that the page imports, so a nested snippet that relies on a page-level import may render as empty content.
 
-1. Import the nested snippet in the parent snippet file where it is used.
+<Steps>
+  <Step title="Import the nested snippet in the parent snippet file">
+    Declare the import where you want to use the nested snippet.
 
     ```mdx shared/parent-snippet.mdx
     import ChildSnippet from "/shared/child-snippet.mdx";
@@ -86,8 +93,9 @@ Each file resolves its own imports. Imports declared on a page do not apply to t
 
     <ChildSnippet />
     ```
-
-2. Import only the parent snippet in your destination file. You do not need to import the nested snippet.
+  </Step>
+  <Step title="Import only the parent snippet in your destination file">
+    You do not need to import the nested snippet.
 
     ```mdx destination-file.mdx
     ---
@@ -99,13 +107,15 @@ Each file resolves its own imports. Imports declared on a page do not apply to t
 
     <ParentSnippet />
     ```
+  </Step>
+</Steps>
 
 ### Import variables
 
 Reference variables from a snippet in a page.
 
-1. Export variables from a snippet file.
-
+<Steps>
+  <Step title="Export variables from a snippet file">
     ```mdx shared/custom-variables.mdx
     export const myName = "Ronan";
 
@@ -113,9 +123,8 @@ Reference variables from a snippet in a page.
 
     ;
     ```
-
-2. Import the snippet from your destination file and use the variable.
-
+  </Step>
+  <Step title="Import the snippet from your destination file and use the variable">
     ```mdx destination-file.mdx
     ---
     title: "An example page"
@@ -126,18 +135,23 @@ Reference variables from a snippet in a page.
 
     Hello, my name is {myName} and I like {myObject.fruit}.
     ```
+  </Step>
+</Steps>
 
 ### Import snippets with variables
 
 Use variables to pass data to a snippet when you import it.
 
-1. Add variables to your snippet and pass in properties when you import it. In this example, the variable is `{word}`.
+<Steps>
+  <Step title="Add variables to your snippet">
+    Pass in properties when you import it. In this example, the variable is `{word}`.
 
     ```mdx shared/my-snippet.mdx
     My keyword of the day is {word}.
     ```
-
-2. Import the snippet into your destination file with the variable. The passed property replaces the variable in the snippet definition.
+  </Step>
+  <Step title="Import the snippet into your destination file with the variable">
+    The passed property replaces the variable in the snippet definition.
 
     ```mdx destination-file.mdx
     ---
@@ -149,6 +163,8 @@ Use variables to pass data to a snippet when you import it.
 
     <MySnippet word="bananas" />
     ```
+  </Step>
+</Steps>
 
 Variables also interpolate inside fenced code blocks. This is useful for snippets that include installation commands or other code examples that differ by package name, version, or environment.
 
@@ -170,7 +186,9 @@ import InstallSnippet from "/shared/install-snippet.mdx";
 
 ### Import React components
 
-1. Create a snippet with a JSX component. See [React components](/customize/react-components) for more information.
+<Steps>
+  <Step title="Create a snippet with a JSX component">
+    See [React components](/customize/react-components) for more information.
 
     ```js components/my-jsx-snippet.jsx
     export const MyJSXSnippet = () => {
@@ -182,12 +200,11 @@ import InstallSnippet from "/shared/install-snippet.mdx";
     };
     ```
 
-<Note>
-  When creating JSX snippets, use arrow function syntax (`=>`) rather than function declarations. The `function` keyword is not supported in snippets.
-</Note>
-
-2. Import the snippet.
-
+    <Note>
+      When creating JSX snippets, use arrow function syntax (`=>`) rather than function declarations. The `function` keyword is not supported in snippets.
+    </Note>
+  </Step>
+  <Step title="Import the snippet">
     ```mdx destination-file.mdx
     ---
     title: "An example page"
@@ -198,3 +215,5 @@ import InstallSnippet from "/shared/install-snippet.mdx";
 
     <MyJSXSnippet />
     ```
+  </Step>
+</Steps>

--- a/create/reusable-snippets.mdx
+++ b/create/reusable-snippets.mdx
@@ -18,7 +18,7 @@ When you import a snippet into another file, the snippet only appears where you 
 
 ## Create snippets
 
-Create a file with the content you want to reuse. Snippets can contain all content types supported by Mintlify and they can import other snippets.
+Create a file with the content you want to reuse. Snippets can contain all content types supported by Mintlify and they can import other snippets. See [Nested snippets](#nested-snippets) for where to declare imports when nesting.
 
 ## Import snippets into pages
 
@@ -70,6 +70,35 @@ Import snippets into pages using either an absolute or relative path.
     ```
 
     </CodeGroup>
+
+### Nested snippets
+
+Snippets can import other snippets. Declare the import in the snippet file that uses the nested snippet, not in the page that imports the parent snippet.
+
+Each file resolves its own imports. Imports declared on a page do not apply to the content of snippets that the page imports, so a nested snippet that relies on a page-level import may render as empty content.
+
+1. Import the nested snippet in the parent snippet file where it is used.
+
+    ```mdx shared/parent-snippet.mdx
+    import ChildSnippet from "/shared/child-snippet.mdx";
+
+    This snippet renders another snippet beneath this sentence.
+
+    <ChildSnippet />
+    ```
+
+2. Import only the parent snippet in your destination file. You do not need to import the nested snippet.
+
+    ```mdx destination-file.mdx
+    ---
+    title: "An example page"
+    description: "This is an example page that imports a snippet containing a nested snippet."
+    ---
+
+    import ParentSnippet from "/shared/parent-snippet.mdx";
+
+    <ParentSnippet />
+    ```
 
 ### Import variables
 


### PR DESCRIPTION
## Summary
The reusable snippets page says snippets "can import other snippets" but never says where the import must be declared. Declaring a nested snippet's import in the top-level page instead of the parent snippet silently renders empty content, because each file resolves its own imports — page-level imports don't apply inside imported snippets. Whether it happens to work is import order-dependent, so the same pattern can work on one page and fail on another.

This adds a "Nested snippets" section stating the rule (declare the import in the snippet file that uses the nested snippet), explaining why, and showing a parent/child snippet example. Also links to it from the "Create snippets" section, the only other place nesting is mentioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to `create/reusable-snippets.mdx` with no runtime, auth, or data impact.
> 
> **Overview**
> Documents a common **nested snippets** pitfall: nested imports must live in the **parent snippet file**, not on the page that imports the parent, because each MDX file resolves its own imports and page-level imports do not apply inside imported snippet content (which can silently render empty).
> 
> Adds a **Nested snippets** subsection with that rule, a short explanation, and parent/child MDX examples, plus a link from **Create snippets** where nesting is first mentioned.
> 
> Reformats several how-to sections (**Import text**, variables, snippets with variables, React components) from numbered lists into **`<Steps>` / `<Step>`** blocks for consistency with the new nested-snippet walkthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44f1f9300a75f0b49247467bcbb41088de4239a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->