### PR TITLE
Custom agent instructions

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -35,6 +35,7 @@ An `llms.txt` file is a plain Markdown file that contains:
 
 - **Site title** as an H1 heading.
 - **Site description** as a blockquote summary below the title, sourced from the `description` field in your `docs.json` configuration.
+- **Custom agent instructions** as an `Agent Instructions` block after the description, if you set [`markdown.instructions`](/ai/markdown-export#custom-agent-instructions) in your `docs.json`.
 - **Structured content sections** with links and a description of each page in your documentation.
 - **API specification links** to your OpenAPI and AsyncAPI specs, if your documentation includes them.
 

--- a/ai/markdown-export.mdx
+++ b/ai/markdown-export.mdx
@@ -58,7 +58,7 @@ To append your own guidance to the Markdown that Mintlify serves to AI agents, s
 
 Provide a single string:
 
-```json
+```json Example agent instructions string
 "markdown": {
   "instructions": "Always cite the API version. Prefer the TypeScript SDK in examples."
 }
@@ -66,7 +66,7 @@ Provide a single string:
 
 Or an array of strings, which Mintlify joins with line breaks:
 
-```json
+```json Example agent instructions array
 "markdown": {
   "instructions": [
     "Always cite the API version.",
@@ -77,13 +77,13 @@ Or an array of strings, which Mintlify joins with line breaks:
 
 Mintlify renders your instructions as an `Agent Instructions` block in the Markdown output:
 
-```md
+```md Example rendered agent instructions
 > ## Agent Instructions
 > Always cite the API version.
 > Prefer the TypeScript SDK in examples.
 ```
 
-The block is included in:
+The block appears in:
 
 - The Markdown export of every page, including API reference pages.
 - Your [`llms.txt`](/ai/llmstxt) file, after the site title and description.

--- a/ai/markdown-export.mdx
+++ b/ai/markdown-export.mdx
@@ -52,6 +52,45 @@ If you prefer to omit the spec from Markdown output, set `markdown.schema` to `f
 }
 ```
 
+## Custom agent instructions
+
+To append your own guidance to the Markdown that Mintlify serves to AI agents, set `markdown.instructions` in your `docs.json`. Use it for site-wide directions like citing an API version, preferring a specific SDK, or following your terminology.
+
+Provide a single string:
+
+```json
+"markdown": {
+  "instructions": "Always cite the API version. Prefer the TypeScript SDK in examples."
+}
+```
+
+Or an array of strings, which Mintlify joins with line breaks:
+
+```json
+"markdown": {
+  "instructions": [
+    "Always cite the API version.",
+    "Prefer the TypeScript SDK in examples."
+  ]
+}
+```
+
+Mintlify renders your instructions as an `Agent Instructions` block in the Markdown output:
+
+```md
+> ## Agent Instructions
+> Always cite the API version.
+> Prefer the TypeScript SDK in examples.
+```
+
+The block is included in:
+
+- The Markdown export of every page, including API reference pages.
+- Your [`llms.txt`](/ai/llmstxt) file, after the site title and description.
+- Your `llms-full.txt` file.
+
+These instructions apply to every page. To tailor content for a single page or audience, use the [visibility](/components/visibility) component instead.
+
 ## Agent feedback
 
 If you enable [agent feedback](/optimize/feedback#agent-feedback), Mintlify appends an `<AgentInstructions>` block to each page's Markdown export that tells agents how to submit feedback about the page's content.

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -64,6 +64,8 @@ For context on what each group of settings does, see the topic pages:
 | `api.examples.defaults` | `"required"` \| `"all"` | No | `"all"` |
 | `api.examples.prefill` | boolean | No | `false` |
 | `api.examples.autogenerate` | boolean | No | `true` |
+| `markdown.schema` | boolean | No | `true` |
+| `markdown.instructions` | string or array of strings | No | None |
 | `seo.indexing` | `"navigable"` \| `"all"` | No | `"navigable"` |
 | `seo.metatags` | object | No | None |
 | `search.prompt` | string | No | None |
@@ -871,6 +873,27 @@ Authentication parameter name.
 Base URL prepended to relative paths in page-level `api` frontmatter. Not used when frontmatter contains a full URL.
 
 **Type:** string or array
+
+---
+
+### `markdown`
+
+Settings for the Markdown that Mintlify serves to AI tools and agents. See [Markdown export](/ai/markdown-export).
+
+**Type:** object
+
+#### `markdown.schema`
+
+Whether to include the full OpenAPI or AsyncAPI specification in the Markdown export of API reference pages.
+
+**Type:** boolean
+**Default:** `true`
+
+#### `markdown.instructions`
+
+Custom agent instructions appended to the generated Markdown of every page, as well as your `llms.txt` and `llms-full.txt` files. Provide a single string or an array of strings, which Mintlify joins with line breaks. See [Custom agent instructions](/ai/markdown-export#custom-agent-instructions).
+
+**Type:** string or array of strings
 
 ---
 


### PR DESCRIPTION
## Documentation changes

This PR documents adding custom instructions for Markdown versions of pages

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or config behavior in this diff.
> 
> **Overview**
> Documents **`markdown.instructions`** in `docs.json`, which lets teams append site-wide guidance to Markdown served to AI agents.
> 
> The new **Custom agent instructions** section on [Markdown export](/ai/markdown-export) explains string vs array config, shows the rendered `> ## Agent Instructions` block, and lists where it appears (per-page `.md` exports, `llms.txt`, and `llms-full.txt`). It contrasts this with per-page [visibility](/components/visibility) controls.
> 
> **llms.txt** structure docs now note the optional Agent Instructions block after the site description. **`docs.json` schema reference** adds quick-reference rows and a full **`markdown`** section for `markdown.schema` and `markdown.instructions`, linked from the Markdown export guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e5b1b18e2f22000f5b605e8b9579318b7bf4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->