### PR TITLE
Enterprise session sso docs

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -241,6 +241,7 @@ OG
 OIDC
 (?i)oklch
 Okta
+offboarding
 onboarding
 oneOf
 openable

--- a/dashboard/audit-logs.mdx
+++ b/dashboard/audit-logs.mdx
@@ -41,7 +41,7 @@ Filter audit logs to find specific activities.
 | Category         | Description                                                        |
 |------------------|--------------------------------------------------------------------|
 | Organization     | Organization settings updates and deletion requests.                |
-| Member           | Team member invitations, removals, and role changes.               |
+| Member           | Team member invitations, removals, role changes, and credential revocations. |
 | Deployment       | Deployment configuration changes including custom domains, authentication, Git sources, and MCP client credentials. |
 | Preview deployment | Preview deployment creation, updates, and authentication changes. |
 | API key          | API key and discovery API key creation and deletion.               |
@@ -53,7 +53,8 @@ Filter audit logs to find specific activities.
 | User             | Individual user notification settings.                             |
 | Automations        | Automation configurations and repository management.                 |
 | Audit log        | Audit log views and exports.                              |
-| Auth             | Login attempts, logouts, and session creations.                     |
+| Auth             | Login attempts, logouts, session creations, and break-glass logins. |
+| SSO              | SSO connection changes, sign-in policy updates, break-glass access updates, and verified domain changes. |
 | SCIM             | Automated user provisioning, updates, and deprovisioning from your identity provider, and group role mapping changes. |
 
 ## Export audit logs

--- a/dashboard/network-access.mdx
+++ b/dashboard/network-access.mdx
@@ -9,7 +9,7 @@ keywords: ["IP allowlist", "network access", "CIDR", "IP restrictions", "securit
   Dashboard access policies require an [Enterprise plan](https://mintlify.com/pricing?ref=network-access).
 </Info>
 
-Control how organization members access the Mintlify dashboard: restrict access to trusted IP addresses and set how long dashboard sessions stay valid. Both policies live on the **Policies** tab of the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page in your dashboard.
+Control how organization members access the Mintlify dashboard: restrict access to trusted IP addresses and set how long dashboard sessions stay valid. Manage both policies on the **Policies** tab of the [Identity & access](https://app.mintlify.com/settings/organization/access) page in your dashboard.
 
 ## IP allowlist
 
@@ -28,7 +28,7 @@ You can allow access two ways:
   Add your current IP address to the allowlist before enabling it. If your address is not on the list, you can lock yourself out of the dashboard. The **Policies** tab displays your current IP address to help you avoid this.
 </Warning>
 
-1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page.
+1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/access) page.
 2. On the **Policies** tab, under **Allowed IP addresses**, enter an individual IP address (for example, `203.0.113.7`) or a CIDR range (for example, `10.0.0.0/8`).
 3. Click **Add**.
 4. Repeat for each address or range you want to allow.
@@ -45,7 +45,7 @@ Both limits accept values from 5 minutes to 14 days.
 
 ### Configure session lifetimes
 
-1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page.
+1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/access) page.
 2. On the **Policies** tab, under **Session lifetimes**, toggle on **Maximum session lifetime** or **Idle session timeout**.
 3. Set a duration for each limit that you enable.
 4. Click **Save**.

--- a/dashboard/network-access.mdx
+++ b/dashboard/network-access.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Network access"
-description: "Restrict Mintlify dashboard and editor access to trusted IP addresses and CIDR ranges by configuring an organization-wide IP allowlist."
-keywords: ["IP allowlist", "network access", "CIDR", "IP restrictions", "security", "dashboard access", "trusted IPs"]
+title: "Dashboard access policies"
+sidebarTitle: "Access policies"
+description: "Restrict Mintlify dashboard access to trusted IP addresses and control how long dashboard sessions stay valid with idle timeouts and maximum session lifetimes."
+keywords: ["IP allowlist", "network access", "CIDR", "IP restrictions", "security", "dashboard access", "trusted IPs", "session lifetime", "idle timeout", "session duration"]
 ---
 
 <Info>
-  Network access controls require an [Enterprise plan](https://mintlify.com/pricing?ref=network-access).
+  Dashboard access policies require an [Enterprise plan](https://mintlify.com/pricing?ref=network-access).
 </Info>
+
+Control how organization members access the Mintlify dashboard: restrict access to trusted IP addresses and set how long dashboard sessions stay valid. Both policies live on the **Policies** tab of the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page in your dashboard.
+
+## IP allowlist
 
 Use an IP allowlist to restrict dashboard and editor access to trusted IP addresses and CIDR ranges. When you enable the allowlist, organization members can only sign in and use the dashboard and web editor from an allowed IP address.
 
@@ -17,15 +22,32 @@ You can allow access two ways:
 - **Individual IP address**: Allow a single address, such as `203.0.113.7`.
 - **CIDR range**: Allow a block of addresses, such as `10.0.0.0/8`. Use CIDR notation to grant access to an entire office or VPN network without listing each address individually.
 
-
-## Configure the IP allowlist
+### Configure the IP allowlist
 
 <Warning>
-  Add your current IP address to the allowlist before enabling it. If your address is not on the list, you can lock yourself out of the dashboard. The [Network access](https://app.mintlify.com/settings/organization/network-access) page displays your current IP address to help you avoid this.
+  Add your current IP address to the allowlist before enabling it. If your address is not on the list, you can lock yourself out of the dashboard. The **Policies** tab displays your current IP address to help you avoid this.
 </Warning>
 
-1. In your Mintlify dashboard, navigate to the [Network access](https://app.mintlify.com/settings/organization/network-access) page.
-2. Under **Allowed IP addresses**, enter an individual IP address (for example, `203.0.113.7`) or a CIDR range (for example, `10.0.0.0/8`).
+1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page.
+2. On the **Policies** tab, under **Allowed IP addresses**, enter an individual IP address (for example, `203.0.113.7`) or a CIDR range (for example, `10.0.0.0/8`).
 3. Click **Add**.
 4. Repeat for each address or range you want to allow.
 5. Enable the allowlist to begin enforcing it.
+
+## Session lifetimes
+
+Control how long dashboard sessions stay valid before members must sign in again. You can set two independent limits:
+
+- **Maximum session lifetime**: Members must sign in again once a session reaches this age, regardless of activity. When off, sessions have no maximum age.
+- **Idle session timeout**: Members are signed out after this period of inactivity. When off, sessions time out after 14 days of inactivity.
+
+Both limits accept values from 5 minutes to 14 days.
+
+### Configure session lifetimes
+
+1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/network-access) page.
+2. On the **Policies** tab, under **Session lifetimes**, toggle on **Maximum session lifetime** or **Idle session timeout**.
+3. Set a duration for each limit that you enable.
+4. Click **Save**.
+
+Lowering the maximum session lifetime applies to active sessions immediately: any session older than the new limit ends the next time it makes a request. Changes to the idle session timeout take effect as active sessions refresh.

--- a/dashboard/roles.mdx
+++ b/dashboard/roles.mdx
@@ -52,8 +52,8 @@ You can invite any number of members to your organization.
 Admins can sign a member out of the dashboard and revoke their keys and tokens without removing them from the organization. Use credential revocation when offboarding someone or responding to a compromised account.
 
 1. Navigate to the [Members](https://app.mintlify.com/settings/organization/members) page of your dashboard.
-2. In the member's row, click the **Revoke credentials** button.
-3. Select which credentials to revoke. All credentials are selected by default.
+2. In the member's row, click the <Icon icon="shield-off" /> **Revoke credentials** button.
+3. Select which credentials to revoke.
 4. Click **Revoke**.
 
 You can revoke any combination of the following credentials:

--- a/dashboard/roles.mdx
+++ b/dashboard/roles.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Roles"
 description: "Assign admin, editor, or viewer roles to team members to control access levels, editing permissions, and deployment capabilities in Mintlify."
-keywords: ["RBAC", "role-based access control", "admin", "editor", "viewer", "permissions"]
+keywords: ["RBAC", "role-based access control", "admin", "editor", "viewer", "permissions", "revoke credentials", "session revocation"]
 boost: 3
 ---
 
@@ -46,3 +46,25 @@ Mintlify provides three dashboard access levels: viewer, editor, and admin.
 By default, the person who creates your Mintlify organization has admin access. Add additional members in the [Members](https://app.mintlify.com/settings/organization/members) page of your dashboard.
 
 You can invite any number of members to your organization.
+
+## Revoke a member's credentials
+
+Admins can sign a member out of the dashboard and revoke their keys and tokens without removing them from the organization. Use credential revocation when offboarding someone or responding to a compromised account.
+
+1. Navigate to the [Members](https://app.mintlify.com/settings/organization/members) page of your dashboard.
+2. In the member's row, click the **Revoke credentials** button.
+3. Select which credentials to revoke. All credentials are selected by default.
+4. Click **Revoke**.
+
+You can revoke any combination of the following credentials:
+
+| Credential | What revoking it does |
+| ---------- | --------------------- |
+| Sessions | Signs the member out of the dashboard. |
+| CLI tokens | Signs the member out of the [CLI](/cli/install). |
+| API keys | Deletes the API keys that the member created. |
+| Discovery API keys | Deletes the discovery API keys that the member created. |
+| M2M clients | Revokes the member's machine-to-machine client credentials. |
+| Connected apps | Disconnects the apps the member authorized through OAuth. |
+
+Revoking credentials cannot be undone. The member can sign in again and create new keys and tokens unless you also remove them from the organization or block their sign-in method. You cannot revoke your own credentials.

--- a/dashboard/sso.mdx
+++ b/dashboard/sso.mdx
@@ -16,7 +16,7 @@ Enterprise admins can configure SAML SSO for Okta or Microsoft Entra directly fr
 
 <Steps>
   <Step title="Configure Okta SSO in your Mintlify dashboard">
-    1. In your Mintlify dashboard, navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page.
+    1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page.
     2. Click **Configure**.
     3. Select **Okta SAML**.
     4. Copy the **Single sign on URL** and **Audience URI**.
@@ -47,7 +47,7 @@ Enterprise admins can configure SAML SSO for Okta or Microsoft Entra directly fr
 
 <Steps>
   <Step title="Configure Microsoft Entra SSO in your Mintlify dashboard">
-    1. In your Mintlify dashboard, navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page.
+    1. In your Mintlify dashboard, navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page.
     2. Click **Configure**.
     3. Select **Microsoft Entra ID SAML**.
     4. Copy the **Single sign on URL** and **Audience URI**.
@@ -96,47 +96,47 @@ When you enable JIT (just-in-time) provisioning, users who sign in through your 
   JIT provisioning only works for IdP-initiated login. Users must sign in from your identity provider (Okta dashboard or Microsoft Entra portal) rather than starting from the Mintlify login page.
 </Note>
 
-To enable JIT provisioning, you must have SSO enabled. Navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page in your dashboard, set up SSO, and then enable JIT provisioning.
-
-## Enforce SSO-only sign-in
-
-Organization admins can require everyone in the organization to sign in through your identity provider. When SSO enforcement is on, Mintlify rejects password, magic link, and Google OAuth sign-ins.
-
-1. Navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
-2. Confirm that SSO works end-to-end.
-3. Toggle **Enforce SSO-only sign-in** on.
-
-<Warning>
-  Mintlify blocks SSO enforcement if turning it on would lock every owner out of the organization. Configure at least one breakglass email or confirm an owner can sign in through your IdP before enforcing.
-</Warning>
-
-To stop enforcing SSO, toggle the setting off. Other sign-in methods become available again immediately.
+To enable JIT provisioning, you must have SSO enabled. Navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page in your dashboard, set up SSO, and then enable JIT provisioning.
 
 ## Verified domains
 
-Add domains your organization owns so Mintlify can tie sign-ins and invitations back to a trusted identity. You can add up to five verified domains per organization.
+Verify ownership of your email domains so Mintlify can scope SSO and member provisioning to people with matching email addresses. When someone signs in with an email address on a verified domain, Mintlify automatically routes them to your identity provider. Automatic routing works whether or not you require SSO, as long as your organization has an active SSO connection.
 
-1. Navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
-2. In the **Verified domains** section, click **Add domain**.
-3. Enter the domain (for example, `example.com`) and click **Add**.
-4. Mintlify generates a verification token. Add it as a DNS TXT record on the domain.
-5. Return to the dashboard and click **Verify**. The status changes from **Pending** to **Verified** once the record propagates.
+You can add up to five verified domains per organization.
+
+1. Navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
+2. On the **SSO** tab, in the **Verified domains** section, enter the domain (for example, `example.com`) and click **Add**.
+3. Mintlify generates a verification token. In your DNS provider, create a TXT record with the name `_mintlify-verification.example.com` and the token as the value. Some DNS providers append the domain automatically. If yours does, enter just `_mintlify-verification` as the record name.
+4. Return to the dashboard and click **Verify**. The status changes from **Pending** to **Verified** once the record propagates.
 
 To remove a domain, click the <Icon icon="trash" /> delete button beside it.
 
-## Breakglass emails
+## Require SSO
 
-Designate emergency-access accounts that can sign in even when SSO enforcement is on or your identity provider is unreachable. Use breakglass emails to recover access if your IdP has an outage or a misconfiguration locks members out.
+Organization admins can require everyone in the organization to sign in through your identity provider. When Require SSO is on, Mintlify rejects password, magic link, and Google OAuth sign-ins.
 
-1. Navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
-2. In the **Breakglass emails** section, add the email addresses of the org members who should retain non-SSO access.
-3. Click **Save changes**.
+1. Navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
+2. Confirm that SSO works end-to-end.
+3. On the **SSO** tab, in the **Sign-in policy** section, toggle **Require SSO** on.
+
+<Warning>
+  You can only require SSO after configuring an SSO connection. Requiring SSO does not check whether members can still sign in, so add break-glass access for at least one admin before turning it on.
+</Warning>
+
+To stop requiring SSO, toggle the setting off. Other sign-in methods become available again immediately.
+
+## Break-glass access
+
+Designate members who can bypass SSO and sign in with a password or magic link. Use break-glass access to recover access if your identity provider has an outage or a misconfiguration locks members out.
+
+1. Navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
+2. On the **SSO** tab, in the **Break-glass access** section, enter the email address of a member who should retain non-SSO access and click **Add**.
+
+Each break-glass email must belong to an existing member of your organization. Break-glass access only takes effect while Require SSO is on.
 
 <Tip>
-  Use breakglass emails for owner accounts that are not tied to your primary IdP, store the credentials in a secure password manager, and review the list whenever team membership changes.
+  Add break-glass access for admin accounts that are not tied to your primary identity provider, store the credentials in a secure password manager, and review the list whenever team membership changes.
 </Tip>
-
-Each breakglass email must already belong to a member of your organization. Members listed as breakglass can sign in with a password, magic link, or Google OAuth even when SSO enforcement is on.
 
 ## Map RBAC roles with SAML groups
 
@@ -193,7 +193,7 @@ Once configured, Mintlify maps the group names from the SAML assertion to roles 
 
 ## Change or remove SSO provider
 
-1. Navigate to the [Single Sign-On](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
+1. Navigate to the [Identity & access](https://app.mintlify.com/settings/organization/sso) page in your dashboard.
 2. Click **Configure**.
 3. Select your preferred SSO provider or no SSO.
 


### PR DESCRIPTION
## Documentation changes

Documents recent updates to SSO, per-user session revocation, and dashboard session lifetimes

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modified in this diff.
> 
> **Overview**
> Updates enterprise dashboard docs for **Identity & access** (replacing separate Network access / Single Sign-On navigation), **session lifetimes**, **per-member credential revocation**, and **audit log** categories.
> 
> **`network-access.mdx`** is reframed as **Dashboard access policies**: IP allowlist setup now points at the **Policies** tab on Identity & access, and a new **Session lifetimes** section documents maximum session age and idle timeout (5 minutes–14 days), including behavior when limits are tightened.
> 
> **`roles.mdx`** adds **Revoke a member's credentials** for admins—selective revocation of sessions, CLI tokens, API/discovery keys, M2M clients, and connected apps for offboarding or incident response.
> 
> **`sso.mdx`** renames navigation to Identity & access, reorders and rewrites **Verified domains** (DNS `_mintlify-verification` TXT), **Require SSO** (formerly enforce SSO-only), and **Break-glass access** (member-based, SSO-tab UI). **`audit-logs.mdx`** extends Member, Auth, and adds an **SSO** filter category. Vale adds **offboarding**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c7609c576fa21e216f899adc038c3074e0cc6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->