### PR TITLE
fix: editor PR titles/descriptions

### DIFF
--- a/editor/branching-and-publishing.mdx
+++ b/editor/branching-and-publishing.mdx
@@ -4,7 +4,7 @@ description: "Understand how branches and protection rules determine what happen
 keywords: ["editor", "branch", "publish", "pull request", "preview", "git", "merge", "deploy"]
 ---
 
-The web editor autosaves everything as you type, but your changes are only live when you choose to publish them. 
+The web editor autosaves everything as you type, but your changes are only live when you choose to publish them.
 
 What happens when you publish depends on two things: **which branch you're on** and **whether that branch requires pull requests**.
 
@@ -27,10 +27,10 @@ The editor tracks the following as pending changes:
 The actions available when you click the publish button depend on your current branch and whether it has branch protection rules that require pull requests.
 
 | Branch type | Branch protection | Available actions |
-|-------------|-------------------|-------------------|
-| <Tooltip headline="Deployment branch" tip="The branch that publishes to your live site, typically 'main'.">Deployment branch</Tooltip> | None | **Publish** directly to your live site |
+| --- | --- | --- |
+| <Tooltip tip="The branch that publishes to your live site, typically 'main'." headline="Deployment branch">Deployment branch</Tooltip> | None | **Publish** directly to your live site |
 | Deployment branch | Pull requests required | **Create branch** to move changes to a new branch |
-| <Tooltip headline="Feature branch" tip="An isolated branch where you work on updates before merging to your deployment branch.">Feature branch</Tooltip> | None | **Save in branch**, **Create pull request** |
+| <Tooltip tip="An isolated branch where you work on updates before merging to your deployment branch." headline="Feature branch">Feature branch</Tooltip> | None | **Save in branch**, **Create pull request** |
 | Feature branch | Pull requests required | **Save in branch**, **Create pull request** |
 
 - **Publish**: Commits and deploys your changes to your live site immediately.
@@ -55,9 +55,9 @@ If there are no pending changes, the editor disables the publish and save action
 ### Create a branch
 
 1. Click the branch name in the editor toolbar.
-1. Click **Create new branch**.
-1. If you have pending changes, choose whether to bring them to the new branch or leave them on the current branch.
-1. Enter a name and click **Create branch**.
+2. Click **Create new branch**.
+3. If you have pending changes, choose whether to bring them to the new branch or leave them on the current branch.
+4. Enter a name and click **Create branch**.
 
 <Tip>
   Use descriptive branch names so you can identify them and other people understand what each branch is for.
@@ -66,8 +66,8 @@ If there are no pending changes, the editor disables the publish and save action
 ### Switch branches
 
 1. Click the branch name in the toolbar.
-1. Search for or scroll to the branch you want.
-1. Click the branch to switch to it.
+2. Search for or scroll to the branch you want.
+3. Click the branch to switch to it.
 
 <Note>
   Switching branches while you have unpublished changes prompts you to bring those changes to the new branch or leave them behind. Changes left behind remain on your original branch.
@@ -84,11 +84,19 @@ Every time you save changes to a feature branch, Mintlify builds a preview deplo
 ### Access and share a preview
 
 1. Click **Publish** in the editor toolbar.
-1. In the publish menu, click the preview URL. The URL format is `organization-branch-name.mintlify.site`.
-    <Frame>
-      <img src="/images/editor/preview-url-light.png" alt="Preview URL emphasized in the publish menu." className="block dark:hidden" />
-      <img src="/images/editor/preview-url-dark.png" alt="Preview URL emphasized in the publish menu." className="hidden dark:block" />
-    </Frame>
+2. In the publish menu, click the preview URL. The URL format is `organization-branch-name.mintlify.site`.
+   <Frame>
+     <img
+       alt="Preview URL emphasized in the publish menu."
+       className="block dark:hidden"
+       src="/images/editor/preview-url-light.png"
+     />
+     <img
+       alt="Preview URL emphasized in the publish menu."
+       className="hidden dark:block"
+       src="/images/editor/preview-url-dark.png"
+     />
+   </Frame>
 
 Copy the URL and send it to reviewers. The preview updates automatically each time you save to the branch.
 
@@ -151,9 +159,9 @@ Either entry point opens the editor on the automation's branch with the changed 
 
 Only one publish can happen at a time per branch. If another team member publishes to the same branch, wait for the current publish to complete before trying again.
 
-### Commit messages
+### Pull request titles and descriptions
 
-When you publish, you can enter a commit message before confirming. If you leave it blank, the editor uses a default message that lists the files you created, updated, moved, or deleted.
+If your organization requires pull requests, you can enter a title and description when you publish. If you leave either blank, the editor uses a default message that lists the files you created, updated, moved, or deleted.
 
 ## Resolve conflicts
 
@@ -182,4 +190,3 @@ Non-overlapping changes apply automatically. If a remote change and your local e
 Sign commits with your GitHub account by authorizing it in your [account settings](https://app.mintlify.com/settings/account). Without authorization, the Mintlify GitHub App signs commits made in the web editor.
 
 For a reference of how editor actions map to Git operations, see [Git essentials](/editor/git-essentials#how-the-editor-maps-to-git).
-


### PR DESCRIPTION
## Summary
This update revises the guide for publishing content and managing branches in the editor. It clarifies you can edit PR titles/descriptions. Not commit messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a single MDX guide; no runtime, auth, or deployment logic changes.
> 
> **Overview**
> Updates **Branching and publishing** so publish-time metadata matches the product: the subsection is renamed from **Commit messages** to **Pull request titles and descriptions**, and the text now says that when pull requests are required you can set a **title** and **description** at publish (with the same default file-list fallback if either is left blank).
> 
> The rest of the diff is editorial/formatting in the same page—markdown table separator row, `Tooltip` attribute order, corrected numbered steps, multiline `<img>` tags, and minor whitespace/EOF cleanup—with no product or code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c538193fb0d0c063668f3d73697a775ddcf647d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->