### PR TITLE
Document required HTTP methods for subpath proxies

### DIFF
--- a/deploy/reverse-proxy.mdx
+++ b/deploy/reverse-proxy.mdx
@@ -47,6 +47,8 @@ Proxy these paths to your Mintlify subdomain:
 | `/llms.txt` (optional)            | `<your-subdomain>.mintlify.site/docs/llms.txt` | No cache |
 | `/llms-full.txt` (optional)       | `<your-subdomain>.mintlify.site/docs/llms-full.txt` | No cache |
 
+Your proxy must forward all HTTP methods on documentation paths. Mintlify sends analytics events as `POST` requests to `/docs/_mintlify/api/v1/e`, so a proxy that only allows `GET` and `HEAD` requests silently breaks the analytics in your dashboard.
+
 Mintlify serves these files under your base path, like `<your-subdomain>.mintlify.site/docs/llms.txt`, so they are available on your domain under your subpath, like `your-domain.com/docs/llms.txt`, through your main subpath route.
 
 The `/.well-known/skills/*`, `/.well-known/agent-skills/*`, `/skill.md`, `/llms.txt`, and `/llms-full.txt` routes are optional. Include them only if you also want to serve these files at root paths on your domain, like `your-domain.com/llms.txt`. Note that each root path maps to the file under your base path on your Mintlify subdomain.

--- a/deploy/route53-cloudfront.mdx
+++ b/deploy/route53-cloudfront.mdx
@@ -34,6 +34,8 @@ Route traffic to this path with a Cache Policy of **CachingEnabled**:
 
 All Behaviors must have an **origin request policy** of `AllViewerExceptHostHeader`.
 
+The behaviors for your subpath must allow all HTTP methods. CloudFront only allows `GET` and `HEAD` requests by default, which blocks the `POST` requests that Mintlify uses for analytics and other interactive features.
+
 ![CloudFront "Behaviors" page with 4 behaviors: `/docs/*`, `/docs`, `Default`, and `/.well-known/*`.](/images/cloudfront/all-behaviors.png)
 
 ## Create CloudFront distribution
@@ -56,6 +58,10 @@ All Behaviors must have an **origin request policy** of `AllViewerExceptHostHead
   <Frame>
     ![Web Application Firewall (WAF) options with "Enable security protections" selected.](/images/cloudfront/enable-security-protections.png)
   </Frame>
+
+  <Note>
+    WAF rules can block the `POST` requests that Mintlify uses for analytics and other interactive features. If analytics stop appearing in your dashboard after enabling WAF, check your WAF logs for blocked requests to paths under `/docs/_mintlify/`.
+  </Note>
 
 5. The remaining settings should be default.
 6. Click **Create distribution**.
@@ -125,9 +131,14 @@ If `.well-known/*` is too generic, you can narrow it down to 2 behaviors at a mi
 
 Create a behavior with a **Path pattern** of your chosen subpath, for example `/docs`, with **Origin and origin groups** pointing to the `.mintlify.site` URL (for example, `acme.mintlify.site`).
 
-- Set "Cache policy" to **CachingOptimized**.
+- Set "Cache policy" to **CachingDisabled**.
 - Set "Origin request policy" to **AllViewerExceptHostHeader**.
 - Set "Viewer protocol policy" to **Redirect HTTP to HTTPS**.
+- Set "Allowed HTTP methods" to **GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE**.
+
+<Warning>
+  CloudFront only allows `GET` and `HEAD` requests by default. If you don't allow all HTTP methods, CloudFront rejects the `POST` requests that Mintlify uses for analytics, and your dashboard won't show any page views even though your docs load normally.
+</Warning>
 
 <Frame>
   ![CloudFront "Create behavior" page with a "Path pattern" of "/docs/*" and "Origin and origin groups" pointing to the `acme.mintlify.site` URL.](/images/cloudfront/behavior-1.png)
@@ -139,9 +150,10 @@ Create a behavior with a **Path pattern** of your chosen subpath followed by `/*
 
 These settings should exactly match your base subpath behavior, with the exception of the **Path pattern**.
 
-- Set "Cache policy" to **CachingOptimized**.
+- Set "Cache policy" to **CachingDisabled**.
 - Set "Origin request policy" to **AllViewerExceptHostHeader**.
 - Set "Viewer protocol policy" to **Redirect HTTP to HTTPS**.
+- Set "Allowed HTTP methods" to **GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE**.
 
 ### `/mintlify-assets/_next/static/*`
 


### PR DESCRIPTION
## Summary
CloudFront distributions default to allowing only GET and HEAD requests, which silently blocks the POST requests Mintlify uses for first-party analytics (`/docs/_mintlify/api/v1/e`). The AWS subpath guide's screenshots show the correct settings (all HTTP methods allowed, CachingDisabled), but the written steps never mention allowed methods and said CachingOptimized — so anyone following the text instead of the screenshots ends up with working docs but an empty analytics dashboard, while third-party analytics (GA4 etc.) keep working since browsers send those directly to the vendor.

Changes:
- **deploy/route53-cloudfront.mdx**: add "Allowed HTTP methods: GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE" to both subpath behavior sections, with a Warning describing the silent failure; add a Note that WAF rules can block the same POSTs; fix the cache policy in the behavior steps from CachingOptimized to CachingDisabled to match the Overview, the screenshots, and the reverse proxy page.
- **deploy/reverse-proxy.mdx**: add a paragraph in the routing configuration section stating proxies must forward all HTTP methods, naming the analytics endpoint.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment guides with no runtime or application code impact.
> 
> **Overview**
> Deployment guides now spell out that **subpath proxies must allow all HTTP methods**, not just `GET`/`HEAD`, because Mintlify analytics and other features use **`POST`** (e.g. `/docs/_mintlify/api/v1/e`). Restricting methods leaves docs working but **silently breaks dashboard analytics**.
> 
> **`deploy/reverse-proxy.mdx`** adds a routing note that proxies must forward all methods on documentation paths and names the analytics endpoint.
> 
> **`deploy/route53-cloudfront.mdx`** adds overview guidance on subpath behaviors, **Allowed HTTP methods** (`GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`) on both `/docs` and `/docs/*` behaviors with a **Warning** about the default CloudFront limitation, a **Note** that **WAF** can block the same POSTs under `/docs/_mintlify/`, and corrects written subpath steps from **CachingOptimized** to **CachingDisabled** so they match the overview, screenshots, and reverse-proxy docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7765741f5b0bf35b75bbb427dbc4026e066d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->