### PR TITLE
Agent static egress

### DIFF
--- a/agent/index.mdx
+++ b/agent/index.mdx
@@ -54,6 +54,20 @@ For deployments connected to your own Git provider, configure how the agent publ
 
 The agent can only access repositories that you connect through the Mintlify GitHub App. Configure which repositories the agent can access in the agent panel **Settings** or in the [GitHub App settings](https://github.com/apps/mintlify/installations/new).
 
+## Use a static IP for Git requests
+
+<Info>
+  Static agent egress requires an [Enterprise plan](https://mintlify.com/pricing?ref=static-agent-egress).
+</Info>
+
+If your Git provider restricts access with an IP allowlist, Mintlify can route Git requests from agent sandboxes through a static IP address.
+
+Contact Mintlify about the deployment that you want to enable static agent egress for. Once enabled, the static address applies to Git operations from the agent and automations, including cloning, fetching, and pushing connected repositories.
+
+<Note>
+  Static agent egress applies only to Git requests from agent sandboxes. Other outbound requests do not use this static IP address.
+</Note>
+
 ## Use AI tools alongside the agent
 
 The agent works asynchronously through pull requests, but you can also use AI coding tools like Cursor or Claude Code locally for fast, iterative edits. Install the Mintlify [skill](/ai/skillmd) and connect the [MCP server](/ai/model-context-protocol) so your editor has the same context the agent uses.


### PR DESCRIPTION
## Documentation changes

Adds info about static IP egress for the agent on enterprise plans.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no product or runtime behavior changes in this PR.
> 
> **Overview**
> Adds a **Use a static IP for Git requests** section to the agent docs for customers whose Git provider uses an **IP allowlist**.
> 
> The section states that **static agent egress is Enterprise-only**, that Mintlify enables it per deployment on request, and that the static IP covers **Git operations from agent sandboxes and automations** (clone, fetch, push). A note clarifies that **only sandbox Git traffic** uses the static IP—not other outbound requests from the agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b07818f8bf1ddcc382b4a5203ad42b98c356048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->