### PR TITLE
test: slot lease validation a (do not merge)

### DIFF
--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -141,3 +141,5 @@ Contact your Mintlify account team to add Advanced Slack Support (Tier 2) or a D
 {/* vale Vale.Terms = YES */}
 
 PREVIEW-SLOT-TEST-A
+
+PREVIEW-SLOT-STICKY-2

--- a/advanced-support.mdx
+++ b/advanced-support.mdx
@@ -139,3 +139,5 @@ Mintlify will use commercially reasonable efforts to meet the following service 
 {/* vale Vale.Terms = NO */}
 Contact your Mintlify account team to add Advanced Slack Support (Tier 2) or a Dedicated CSM (Tier 3), or email gtm@mintlify.com.
 {/* vale Vale.Terms = YES */}
+
+PREVIEW-SLOT-TEST-A


### PR DESCRIPTION
Temporary PR validating sticky slot leases in prod (ENG-10131 follow-up, server#6618). Will be closed shortly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only test strings with no functional or security impact; intended to be reverted and not merged.
> 
> **Overview**
> Adds two plain-text markers at the end of **Get started** in `advanced-support.mdx`: `PREVIEW-SLOT-TEST-A` and `PREVIEW-SLOT-STICKY-2`. No support-tier copy or structure is changed.
> 
> This is a **temporary** change for sticky slot lease validation in prod (ENG-10131 / server#6618); the PR is not intended to merge and the lines should be removed after validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1cbedb0e8945c1d06074f478d23fbd8a5ac7a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->