### PR TITLE
Edit deslop endpoint reference

### DIFF
--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -19,7 +19,7 @@
     "/v1/deslop/{projectId}": {
       "post": {
         "summary": "Detect AI-sounding prose in a page",
-        "description": "Analyzes a documentation page for AI-generated prose and returns flagged passages with suggested human rewrites. Consumes one AI credit per checked page. Pages under 50 words are skipped and not charged.",
+        "description": "Analyzes a page for AI-generated prose and returns flagged passages with suggested rewrites. Consumes one AI credit per checked page. Skips pages under 50 words. Limited to 30 requests per minute per client IP address.",
         "parameters": [
           {
             "name": "projectId",
@@ -44,7 +44,7 @@
                   },
                   "content": {
                     "type": "string",
-                    "minLength": 1,
+                    "maxLength": 1000000,
                     "description": "The raw MDX or Markdown content of the page to check."
                   }
                 }
@@ -82,6 +82,9 @@
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
             }
+          },
+          "500": {
+            "description": "An unexpected error occurred while processing the page."
           }
         }
       }
@@ -666,7 +669,13 @@
           "text": { "type": "string", "description": "The flagged passage text." },
           "label": { "type": "string", "description": "Detection label for the passage, for example `AI-Generated`." },
           "aiAssistanceScore": { "type": "number", "description": "AI-assistance score for the passage (0-1)." },
-          "confidence": { "type": "string", "description": "Detection confidence, for example `High`." },
+          "confidence": {
+            "description": "Detection confidence, returned as either a label such as `High` or a numeric score.",
+            "oneOf": [
+              { "type": "string" },
+              { "type": "number" }
+            ]
+          },
           "startLine": { "type": "integer", "description": "1-based start line of the passage in the original content." },
           "endLine": { "type": "integer", "description": "1-based end line of the passage in the original content." },
           "rewrites": {

--- a/admin-openapi.json
+++ b/admin-openapi.json
@@ -74,7 +74,12 @@
           "429": {
             "description": "Rate limit exceeded.",
             "content": {
-              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "example": "Too many requests, please try again later."
+                }
+              }
             }
           },
           "503": {

--- a/api/admin/deslop.mdx
+++ b/api/admin/deslop.mdx
@@ -13,10 +13,11 @@ Authenticate with an [admin API key](/api/introduction#admin-api-key).
 - Consumes 1 AI credit per checked page.
 - The endpoint skips pages under 50 words and does not charge for them. The response returns `skipped: "too_short"` with `creditsCharged: 0`.
 - If detection is temporarily unavailable, the endpoint returns `503` and doesn't consume a credit.
+- The endpoint accepts up to 30 requests per minute per client IP address.
 
 ## Response
 
-Checked pages return a verdict (`predictionShort`), AI and human fractions, and a `windows` array of flagged passages. Each window includes a line range and a suggested rewrite.
+Checked pages return a verdict (`predictionShort`), AI and human fractions, and a `windows` array of flagged passages. Each window includes a line range and can include one to three suggested rewrites.
 
 ## Usage
 

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -380,12 +380,12 @@ mint deslop [files...] [flags]
 | --- | --- |
 | `--format` | Output format: `table` (default, colored), `plain` (pipeable), or `json`. |
 | `--subdomain` | Documentation subdomain to check against. Defaults to your configured subdomain. |
-| `--threshold` | Fail a page when its AI-written fraction meets this value, from `0` to `1`. Defaults to `0.5`. |
+| `--threshold` | Fail a page when the sum of its AI-generated and AI-assisted fractions meets this value, from `0` to `1`. Defaults to `0.5`. |
 | `--fix-whitespace` | Normalize prose whitespace in the checked files (trailing spaces, blank-line runs, and invisible Unicode characters). Skips code blocks and frontmatter. |
 
 For each flagged page, the command reports the AI-written fraction, the specific passages that read as AI-generated with their line numbers, and suggested human-style rewrites.
 
-Each checked page consumes one AI credit. The command skips pages under 50 words and does not charge for them. If any page is at or above the threshold, the command exits with code `1. If every page is clean, the command exists with code `0`. This lets you run the command in a rewrite loop or in CI.
+Each checked page consumes one AI credit. The command skips pages under 50 words and does not charge for them. If any page is at or above the threshold, or if a check returns an error, the command exits with code `1`. If every page is clean, the command exits with code `0`. This lets you run the command in a rewrite loop or in CI.
 
 ### Examples
 

--- a/cli/commands.mdx
+++ b/cli/commands.mdx
@@ -380,7 +380,7 @@ mint deslop [files...] [flags]
 | --- | --- |
 | `--format` | Output format: `table` (default, colored), `plain` (pipeable), or `json`. |
 | `--subdomain` | Documentation subdomain to check against. Defaults to your configured subdomain. |
-| `--threshold` | Fail a page when the sum of its AI-generated and AI-assisted fractions meets this value, from `0` to `1`. Defaults to `0.5`. |
+| `--threshold` | Fail a page when the sum of its AI-generated and AI-assisted fractions is greater than this value, from `0` to `1`. Defaults to `0.5`. |
 | `--fix-whitespace` | Normalize prose whitespace in the checked files (trailing spaces, blank-line runs, and invisible Unicode characters). Skips code blocks and frontmatter. |
 
 For each flagged page, the command reports the AI-written fraction, the specific passages that read as AI-generated with their line numbers, and suggested human-style rewrites.


### PR DESCRIPTION
## Documentation changes

Cleans up and adds a bit more info about `mint deslop`

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI description changes only; no runtime code in this diff.
> 
> **Overview**
> Updates **deslop** documentation across the OpenAPI spec, admin API page, and CLI reference so they match current API and CLI behavior.
> 
> The **`POST /v1/deslop/{projectId}`** spec now documents a **30 requests/minute per IP** limit, a **`content` max length** of 1,000,000 (replacing a minimum length), **`429`** as **plain text** (not JSON), a **`500`** response, and **`confidence`** on windows as either a string label or a numeric score.
> 
> The admin **deslop** page adds the rate limit under Credits and notes that each flagged window may include **one to three** rewrites.
> 
> **`mint deslop`** docs clarify that **`--threshold`** compares the **sum of AI-generated and AI-assisted fractions** (fail when greater than the threshold), that the command **exits `1` on API/check errors** as well as over-threshold pages, and fix a small exit-code wording typo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac19d3b8bfd8d0badf890bbdec0c8911b15c613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->