### PR TITLE
Add deslop endpoint to Admin API spec

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -16,6 +16,76 @@
     }
   ],
   "paths": {
+    "/v1/deslop/{projectId}": {
+      "post": {
+        "summary": "Detect AI-sounding prose in a page",
+        "description": "Analyzes a documentation page for AI-generated prose and returns flagged passages with suggested human rewrites. Consumes one AI credit per checked page. Pages under 50 words are skipped and not charged.",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Your project ID. Can be copied from the [API keys](https://app.mintlify.com/settings/organization/api-keys) page in your dashboard."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["path", "content"],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Repo-relative path of the page, used for reporting only."
+                  },
+                  "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The raw MDX or Markdown content of the page to check."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The page was checked, or skipped because it was too short.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/DeslopResult" } }
+            }
+          },
+          "400": {
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          },
+          "402": {
+            "description": "Insufficient AI credits.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          },
+          "503": {
+            "description": "Detection is temporarily unavailable. No credit is charged.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          }
+        }
+      }
+    },
     "/v1/agent/{projectId}/job": {
       "post": {
         "summary": "Create agent job (v1)",
@@ -562,6 +632,57 @@
   },
   "components": {
     "schemas": {
+      "DeslopResult": {
+        "type": "object",
+        "required": ["path", "skipped", "creditsCharged"],
+        "properties": {
+          "path": { "type": "string", "description": "The path from the request." },
+          "skipped": {
+            "type": "string",
+            "nullable": true,
+            "enum": ["too_short", null],
+            "description": "Reason the page was skipped, or null when the page was checked. `too_short` means the page had fewer than 50 words of prose and was not charged."
+          },
+          "predictionShort": {
+            "type": "string",
+            "enum": ["AI", "AI-Assisted", "Human", "Mixed"],
+            "description": "Overall verdict for the page. Present only when the page was checked."
+          },
+          "fractionAi": { "type": "number", "description": "Fraction of the page detected as AI-generated (0-1)." },
+          "fractionAiAssisted": { "type": "number", "description": "Fraction detected as AI-assisted (0-1)." },
+          "fractionHuman": { "type": "number", "description": "Fraction detected as human-written (0-1)." },
+          "windows": {
+            "type": "array",
+            "description": "Flagged (non-human) passages. Present only when the page was checked.",
+            "items": { "$ref": "#/components/schemas/DeslopWindow" }
+          },
+          "creditsCharged": { "type": "integer", "description": "AI credits charged for this request (0 when skipped)." }
+        }
+      },
+      "DeslopWindow": {
+        "type": "object",
+        "required": ["text", "label", "aiAssistanceScore", "startLine", "endLine"],
+        "properties": {
+          "text": { "type": "string", "description": "The flagged passage text." },
+          "label": { "type": "string", "description": "Detection label for the passage, for example `AI-Generated`." },
+          "aiAssistanceScore": { "type": "number", "description": "AI-assistance score for the passage (0-1)." },
+          "confidence": { "type": "string", "description": "Detection confidence, for example `High`." },
+          "startLine": { "type": "integer", "description": "1-based start line of the passage in the original content." },
+          "endLine": { "type": "integer", "description": "1-based end line of the passage in the original content." },
+          "rewrites": {
+            "type": "array",
+            "description": "Suggested human rewrites of the passage.",
+            "items": {
+              "type": "object",
+              "required": ["text", "rationale"],
+              "properties": {
+                "text": { "type": "string", "description": "The rewritten passage." },
+                "rationale": { "type": "string", "description": "Why the rewrite reads more human." }
+              }
+            }
+          }
+        }
+      },
       "AgentJob": {
         "type": "object",
         "properties": {

--- a/api/admin/deslop.mdx
+++ b/api/admin/deslop.mdx
@@ -1,0 +1,31 @@
+---
+title: "Detect AI-sounding prose"
+openapi: /admin-openapi.json POST /v1/deslop/{projectId}
+keywords: ["deslop", "AI detection", "slop", "prose", "content quality"]
+---
+
+This endpoint analyzes a documentation page for AI-generated prose and returns flagged passages with suggested human rewrites.
+
+Authenticate with an [admin API key](/api/introduction#admin-api-key).
+
+## Credits
+
+- Consumes 1 AI credit per checked page.
+- Pages under 50 words are skipped and not charged. The response returns `skipped: "too_short"` with `creditsCharged: 0`.
+- If detection is temporarily unavailable, the endpoint returns `503` and no credit is charged.
+
+## Response
+
+Checked pages return a verdict (`predictionShort`), AI and human fractions, and a `windows` array of flagged passages. Each window includes a line range and a suggested rewrite.
+
+## Usage
+
+```bash
+curl -X POST https://api.mintlify.com/v1/deslop/{projectId} \
+  -H "Authorization: Bearer mint_xxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "guides/quickstart.mdx",
+    "content": "# Quickstart\n\nWelcome to our comprehensive documentation..."
+  }'
+```

--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -17,6 +17,7 @@ The Mintlify REST (Representational State Transfer) API enables you to programma
 - [Get update status](/api/update/status): Get the status of an update and other details about your docs.
 - [Trigger preview deployment](/api/preview/trigger): Create or update a preview deployment for a specific branch.
 - [Trigger automation](/api/automations/trigger): Run a scheduled automation on demand.
+- [Detect AI-sounding prose](/api/admin/deslop): Analyze a page for AI-generated prose and get suggested human rewrites.
 - [Create agent job](/api/agent/v2/create-agent-job): Create an agent job to automatically edit your documentation.
 - [Get agent job](/api/agent/v2/get-agent-job): Retrieve the details and status of a specific agent job.
 - [Send follow-up message](/api/agent/v2/send-message): Send a follow-up message to an existing agent job.
@@ -62,6 +63,7 @@ Use the admin API key for deployment, triggering the agent, and analytics endpoi
 - [Get update status](/api/update/status)
 - [Trigger preview deployment](/api/preview/trigger)
 - [Trigger automation](/api/automations/trigger)
+- [Detect AI-sounding prose](/api/admin/deslop)
 - [Create agent job](/api/agent/v2/create-agent-job)
 - [Get agent job](/api/agent/v2/get-agent-job)
 - [Send follow-up message](/api/agent/v2/send-message)

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -324,6 +324,47 @@ The overall score uses weighted scoring, so higher-impact checks contribute more
 
 ---
 
+## `mint deslop`
+
+Check documentation pages for AI-sounding prose and get rewrite suggestions. Requires authentication with `mint login`.
+
+```bash
+mint deslop [files...] [flags]
+```
+
+| Argument | Description |
+| --- | --- |
+| `files` | Optional. Paths or globs to check. If omitted, the command checks the `.md` and `.mdx` pages that changed in your working tree (Git diff plus untracked files). |
+
+| Flag | Description |
+| --- | --- |
+| `--format` | Output format: `table` (default, colored), `plain` (pipeable), or `json`. |
+| `--subdomain` | Documentation subdomain to check against. Defaults to your configured subdomain. |
+| `--threshold` | Fail a page when its AI-written fraction meets this value, from `0` to `1`. Defaults to `0.5`. |
+| `--fix-whitespace` | Normalize prose whitespace in the checked files (trailing spaces, blank-line runs, and invisible Unicode characters). Skips code blocks and frontmatter. |
+
+For each flagged page, the command reports the AI-written fraction, the specific passages that read as AI-generated with their line numbers, and suggested human-style rewrites.
+
+Each checked page consumes one AI credit. Pages under 50 words are skipped and not charged. The command exits with code `1` when any page is flagged at or above the threshold and `0` when every page is clean, so you can run it in a rewrite loop or in CI.
+
+### Examples
+
+```bash
+# Check pages changed in your working tree
+mint deslop
+
+# Check a specific page
+mint deslop docs/guide.mdx
+
+# Check every MDX page and emit JSON for scripting
+mint deslop "docs/**/*.mdx" --format json
+
+# Also clean up whitespace in the checked files
+mint deslop docs/guide.mdx --fix-whitespace
+```
+
+---
+
 ## `mint new`
 
 Create a new documentation project by picking a theme or cloning a pre-defined template from the [mintlify/templates](https://github.com/mintlify/templates) repository.

--- a/cli/index.mdx
+++ b/cli/index.mdx
@@ -32,6 +32,9 @@ Run `mint broken-links` to find broken links, `mint a11y` to check accessibility
 ### Check agent readiness
 Run `mint score` to evaluate how well agents can navigate a documentation site. With no arguments, the command scores your configured subdomain. Pass a URL to score any other site. The command displays an overall readiness score and individual check results.
 
+### Detect AI-sounding prose
+Run `mint deslop` to check pages for AI-generated prose and get human-style rewrite suggestions. With no arguments, the command checks the pages you have changed. It flags the specific passages that read as AI-generated so you can revise them.
+
 ### Manage configuration
 Run `mint config` to set persistent defaults like your documentation subdomain.
 

--- a/docs.json
+++ b/docs.json
@@ -386,7 +386,8 @@
                   "api/update/trigger",
                   "api/update/status",
                   "api/preview/trigger",
-                  "api/automations/trigger"
+                  "api/automations/trigger",
+                  "api/admin/deslop"
                 ]
               },
               {


### PR DESCRIPTION
## What

Documents the new `POST /v1/deslop/{projectId}` Admin API endpoint in `admin-openapi.json`.

Backend: mintlify/server#6593 (exposes deslop via admin API key on `/external/v1/deslop/:projectId`, gated by `ADMIN_API_ACCESS`).

## Endpoint

- **Auth**: admin API key (bearer), same as the rest of the Admin API.
- **Request**: `{ path, content }` — repo-relative path (reporting only) + raw MDX/Markdown.
- **Response**: `DeslopResult` — either a checked page (`predictionShort`, AI fractions, flagged `windows[]` with suggested rewrites, `creditsCharged: 1`) or a skipped page (`skipped: "too_short"`, `creditsCharged: 0`).
- **Errors**: 400 bad body, 402 insufficient credits, 429 rate limit, 503 detection unavailable (no charge).
- Consumes 1 AI credit per checked page; pages under 50 words are skipped free.

## Notes

- English-only edit to the spec; translations handled automatically on merge.
- Merge after the server PR deploys, since the endpoint won't exist until then.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI spec only; no runtime code. Accuracy depends on the server endpoint matching the spec after deploy.
> 
> **Overview**
> This PR adds **public documentation** for programmatic AI-prose detection, aligned with the backend deslop Admin API (server PR).
> 
> **Admin API:** `admin-openapi.json` now defines **`POST /v1/deslop/{projectId}`** (admin bearer auth, body `path` + `content`), with **`DeslopResult`** / **`DeslopWindow`** schemas covering verdicts, flagged line ranges, rewrite suggestions, credit charging, and skip/error behavior (400, 402, 429, 503). A new **`api/admin/deslop.mdx`** page references the spec and includes usage notes and a curl example.
> 
> **Discovery:** **`api/introduction.mdx`** lists deslop under endpoints and admin API key scope; **`docs.json`** adds the page under the Admin API group.
> 
> **CLI:** **`cli/commands.mdx`** documents **`mint deslop`** (default changed files, flags, credits, exit codes, examples); **`cli/index.mdx`** adds a short overview section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73557949fa2b9ba0f5914ffccb3d84c1610728b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->