### PR TITLE
Clarify default Vale config

### DIFF
--- a/deploy/ci.mdx
+++ b/deploy/ci.mdx
@@ -38,9 +38,16 @@ To see detailed results for broken links on a pull request, click the **Checks**
 Mintlify supports automatically running Vale in a CI check and displaying the results as a check status.
 
 #### Configuration
-If you have a `.vale.ini` file in the root content directory of your deployment, the Vale CI check uses that configuration file and any configuration files in your specified `stylesPath`.
+
+If you have a `.vale.ini` file in the root content directory of your deployment, the Vale CI check uses that configuration file and any configuration files in your specified `StylesPath`.
 
 If you don't have a Vale config file, the default configuration automatically loads.
+
+<Note>
+The default configuration runs in Mintlify's build environment, where `StylesPath = /app/styles` points to an internal directory. If you create your own `.vale.ini` file, use a relative path within your repository, such as `StylesPath = styles`.
+
+For security reasons, you cannot use absolute paths or paths containing `..` in your configuration files.
+</Note>
 
 ````mdx Default vale.ini configuration expandable
 # Top level styles
@@ -376,27 +383,21 @@ To add your own vocabulary for the default configuration, create a `styles/confi
     |- .vale.ini
     |- styles/
       |- config/
-      |- vocabularies/
-        |- Mintlify/
-          |- accept.txt
-          |- reject.txt
+        |- vocabularies/
+          |- Mintlify/
+            |- accept.txt
+            |- reject.txt
     |- example-page.mdx
   |- test/
 ```
 
-<Note>
-For security reasons, absolute `stylesPath`, or `stylesPath` which include `..` values aren't supported.
-
-Use relative paths and include the `stylesPath` in your repository.
-</Note>
-
 #### Packages
-Vale supports a range of [packages](https://vale.sh/docs/keys/packages) that check for spelling and style errors. Any packages you include in your repository under the correct `stylesPath` automatically install and run with your Vale configuration.
+Vale supports a range of [packages](https://vale.sh/docs/keys/packages) that check for spelling and style errors. Any packages you include in your repository under the correct `StylesPath` automatically install and run with your Vale configuration.
 
 For packages not included in your repository, you may specify any packages from the [Vale package registry](https://vale.sh/explorer), and they're automatically downloaded and used in your Vale configuration.
 
 <Note>
-For security reasons, automatically downloading packages that aren't from the [Vale package registry](https://vale.sh/explorer) is **not** supported.
+For security reasons, you cannot automatically download packages that aren't from the [Vale package registry](https://vale.sh/explorer).
 </Note>
 
 #### Vale with `MDX`


### PR DESCRIPTION
## Documentation changes

This explains the default Vale config example and what to change if people copy and reuse it.

Closes https://linear.app/mintlify/issue/DOC-394/clarify-stylespath-note-on-vale-ci-page

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `deploy/ci.mdx` with no runtime or security behavior changes.
> 
> **Overview**
> Updates the **Vale** section on the CI checks page so readers understand the shipped default `vale.ini` versus what they should use in their own repo.
> 
> A new **Note** explains that `StylesPath = /app/styles` in the default example is Mintlify’s internal build path, and that a custom `.vale.ini` should use a **relative** path (for example `StylesPath = styles`). The same note now carries the security guidance on disallowed absolute paths and `..`, replacing a separate note that appeared later in the section.
> 
> Prose is aligned with Vale’s config key casing (`StylesPath` instead of `stylesPath`), the monorepo directory tree indentation for `styles/config/vocabularies` is corrected, and the package-registry security note is tightened slightly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5b02b223f73f83fdd40935acecb062c3be8c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->