### PR TITLE
docs: remove inaccurate lazy loading example from React components page

### DIFF
--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -222,4 +222,4 @@ import { ColorGenerator } from "/snippets/color-generator.jsx"
 - **Optimize dependency arrays**: Only include necessary dependencies in `useEffect`.
 - **Memoize expensive operations**: Use `useMemo` or `useCallback` where appropriate.
 - **Reduce re-renders**: Break large components into smaller ones.
-- **Lazy loading**: Component code cannot be lazy loaded. All components on a page load with it. If a component does expensive work when it mounts, such as fetching data or heavy computation, use conditional rendering to defer mounting it until user interaction.
+- **Lazy loading**: Component code cannot lazy load. All components load with the page. If a component performs resource-intensive operations when it mounts, such as fetching data or heavy computation, use conditional rendering to defer mounting it until user interaction.

--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -77,6 +77,7 @@ React components in Mintlify run in a sandboxed MDX environment with the followi
 - **No default exports**: Use named exports (`export const MyComponent = ...`). Default exports (`export default`) are not supported.
 - **No cross-snippet imports**: Snippet files cannot import other snippet files. Import all dependencies directly in the parent MDX file.
 - **No JSON imports**: Importing `.json` files is not supported.
+- **No code splitting**: `React.lazy` and dynamic `import()` are not supported. All component code on a page, including imported snippets, is compiled into the page and loads with it.
 
 {/* vale Mintlify.Ellipses = YES */}
 
@@ -221,51 +222,4 @@ import { ColorGenerator } from "/snippets/color-generator.jsx"
 - **Optimize dependency arrays**: Only include necessary dependencies in `useEffect`.
 - **Memoize expensive operations**: Use `useMemo` or `useCallback` where appropriate.
 - **Reduce re-renders**: Break large components into smaller ones.
-- **Lazy loading**: Defer rendering complex components to improve initial page load. Because the MDX sandbox does not support `React.lazy` or dynamic `import()`, gate heavy components behind user interaction or visibility instead. See [Defer rendering for heavy components](#defer-rendering-for-heavy-components).
-
-### Defer rendering for heavy components
-
-`React.lazy`, `Suspense`, and dynamic `import()` are not available in the MDX sandbox. To get the same benefit, render a lightweight placeholder first and only mount the expensive component after the reader opts in. This keeps the initial page load fast while still letting readers interact with the full component.
-
-The example below keeps the `ColorGenerator` from the previous section unmounted until the reader clicks **Load color generator**:
-
-export const LazyColorGenerator = () => {
-  const [show, setShow] = useState(false)
-
-  if (!show) {
-    return (
-      <button
-        onClick={() => setShow(true)}
-        className="px-3 py-1.5 text-sm rounded-lg border border-zinc-950/20 dark:border-white/20 text-zinc-950/80 dark:text-white/80"
-      >
-        Load color generator
-      </button>
-    )
-  }
-
-  return <ColorGenerator />
-}
-
-<LazyColorGenerator />
-
-```mdx
-import { ColorGenerator } from "/snippets/color-generator.jsx"
-
-export const LazyColorGenerator = () => {
-  const [show, setShow] = useState(false)
-
-  if (!show) {
-    return (
-      <button onClick={() => setShow(true)}>
-        Load color generator
-      </button>
-    )
-  }
-
-  return <ColorGenerator />
-}
-
-<LazyColorGenerator />
-```
-
-To defer rendering until the component scrolls into view, swap the button for an `IntersectionObserver` set up inside a `useEffect`. The pattern is the same: keep `show` false until the trigger fires, then return the heavy component.
+- **Lazy loading**: Component code cannot be lazy loaded. All components on a page load with it. If a component does expensive work when it mounts, such as fetching data or heavy computation, use conditional rendering to defer mounting it until user interaction.

--- a/customize/react-components.mdx
+++ b/customize/react-components.mdx
@@ -77,7 +77,7 @@ React components in Mintlify run in a sandboxed MDX environment with the followi
 - **No default exports**: Use named exports (`export const MyComponent = ...`). Default exports (`export default`) are not supported.
 - **No cross-snippet imports**: Snippet files cannot import other snippet files. Import all dependencies directly in the parent MDX file.
 - **No JSON imports**: Importing `.json` files is not supported.
-- **No code splitting**: `React.lazy` and dynamic `import()` are not supported. All component code on a page, including imported snippets, is compiled into the page and loads with it.
+- **No code splitting**: `React.lazy` and dynamic `import()` are not supported. All component code on a page, including imported snippets, compiles into the page and loads with it.
 
 {/* vale Mintlify.Ellipses = YES */}
 


### PR DESCRIPTION
## Summary

PR #6133 added a "Defer rendering for heavy components" section claiming that gating a component's mount behind a button click "keeps the initial page load fast." This is inaccurate: MDX pages are compiled server-side into a single function-body string with all imported snippets inlined, and the entire string is downloaded, parsed, and evaluated at hydration regardless of whether a component ever mounts. Deferred mounting saves no bytes, parse time, or eval time at page load.

closes https://linear.app/mintlify/issue/DOC-391/fix-lazy-loading-example

## Changes

- Added a **No code splitting** constraint to the Constraints list: `React.lazy` and dynamic `import()` are not supported, and all component code on a page loads with it. This directly answers the customer question that motivated #6133.
- Rewrote the **Lazy loading** consideration to be accurate: code cannot be lazy loaded; conditional rendering can defer expensive mount-time work (data fetching, heavy computation) only.
- Removed the "Defer rendering for heavy components" section, its `LazyColorGenerator` example, and the IntersectionObserver guidance.

English page only; translations regenerate after merge.

## Verification

Traced the rendering pipeline in mintlify/mint: `getMdx.ts` → `serialize` (function-body output), snippets inlined via `resolveAllImports.ts`, imports stripped by `remarkRemoveImports.ts`, full string evaluated at hydration via `runSync`. No runtime module system exists for `React.lazy`/dynamic `import()` to resolve against.

`mint broken-links`, `mint a11y`, and `vale` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the English React components page; no runtime or product behavior.
> 
> **Overview**
> Corrects **React components** docs that wrongly implied gating mount behind a button speeds initial page load. Mintlify MDX inlines all snippet code into one bundle evaluated at hydration, so deferred mounting does not reduce download, parse, or eval cost.
> 
> Adds a **No code splitting** constraint (`React.lazy` and dynamic `import()` unsupported; all page component code loads together). Rewrites the **Lazy loading** consideration to state that only **mount-time** work (fetches, heavy computation) can be deferred via conditional rendering. Removes the **Defer rendering for heavy components** section, `LazyColorGenerator` demo, and IntersectionObserver guidance.
> 
> English `customize/react-components.mdx` only; locales noted to regenerate after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfda33e37b74799f5d06e407ce121783db0289d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->