### PR TITLE
Document seo.organization and the JSON-LD structured data graph

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,9 +7,9 @@ jobs:
     name: Check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22.x"
       - name: Install Mintlify CLI

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -68,11 +68,11 @@ Mintlify adds [schema.org](https://schema.org) structured data to every indexabl
 
 Each page emits a connected `@graph` of entities with stable `@id`s:
 
-- `Organization` — the publisher of your documentation. Derived from your site name, docs logo, and site URL, or configured explicitly with [`seo.organization`](/organize/settings-seo#seo).
-- `WebSite` — your documentation site.
-- `WebPage` — the current page, including its description and modification dates.
-- `BreadcrumbList` — the page's location in your navigation hierarchy, generated from your `docs.json` navigation.
-- The main content entity — `TechArticle` for documentation pages, or `APIReference` for pages generated from API specifications (pages with `api`, `openapi`, or `asyncapi` frontmatter).
+- `Organization`: The publisher of your site. Derived from your site name, logo, and site URL, or configured explicitly with [`seo.organization`](/organize/settings-seo#seo).
+- `WebSite`: Your site.
+- `WebPage`: The current page, including its description and modification dates.
+- `BreadcrumbList`: The page's location in your navigation hierarchy, generated from your `docs.json` navigation.
+- The main content entity: `TechArticle` for documentation pages or `APIReference` for pages generated from API specifications (pages with `api`, `openapi`, or `asyncapi` frontmatter).
 
 Mintlify generates the structured data from page frontmatter and `docs.json` configurations, including the page title, description, keywords, canonical URL, last updated date, site name, and logo. The structured data doesn't include any fields without a corresponding value. Pages with `noindex: true` do not include structured data.
 

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -76,7 +76,7 @@ Each page emits a connected `@graph` of entities with stable `@id`s:
 
 Mintlify generates the structured data from page frontmatter and `docs.json` configurations, including the page title, description, keywords, canonical URL, last updated date, site name, and logo. The structured data doesn't include any fields without a corresponding value. Pages with `noindex: true` do not include structured data.
 
-To change structured data, update the corresponding frontmatter fields or `docs.json` configurations. To control the publisher entity — including a stable `@id`, legal name, canonical logo, and `sameAs` profile links — set [`seo.organization`](/organize/settings-seo#seo) in your `docs.json`.
+To change structured data, update the corresponding frontmatter fields or `docs.json` configurations. To control the publisher entity, including a stable `@id`, legal name, canonical logo, and `sameAs` profile links, set [`seo.organization`](/organize/settings-seo#seo) in your `docs.json`.
 
 ## OG images
 

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -66,9 +66,17 @@ Any meta tags in your `docs.json` `seo.metatags` configuration are also automati
 
 Mintlify adds [schema.org](https://schema.org) structured data to every indexable page as a JSON-LD script. This structured data helps search engines display rich results for your pages.
 
+Each page emits a connected `@graph` of entities with stable `@id`s:
+
+- `Organization` — the publisher of your documentation. Derived from your site name, docs logo, and site URL, or configured explicitly with [`seo.organization`](/organize/settings-seo#seo).
+- `WebSite` — your documentation site.
+- `WebPage` — the current page, including its description and modification dates.
+- `BreadcrumbList` — the page's location in your navigation hierarchy, generated from your `docs.json` navigation.
+- The main content entity — `TechArticle` for documentation pages, or `APIReference` for pages generated from API specifications (pages with `api`, `openapi`, or `asyncapi` frontmatter).
+
 Mintlify generates the structured data from page frontmatter and `docs.json` configurations, including the page title, description, keywords, canonical URL, last updated date, site name, and logo. The structured data doesn't include any fields without a corresponding value. Pages with `noindex: true` do not include structured data.
 
-To change structured data, update the corresponding frontmatter fields or `docs.json` configurations.
+To change structured data, update the corresponding frontmatter fields or `docs.json` configurations. To control the publisher entity — including a stable `@id`, legal name, canonical logo, and `sameAs` profile links — set [`seo.organization`](/organize/settings-seo#seo) in your `docs.json`.
 
 ## OG images
 

--- a/organize/settings-reference.mdx
+++ b/organize/settings-reference.mdx
@@ -68,6 +68,7 @@ For context on what each group of settings does, see the topic pages:
 | `markdown.instructions` | string or array of strings | No | None |
 | `seo.indexing` | `"navigable"` \| `"all"` | No | `"navigable"` |
 | `seo.metatags` | object | No | None |
+| `seo.organization` | object | No | None |
 | `search.prompt` | string | No | None |
 | `integrations.*` | object | No | None |
 
@@ -919,6 +920,12 @@ Which pages search engines should index.
 #### `seo.metatags`
 
 Custom meta tags added to every page. Key-value pairs.
+
+**Type:** object
+
+#### `seo.organization`
+
+Organization used as the publisher entity in structured data (JSON-LD) on every page. Accepts `id`, `name`, `legalName`, `url`, `logo`, and `sameAs`. See [SEO and search](/organize/settings-seo#seo).
 
 **Type:** object
 

--- a/organize/settings-seo.mdx
+++ b/organize/settings-seo.mdx
@@ -46,6 +46,30 @@ Search engine indexing and metadata settings.
   ```
 </ResponseField>
 
+<ResponseField name="seo.organization" type="object">
+  The organization used as the publisher entity in the [structured data](/optimize/seo#structured-data) emitted on every page. All fields are optional. When omitted, Mintlify derives the organization from your site name, docs logo, and site URL.
+
+  - `id` — Stable `@id` URL identifying your organization across pages, for example `https://example.com/#organization`. Defaults to `<site origin>/#organization`.
+  - `name` — Organization name. Defaults to the site name.
+  - `legalName` — Registered legal name.
+  - `url` — Canonical organization homepage URL.
+  - `logo` — Canonical logo URL used in structured data. Defaults to the docs logo.
+  - `sameAs` — Array of URLs for official profiles, such as X, LinkedIn, or GitHub.
+
+  ```json
+  "organization": {
+    "id": "https://example.com/#organization",
+    "legalName": "Example Co. Inc.",
+    "url": "https://example.com",
+    "logo": "https://example.com/images/logo.png",
+    "sameAs": [
+      "https://x.com/example",
+      "https://github.com/example"
+    ]
+  }
+  ```
+</ResponseField>
+
 ```json docs.json
 "seo": {
   "indexing": "navigable",


### PR DESCRIPTION
Docs for mintlify/mint#9114 — merge alongside it (behavior ships with that PR plus a `@mintlify/validation` publish + server bump for the `seo.organization` field).

## Changes

- **organize/settings-seo.mdx**: new `seo.organization` ResponseField documenting `id`, `name`, `legalName`, `url`, `logo`, `sameAs` with defaults and an example.
- **organize/settings-reference.mdx**: quick-reference table row + full property reference entry for `seo.organization`.
- **optimize/seo.mdx**: Structured data section now describes the JSON-LD `@graph` (Organization, WebSite, WebPage, BreadcrumbList from navigation, and TechArticle/APIReference typing for API spec pages) and links to the `seo.organization` setting.

`mint broken-links` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI action version bumps only; no product runtime changes in this repo.
> 
> **Overview**
> Documents the new **`seo.organization`** `docs.json` setting and how Mintlify’s per-page JSON-LD **`@graph`** is structured.
> 
> **`organize/settings-seo.mdx`** adds a `seo.organization` field (`id`, `name`, `legalName`, `url`, `logo`, `sameAs`) with defaults and an example. **`organize/settings-reference.mdx`** lists it in the quick-reference table and the full `seo` section.
> 
> **`optimize/seo.mdx`** expands **Structured data** to describe the connected graph (`Organization`, `WebSite`, `WebPage`, `BreadcrumbList`, and `TechArticle` vs `APIReference`) and points readers to `seo.organization` for the publisher entity.
> 
> **`.github/workflows/check-links.yml`** bumps `actions/checkout` and `actions/setup-node` from v4 to v5.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4436db997253f0e6ba9230bcb09758034c86c360. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->