### PR TITLE
Add editor drafts documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -91,6 +91,7 @@
                       "editor/pages",
                       "editor/navigation",
                       "editor/live-preview",
+                      "editor/drafts",
                       "editor/branching-and-publishing",
                       "editor/agent",
                       "editor/configurations",

--- a/editor/drafts.mdx
+++ b/editor/drafts.mdx
@@ -1,0 +1,93 @@
+---
+title: "Drafts"
+description: "Create isolated drafts in the web editor that stay unpublished until you request review and publish, without managing Git branches yourself."
+keywords: ["editor", "draft", "drafts", "publish", "request review", "pull request", "autosave"]
+---
+
+Use drafts to work on changes in the web editor without touching your live site. A draft is an isolated workspace where you edit, preview, and refine content. Your changes stay unpublished until you choose to publish them.
+
+Drafts are the recommended way to make changes in the web editor. Each draft has its own Git branch and pull request, but the editor manages those for you, so you can work without switching branches or opening pull requests by hand.
+
+## How drafts work
+
+**Every edit saves automatically.** As you type, the editor saves your work to Mintlify's servers, then commits it to the draft's branch in the background. Your changes persist across tabs, devices, and network interruptions.
+
+**Each draft tracks its own version history.** Because the editor commits your edits as you work, a draft builds up a history of changes on its branch and keeps an open pull request that reflects the current state of the draft.
+
+**Nothing goes live until you publish.** A draft never affects your live site while you edit it. You control when its changes deploy.
+
+**You can keep multiple drafts at once.** Work on several sets of changes in parallel, each in its own draft, and publish them independently.
+
+<Note>
+  Drafts are separate from the deployment branch that builds your live site. Editing a draft never changes your live site until you publish the draft.
+</Note>
+
+## Create a draft
+
+1. Click the deployment selector in the editor toolbar. It shows **Live site** when you're editing your deployment branch, or the draft's name when you're in a draft.
+2. Select the **Drafts** tab.
+3. Click **New draft**.
+
+The editor creates the draft and switches to it. New drafts start with the name "Untitled draft"—rename it so you and your teammates can identify it later.
+
+<Tip>
+  If your deployment branch requires pull requests, the editor prompts you to **Create a new draft** when you try to edit your live site directly. Create a draft to keep working.
+</Tip>
+
+## Switch between drafts
+
+1. Click the deployment selector in the editor toolbar.
+2. Select **Live site** to return to your deployment branch, or open the **Drafts** tab and choose a draft.
+
+The **Drafts** tab lists your drafts with the time each was last updated, most recent first. Use the search field to filter drafts by name.
+
+## Publish a draft
+
+When your draft is ready, open the publish menu to review your changes and publish. The available actions depend on whether your deployment branch requires review before changes go live.
+
+<Steps>
+  <Step title="Open the publish menu">
+    Click **Publish** in the editor toolbar. The menu lists every pending change in the draft. Click any change to review its diff.
+  </Step>
+  <Step title="Request review (if required)">
+    If your deployment branch requires review, click **Request review** to mark the draft's pull request ready for your team to review. Reviewers approve the pull request from the editor or from your Git provider.
+  </Step>
+  <Step title="Publish">
+    Click **Publish** to merge the draft into your deployment branch and deploy it. If review is required, **Publish** becomes available after the pull request is approved.
+
+    <Check>
+      After publishing, the editor confirms the draft has been published and offers to take you back to your deployment branch. Your live site updates once Mintlify builds and deploys the changes, which typically takes from 30 seconds to a few minutes.
+    </Check>
+  </Step>
+</Steps>
+
+<Note>
+  Only one publish can happen at a time per draft. If a publish is already in progress, wait for it to finish before publishing again.
+</Note>
+
+## Rename a draft
+
+1. Open the deployment selector and select the **Drafts** tab.
+2. Hover over the draft and click the rename (pencil) icon.
+3. Enter a new name and press <kbd>Enter</kbd>.
+
+Renaming a draft also updates the title of its pull request.
+
+## Delete a draft
+
+1. Open the deployment selector and select the **Drafts** tab.
+2. Hover over the draft and click the delete (trash) icon.
+3. Confirm the deletion.
+
+<Warning>
+  Deleting a draft permanently discards its unpublished changes and closes its pull request. This action cannot be undone.
+</Warning>
+
+## Drafts versus branches
+
+Drafts and branches both let you work on changes in isolation before publishing. Choose based on how your team works:
+
+- **Use drafts** if you want the editor to manage Git for you. Drafts are the simplest way to make changes without thinking about branches or pull requests.
+- **Use branches** if you follow a Git-based workflow and want to name branches, manage pull requests directly, or coordinate with changes made outside the editor. See [Branching and publishing](/editor/branching-and-publishing).
+
+Both tabs are available in the deployment selector, so you can move between the two approaches at any time.

--- a/editor/drafts.mdx
+++ b/editor/drafts.mdx
@@ -6,7 +6,7 @@ keywords: ["editor", "draft", "drafts", "publish", "request review", "pull reque
 
 Use drafts to work on changes in the web editor without touching your live site. A draft is an isolated workspace where you edit, preview, and refine content. Your changes stay unpublished until you choose to publish them.
 
-Drafts are the recommended way to make changes in the web editor. Each draft has its own Git branch and pull request, but the editor manages those for you, so you can work without switching branches or opening pull requests by hand.
+Drafts are the recommended way to make changes in the web editor. Each draft is backed by a Git branch and pull request that the editor manages for you, so you can work without switching branches or opening pull requests by hand.
 
 ## How drafts work
 

--- a/editor/index.mdx
+++ b/editor/index.mdx
@@ -35,6 +35,10 @@ keywords: ["editor", "visual", "collaborative", "web editor"]
 
 ## Explore the editor
 
+<Card title="Drafts" icon="file-pen" horizontal href="/editor/drafts">
+  Work on changes in an isolated draft that stays unpublished until you request review and publish.
+</Card>
+
 <Card title="Branching and publishing" icon="git-branch" horizontal href="/editor/branching-and-publishing">
   How branches and protection rules determine what happens when you publish, and how to manage the pull request review process.
 </Card>


### PR DESCRIPTION
## Documentation changes

Documents the web editor **Drafts** workflow, which shipped in the June 12, 2026 changelog but had no dedicated docs page.

New page `editor/drafts.mdx` covers:
- What a draft is and how it maps to a Git branch + pull request the editor manages for you
- Autosave/background autocommit and per-draft version history
- Creating, switching between, renaming, and deleting drafts from the deployment selector
- Publishing a draft: **Request review** (when the deployment branch requires review) → **Publish** (merge and deploy)
- When to use drafts versus branches

Also:
- Added `editor/drafts` to the Editor group in `docs.json` (after `editor/live-preview`, before `editor/branching-and-publishing`)
- Added a Drafts card to the editor overview (`editor/index.mdx`)

Content was derived from the drafts implementation in `mintlify/server` (`draft.controller.ts`, `draftMirror.service.ts`, `draft-autocommit-queue.ts`) and the dashboard editor UI in `mintlify/mint` (deployment dropdown, draft publish flow), so UI labels and behavior match the product.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful


Link to Devin session: https://app.devin.ai/sessions/cda7391119dd4d39a825f8ffee4bc7f1
Requested by: @cdxker

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code or config behavior changes.
> 
> **Overview**
> Adds a dedicated **Drafts** page for the web editor workflow that shipped without full docs coverage.
> 
> The new `editor/drafts.mdx` explains isolated drafts (editor-managed Git branch + PR), autosave/background commits, creating and switching drafts via the deployment selector, rename/delete, and publishing through **Request review** → **Publish** when branch protection applies. It also contrasts **drafts** vs manual **branches** and links to branching docs.
> 
> Navigation is wired in **`docs.json`** (`editor/drafts` after live preview, before branching) and the editor overview gets a **Drafts** card in **`editor/index.mdx`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 803694208142aa879de63702c115e2d78f28634e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->