### PR TITLE
Clarify which API key type each endpoint requires

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -20,7 +20,7 @@
       "post": {
         "summary": "Create agent job (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 create agent job](/api/agent/v2/create-agent-job) instead. Creates a new agent job that can generate and edit documentation based on provided messages and branch information.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Deprecated: use [v2 create agent job](/api/agent/v2/create-agent-job) instead. Creates a new agent job that can generate and edit documentation based on provided messages and branch information.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -117,7 +117,7 @@
       "get": {
         "summary": "Get agent job by ID (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves the details and status of a specific agent job by its ID.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves the details and status of a specific agent job by its ID.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -228,7 +228,7 @@
       "get": {
         "summary": "Get all agent jobs (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves all agent jobs for the specified domain, including their status and details.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves all agent jobs for the specified domain, including their status and details.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -361,7 +361,7 @@
     "/v2/agent/{projectId}/job": {
       "post": {
         "summary": "Create agent job",
-        "description": "Creates a new agent job that runs in the background. The job processes the prompt asynchronously — poll the get job endpoint to track progress. If the agent edits files successfully, a pull request is automatically created.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Creates a new agent job that runs in the background. The job processes the prompt asynchronously — poll the get job endpoint to track progress. If the agent edits files successfully, a pull request is automatically created.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -428,7 +428,7 @@
     "/v2/agent/{projectId}/job/{id}": {
       "get": {
         "summary": "Get agent job",
-        "description": "Retrieves the current status and details of an agent job. Poll this endpoint to track job progress.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Retrieves the current status and details of an agent job. Poll this endpoint to track job progress.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -476,7 +476,7 @@
     "/v2/agent/{projectId}/job/{id}/message": {
       "post": {
         "summary": "Send follow-up message",
-        "description": "Sends a follow-up message to an existing agent job. The message is processed asynchronously — poll the get job endpoint to track progress.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Sends a follow-up message to an existing agent job. The message is processed asynchronously — poll the get job endpoint to track progress.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -627,7 +627,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key. This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     }
   }

--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -20,7 +20,7 @@
       "post": {
         "summary": "Create agent job (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 create agent job](/api/agent/v2/create-agent-job) instead. Creates a new agent job that can generate and edit documentation based on provided messages and branch information.",
+        "description": "Deprecated: use [v2 create agent job](/api/agent/v2/create-agent-job) instead. Creates a new agent job that can generate and edit documentation based on provided messages and branch information.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -117,7 +117,7 @@
       "get": {
         "summary": "Get agent job by ID (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves the details and status of a specific agent job by its ID.",
+        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves the details and status of a specific agent job by its ID.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -228,7 +228,7 @@
       "get": {
         "summary": "Get all agent jobs (v1)",
         "deprecated": true,
-        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves all agent jobs for the specified domain, including their status and details.",
+        "description": "Deprecated: use [v2 get agent job](/api/agent/v2/get-agent-job) instead. Retrieves all agent jobs for the specified domain, including their status and details.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -361,7 +361,7 @@
     "/v2/agent/{projectId}/job": {
       "post": {
         "summary": "Create agent job",
-        "description": "Creates a new agent job that runs in the background. The job processes the prompt asynchronously — poll the get job endpoint to track progress. If the agent edits files successfully, a pull request is automatically created.",
+        "description": "Creates a new agent job that runs in the background. The job processes the prompt asynchronously — poll the get job endpoint to track progress. If the agent edits files successfully, a pull request is automatically created.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -428,7 +428,7 @@
     "/v2/agent/{projectId}/job/{id}": {
       "get": {
         "summary": "Get agent job",
-        "description": "Retrieves the current status and details of an agent job. Poll this endpoint to track job progress.",
+        "description": "Retrieves the current status and details of an agent job. Poll this endpoint to track job progress.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -476,7 +476,7 @@
     "/v2/agent/{projectId}/job/{id}/message": {
       "post": {
         "summary": "Send follow-up message",
-        "description": "Sends a follow-up message to an existing agent job. The message is processed asynchronously — poll the get job endpoint to track progress.",
+        "description": "Sends a follow-up message to an existing agent job. The message is processed asynchronously — poll the get job endpoint to track progress.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",

--- a/analytics.openapi.json
+++ b/analytics.openapi.json
@@ -16,7 +16,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key. This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     },
     "schemas": {
@@ -646,7 +646,7 @@
     "/v1/analytics/{projectId}/feedback": {
       "get": {
         "summary": "Get user feedback",
-        "description": "Returns paginated user feedback with optional filtering\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns paginated user feedback with optional filtering\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -762,7 +762,7 @@
     "/v1/analytics/{projectId}/feedback/by-page": {
       "get": {
         "summary": "Get feedback by page",
-        "description": "Returns feedback counts aggregated by documentation page path (thumbs up/down for contextual feedback, code snippet count, and total per page)\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns feedback counts aggregated by documentation page path (thumbs up/down for contextual feedback, code snippet count, and total per page)\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -869,7 +869,7 @@
     "/v1/analytics/{projectId}/assistant": {
       "get": {
         "summary": "Get assistant conversations",
-        "description": "Returns paginated AI assistant conversation history\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns paginated AI assistant conversation history\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -962,7 +962,7 @@
     "/v1/analytics/{projectId}/assistant/caller-stats": {
       "get": {
         "summary": "Get assistant caller stats",
-        "description": "Returns a breakdown of assistant query counts by caller type (web, API, and other) for the specified date range.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns a breakdown of assistant query counts by caller type (web, API, and other) for the specified date range.\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -1033,7 +1033,7 @@
     "/v1/analytics/{projectId}/searches": {
       "get": {
         "summary": "Get search queries",
-        "description": "Returns paginated documentation search terms for the date range, ordered by hit count descending. Each row includes click-through rate, the most-clicked result path for that query (if any), and the last time the term was searched. `totalSearches` is the total number of search query events in the same date range (sum of all hits, not distinct queries).\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns paginated documentation search terms for the date range, ordered by hit count descending. Each row includes click-through rate, the most-clicked result path for that query (if any), and the last time the term was searched. `totalSearches` is the total number of search query events in the same date range (sum of all hits, not distinct queries).\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -1125,7 +1125,7 @@
     "/v1/analytics/{projectId}/views": {
       "get": {
         "summary": "Get page views",
-        "description": "Returns per-path and site-wide content view event counts, split by human and AI traffic.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns per-path and site-wide content view event counts, split by human and AI traffic.\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],
@@ -1219,7 +1219,7 @@
     "/v1/analytics/{projectId}/visitors": {
       "get": {
         "summary": "Get unique visitors",
-        "description": "Returns per-path and site-wide approximate distinct visitors by traffic type. The `total` field is deduplicated across human and AI (union of distinct visitor IDs with any qualifying content view).\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Returns per-path and site-wide approximate distinct visitors by traffic type. The `total` field is deduplicated across human and AI (union of distinct visitor IDs with any qualifying content view).\n\nAuthenticate with an admin API key.",
         "tags": [
           "Analytics"
         ],

--- a/analytics.openapi.json
+++ b/analytics.openapi.json
@@ -646,7 +646,7 @@
     "/v1/analytics/{projectId}/feedback": {
       "get": {
         "summary": "Get user feedback",
-        "description": "Returns paginated user feedback with optional filtering",
+        "description": "Returns paginated user feedback with optional filtering\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -762,7 +762,7 @@
     "/v1/analytics/{projectId}/feedback/by-page": {
       "get": {
         "summary": "Get feedback by page",
-        "description": "Returns feedback counts aggregated by documentation page path (thumbs up/down for contextual feedback, code snippet count, and total per page)",
+        "description": "Returns feedback counts aggregated by documentation page path (thumbs up/down for contextual feedback, code snippet count, and total per page)\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -869,7 +869,7 @@
     "/v1/analytics/{projectId}/assistant": {
       "get": {
         "summary": "Get assistant conversations",
-        "description": "Returns paginated AI assistant conversation history",
+        "description": "Returns paginated AI assistant conversation history\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -962,7 +962,7 @@
     "/v1/analytics/{projectId}/assistant/caller-stats": {
       "get": {
         "summary": "Get assistant caller stats",
-        "description": "Returns a breakdown of assistant query counts by caller type (web, API, and other) for the specified date range.",
+        "description": "Returns a breakdown of assistant query counts by caller type (web, API, and other) for the specified date range.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -1033,7 +1033,7 @@
     "/v1/analytics/{projectId}/searches": {
       "get": {
         "summary": "Get search queries",
-        "description": "Returns paginated documentation search terms for the date range, ordered by hit count descending. Each row includes click-through rate, the most-clicked result path for that query (if any), and the last time the term was searched. `totalSearches` is the total number of search query events in the same date range (sum of all hits, not distinct queries).",
+        "description": "Returns paginated documentation search terms for the date range, ordered by hit count descending. Each row includes click-through rate, the most-clicked result path for that query (if any), and the last time the term was searched. `totalSearches` is the total number of search query events in the same date range (sum of all hits, not distinct queries).\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -1125,7 +1125,7 @@
     "/v1/analytics/{projectId}/views": {
       "get": {
         "summary": "Get page views",
-        "description": "Returns per-path and site-wide content view event counts, split by human and AI traffic.",
+        "description": "Returns per-path and site-wide content view event counts, split by human and AI traffic.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],
@@ -1219,7 +1219,7 @@
     "/v1/analytics/{projectId}/visitors": {
       "get": {
         "summary": "Get unique visitors",
-        "description": "Returns per-path and site-wide approximate distinct visitors by traffic type. The `total` field is deduplicated across human and AI (union of distinct visitor IDs with any qualifying content view).",
+        "description": "Returns per-path and site-wide approximate distinct visitors by traffic type. The `total` field is deduplicated across human and AI (union of distinct visitor IDs with any qualifying content view).\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "tags": [
           "Analytics"
         ],

--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -19,7 +19,7 @@
     "/v1/assistant/{domain}/message": {
       "post": {
         "summary": "Assistant message v1",
-        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v4.",
+        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v4.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
         "parameters": [
           {
             "name": "domain",
@@ -455,7 +455,7 @@
     "/v2/assistant/{domain}/message": {
       "post": {
         "summary": "Assistant message",
-        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v5+.",
+        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v5+.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
         "parameters": [
           {
             "name": "domain",
@@ -743,7 +743,7 @@
     "/v1/page/{domain}": {
       "post": {
         "summary": "Get page content",
-        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.",
+        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
         "parameters": [
           {
             "name": "domain",
@@ -822,7 +822,7 @@
           }
         },
         "summary": "Search documentation",
-        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.",
+        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
         "parameters": [
           {
             "name": "domain",
@@ -921,7 +921,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an assistant API key (prefixed with `mint_dsc_`). This is a public key safe for use in client-side code. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an assistant API key (prefixed with `mint_dsc_`). Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard. In production, proxy requests through your backend rather than embedding the key in client-side code."
       }
     }
   }

--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -19,7 +19,7 @@
     "/v1/assistant/{domain}/message": {
       "post": {
         "summary": "Assistant message v1",
-        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v4.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
+        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v4.\n\nAuthenticate with an assistant API key.",
         "parameters": [
           {
             "name": "domain",
@@ -455,7 +455,7 @@
     "/v2/assistant/{domain}/message": {
       "post": {
         "summary": "Assistant message",
-        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v5+.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
+        "description": "Generates a response message from the assistant for the specified domain. Compatible with AI SDK v5+.\n\nAuthenticate with an assistant API key.",
         "parameters": [
           {
             "name": "domain",
@@ -743,7 +743,7 @@
     "/v1/page/{domain}": {
       "post": {
         "summary": "Get page content",
-        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
+        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.\n\nAuthenticate with an assistant API key.",
         "parameters": [
           {
             "name": "domain",
@@ -822,7 +822,7 @@
           }
         },
         "summary": "Search documentation",
-        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.\n\nAuthenticate with an assistant API key, prefixed with `mint_dsc_`.",
+        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.\n\nAuthenticate with an assistant API key.",
         "parameters": [
           {
             "name": "domain",
@@ -921,7 +921,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an assistant API key (prefixed with `mint_dsc_`). Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard. In production, proxy requests through your backend rather than embedding the key in client-side code."
+        "description": "The Authorization header expects a Bearer token. Use an assistant API key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard. In production, proxy requests through your backend rather than embedding the key in client-side code."
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
     "/project/update/{projectId}": {
       "post": {
         "summary": "Trigger update",
-        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. The update is triggered from your configured deployment branch.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. The update is triggered from your configured deployment branch.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -57,7 +57,7 @@
     "/project/update-status/{statusId}": {
       "get": {
         "summary": "Get update status",
-        "description": "Get the status of an update from the status ID\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Get the status of an update from the status ID\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "statusId",
@@ -218,7 +218,7 @@
     "/project/preview/{projectId}": {
       "post": {
         "summary": "Trigger preview deployment",
-        "description": "Create or update a preview deployment for a specific branch. If a preview already exists for the branch, it triggers a redeployment. Returns a status ID to track progress and the preview URL.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Create or update a preview deployment for a specific branch. If a preview already exists for the branch, it triggers a redeployment. Returns a status ID to track progress and the preview URL.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -307,7 +307,7 @@
     "/workflow/{projectId}/{workflowSchemaId}/trigger": {
       "post": {
         "summary": "Trigger automation",
-        "description": "Trigger a scheduled automation to run immediately, instead of waiting for its next scheduled time. Useful for running automations from CI/CD pipelines, like a GitHub Action that runs on every merge to your default branch. Only scheduled (custom schedule) automations can be triggered. The run picks up changes since the last completed run, identical to a regular scheduled run.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Trigger a scheduled automation to run immediately, instead of waiting for its next scheduled time. Useful for running automations from CI/CD pipelines, like a GitHub Action that runs on every merge to your default branch. Only scheduled (custom schedule) automations can be triggered. The run picks up changes since the last completed run, identical to a regular scheduled run.\n\nAuthenticate with an admin API key.",
         "parameters": [
           {
             "name": "projectId",
@@ -392,7 +392,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key. This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     }
   }

--- a/openapi.json
+++ b/openapi.json
@@ -22,7 +22,7 @@
     "/project/update/{projectId}": {
       "post": {
         "summary": "Trigger update",
-        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. The update is triggered from your configured deployment branch.",
+        "description": "Queue a deployment update for your documentation project. Returns a status ID that can be used to track the update progress. The update is triggered from your configured deployment branch.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -57,7 +57,7 @@
     "/project/update-status/{statusId}": {
       "get": {
         "summary": "Get update status",
-        "description": "Get the status of an update from the status ID",
+        "description": "Get the status of an update from the status ID\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "statusId",
@@ -218,7 +218,7 @@
     "/project/preview/{projectId}": {
       "post": {
         "summary": "Trigger preview deployment",
-        "description": "Create or update a preview deployment for a specific branch. If a preview already exists for the branch, it triggers a redeployment. Returns a status ID to track progress and the preview URL.",
+        "description": "Create or update a preview deployment for a specific branch. If a preview already exists for the branch, it triggers a redeployment. Returns a status ID to track progress and the preview URL.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",
@@ -307,7 +307,7 @@
     "/workflow/{projectId}/{workflowSchemaId}/trigger": {
       "post": {
         "summary": "Trigger automation",
-        "description": "Trigger a scheduled automation to run immediately, instead of waiting for its next scheduled time. Useful for running automations from CI/CD pipelines, like a GitHub Action that runs on every merge to your default branch. Only scheduled (custom schedule) automations can be triggered. The run picks up changes since the last completed run, identical to a regular scheduled run.",
+        "description": "Trigger a scheduled automation to run immediately, instead of waiting for its next scheduled time. Useful for running automations from CI/CD pipelines, like a GitHub Action that runs on every merge to your default branch. Only scheduled (custom schedule) automations can be triggered. The run picks up changes since the last completed run, identical to a regular scheduled run.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "parameters": [
           {
             "name": "projectId",

--- a/static-export-openapi.json
+++ b/static-export-openapi.json
@@ -19,7 +19,7 @@
     "/static-export/jobs": {
       "post": {
         "summary": "Start static export job",
-        "description": "Start a static export job for a deployment. The job pre-renders your documentation into a self-contained set of static HTML, RSC, and asset files. Returns a job ID you can use to poll status and, once complete, generate a downloadable bundle.\n\nStatic export is available on Enterprise plans.",
+        "description": "Start a static export job for a deployment. The job pre-renders your documentation into a self-contained set of static HTML, RSC, and asset files. Returns a job ID you can use to poll status and, once complete, generate a downloadable bundle.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "operationId": "startStaticExportJob",
         "requestBody": {
           "required": true,
@@ -78,7 +78,7 @@
     "/static-export/jobs/{jobId}": {
       "get": {
         "summary": "Get static export job status",
-        "description": "Retrieve the current status and progress of a static export job. Poll this endpoint after starting a job until `status` is `completed` (or `failed`).\n\nStatic export is available on Enterprise plans.",
+        "description": "Retrieve the current status and progress of a static export job. Poll this endpoint after starting a job until `status` is `completed` (or `failed`).\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "operationId": "getStaticExportJob",
         "parameters": [
           {
@@ -128,7 +128,7 @@
     "/static-export/jobs/{jobId}/bundle": {
       "post": {
         "summary": "Generate export bundle",
-        "description": "Package a completed static export job into a single archive and return a download link. The link is a presigned S3 URL — download it before `expiresAt`.\n\nThe job must have a `status` of `completed` before a bundle can be generated.\n\nStatic export is available on Enterprise plans.",
+        "description": "Package a completed static export job into a single archive and return a download link. The link is a presigned S3 URL — download it before `expiresAt`.\n\nThe job must have a `status` of `completed` before a bundle can be generated.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
         "operationId": "generateStaticExportBundle",
         "parameters": [
           {
@@ -191,7 +191,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Admin API key. Generate one on the API keys page in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     },
     "schemas": {

--- a/static-export-openapi.json
+++ b/static-export-openapi.json
@@ -19,7 +19,7 @@
     "/static-export/jobs": {
       "post": {
         "summary": "Start static export job",
-        "description": "Start a static export job for a deployment. The job pre-renders your documentation into a self-contained set of static HTML, RSC, and asset files. Returns a job ID you can use to poll status and, once complete, generate a downloadable bundle.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Start a static export job for a deployment. The job pre-renders your documentation into a self-contained set of static HTML, RSC, and asset files. Returns a job ID you can use to poll status and, once complete, generate a downloadable bundle.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key.",
         "operationId": "startStaticExportJob",
         "requestBody": {
           "required": true,
@@ -78,7 +78,7 @@
     "/static-export/jobs/{jobId}": {
       "get": {
         "summary": "Get static export job status",
-        "description": "Retrieve the current status and progress of a static export job. Poll this endpoint after starting a job until `status` is `completed` (or `failed`).\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Retrieve the current status and progress of a static export job. Poll this endpoint after starting a job until `status` is `completed` (or `failed`).\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key.",
         "operationId": "getStaticExportJob",
         "parameters": [
           {
@@ -128,7 +128,7 @@
     "/static-export/jobs/{jobId}/bundle": {
       "post": {
         "summary": "Generate export bundle",
-        "description": "Package a completed static export job into a single archive and return a download link. The link is a presigned S3 URL — download it before `expiresAt`.\n\nThe job must have a `status` of `completed` before a bundle can be generated.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key, prefixed with `mint_`.",
+        "description": "Package a completed static export job into a single archive and return a download link. The link is a presigned S3 URL — download it before `expiresAt`.\n\nThe job must have a `status` of `completed` before a bundle can be generated.\n\nStatic export is available on Enterprise plans.\n\nAuthenticate with an admin API key.",
         "operationId": "generateStaticExportBundle",
         "parameters": [
           {
@@ -191,7 +191,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "The Authorization header expects a Bearer token. Use an admin API key (prefixed with `mint_`). This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
+        "description": "The Authorization header expects a Bearer token. Use an admin API key. This is a server-side secret key. Generate one on the [API keys page](https://app.mintlify.com/settings/organization/api-keys) in your dashboard."
       }
     },
     "schemas": {


### PR DESCRIPTION
## What changed

Every operation description across the five OpenAPI specs now ends with a line stating which key authenticates it:

- `openapi.json`, `admin-openapi.json`, `analytics.openapi.json`, `static-export-openapi.json`: *Authenticate with an admin API key.*
- `discovery-openapi.json`: *Authenticate with an assistant API key.*

Two security-scheme fixes along the way:

- `discovery-openapi.json` claimed the assistant key is "a public key safe for use in client-side code," contradicting the warning in `api/introduction.mdx` (proxy in production; keys consume credits). It now matches the docs guidance.
- `static-export-openapi.json`'s one-line scheme description now matches the fuller wording the other admin specs use.

## Why

The dashboard offers two key types but endpoint pages didn't say which one they take. Companion dashboard-copy change: mintlify/mint#9112.

## Verification

All five specs pass `mint openapi-check`; diffs touch only description strings.