### PR TITLE
docs: document the mint signup command

### DIFF
--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -33,6 +33,45 @@ mint dev [flags]
 
 ---
 
+## `mint signup`
+
+Create a new Mintlify account from the terminal.
+
+```bash
+mint signup [flags]
+```
+
+| Flag | Description |
+| --- | --- |
+| `--firstName` | Your first name. |
+| `--lastName` | Your last name. |
+| `--company` | Your company name. |
+| `--email` | Email address for the account. |
+
+Run the command without flags to enter your details interactively. The CLI prompts for any value you do not pass as a flag.
+
+After you submit your details, Mintlify sends a verification link to your email. The command waits until you click the link, then creates your account, logs you in, and stores your credentials. When it finishes, open the [dashboard](https://app.mintlify.com) to connect your GitHub and start building.
+
+<Note>
+  `mint signup` does not return until you click the verification link, which can take several minutes. In scripts or automations, run it as a background process instead of waiting on it synchronously.
+</Note>
+
+### Examples
+
+```bash
+# Sign up interactively
+mint signup
+
+# Sign up with all details provided
+mint signup \
+  --firstName Jane \
+  --lastName Doe \
+  --company Acme \
+  --email jane@acme.com
+```
+
+---
+
 ## `mint login`
 
 Authenticate with your Mintlify account.
@@ -410,7 +449,6 @@ These commands are available to run but are not yet functional. Running them rec
 | --- | --- |
 | `mint ai` | AI-powered documentation tools. |
 | `mint test` | Documentation testing. |
-| `mint signup` | Account sign-up from the CLI. |
 | `mint mcp` | MCP server for documentation. |
 
 ---

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -50,7 +50,7 @@ mint signup [flags]
 
 Run the command without flags to enter your details interactively. The CLI prompts for any value you do not pass as a flag.
 
-After you submit your details, Mintlify sends a verification link to your email. The command waits until you click the link, then creates your account, logs you in, and stores your credentials. When it finishes, open the [dashboard](https://app.mintlify.com) to connect your GitHub and start building.
+After you submit your details, Mintlify sends a verification link to your email. The command waits until you click the link, then creates your account, logs you in, and stores your credentials. When it finishes, open the [dashboard](https://app.mintlify.com) to connect your repository and start building.
 
 <Note>
   `mint signup` does not return until you click the verification link, which can take several minutes. In scripts or automations, run it as a background process instead of waiting on it synchronously.


### PR DESCRIPTION
## What

Documents the `mint signup` CLI command, which creates a new Mintlify account from the terminal.

Previously `mint signup` was listed under **Coming soon** in `cli/commands.mdx`. It is now a functional command, so this PR:

- Removes `mint signup` from the "Coming soon" table.
- Adds a full `## mint signup` reference section with:
  - The `--firstName`, `--lastName`, `--company`, and `--email` flags.
  - A note that the CLI prompts interactively for any value not passed as a flag.
  - The email-verification flow (the command waits for the verification link, then creates the account, logs you in, and stores credentials).
  - A `<Note>` warning that the command blocks until verification and should be run as a background process in scripts and automations.
  - Interactive and fully-flagged usage examples.

## Why

The command shipped and behaves as documented (verified against the `@mintlify/cli` source), but the reference still marked it as unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the CLI commands reference; no runtime or security behavior is modified.
> 
> **Overview**
> Promotes **`mint signup`** from the **Coming soon** list to a full CLI reference section in `cli/commands.mdx`, reflecting that terminal sign-up is now supported.
> 
> The new section documents **`--firstName`**, **`--lastName`**, **`--company`**, and **`--email`**, interactive prompts for missing fields, and the email verification flow (the command blocks until the link is clicked, then creates the account, logs you in, and stores credentials). A **Note** warns that scripts should run it in the background because it can wait several minutes, and examples cover interactive and fully flagged usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ddcb06b0125baba4895134ed9e8b2139ba6a5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->