### PR TITLE
automation-integration-gate

### DIFF
--- a/automations/integrations.mdx
+++ b/automations/integrations.mdx
@@ -5,6 +5,10 @@ description: "Connect Slack, Notion, Linear, Jira, Confluence, and other apps so
 keywords: ["integrations", "Slack", "Notion", "Linear", "Jira", "Confluence", "Salesforce", "Intercom", "Google Calendar", "Google Drive", "HubSpot", "Plain", "context", "automations", "Nango"]
 ---
 
+<Info>
+  Automation integrations require an Enterprise plan.
+</Info>
+
 Integrations give [automations](/automations/index) access to context from other tools that your team uses. Once connected, an automation can search Slack threads, read Notion pages, look up Linear issues, and pull context from other apps to inform its content updates.
 
 ## Connection scope

--- a/automations/integrations.mdx
+++ b/automations/integrations.mdx
@@ -6,7 +6,7 @@ keywords: ["integrations", "Slack", "Notion", "Linear", "Jira", "Confluence", "S
 ---
 
 <Info>
-  Automation integrations require an Enterprise plan.
+  Automation integrations require an [Enterprise plan](https://mintlify.com/pricing?ref=automation-integrations).
 </Info>
 
 Integrations give [automations](/automations/index) access to context from other tools that your team uses. Once connected, an automation can search Slack threads, read Notion pages, look up Linear issues, and pull context from other apps to inform its content updates.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change with no product or security impact.
> 
> **Overview**
> Adds an upfront **`<Info>`** callout on **`automations/integrations.mdx`** stating that automation integrations require an **[Enterprise plan](https://mintlify.com/pricing?ref=automation-integrations)**.
> 
> Also fixes a stray list marker on the personal-integration disconnect note so it renders as normal body text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554086e5040f44a8a443dd66384f9b9cd1ae9c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->