### PR TITLE
Document /mintlify-assets and /_mintlify routing for subpath proxies

### DIFF
--- a/deploy/cloudflare.mdx
+++ b/deploy/cloudflare.mdx
@@ -101,7 +101,9 @@ async function handleRequest(request) {
 ```
 
 <Warning>
-  In addition to your subpath, your Worker must proxy `/mintlify-assets/*`, which serves the CSS, JavaScript, and favicons for your documentation, and `/_mintlify/*`, which handles API playground requests. These paths are requested from the root of your domain, not your subpath. If you route traffic to your Worker with route patterns instead of a custom domain, add routes for `yoursite.com/mintlify-assets/*` and `yoursite.com/_mintlify/*` alongside your subpath route.
+  In addition to your subpath, your Worker must proxy `/mintlify-assets/*`, which serves the CSS, JavaScript, and favicons for your documentation, and `/_mintlify/*`, which handles API playground requests.
+  
+  If you route traffic to your Worker with route patterns instead of a custom domain, add routes for `yoursite.com/mintlify-assets/*` and `yoursite.com/_mintlify/*` alongside your subpath route.  These paths must originate from the root of your domain, not your subpath.
 </Warning>
 
 Click **Deploy** and wait for the changes to propagate.

--- a/deploy/cloudflare.mdx
+++ b/deploy/cloudflare.mdx
@@ -70,8 +70,12 @@ async function handleRequest(request) {
       return await fetch(request);
     }
     
-    // If the request is to the docs subpath
-    if (/^\/docs/.test(urlObject.pathname)) {
+    // If the request is to the docs subpath or a Mintlify asset or API path
+    if (
+      /^\/docs/.test(urlObject.pathname) ||
+      /^\/mintlify-assets\//.test(urlObject.pathname) ||
+      /^\/_mintlify\//.test(urlObject.pathname)
+    ) {
       // Then Proxy to Mintlify
       const DOCS_URL = "[SUBDOMAIN].mintlify.site";
       const CUSTOM_URL = "[YOUR_DOMAIN]";
@@ -95,6 +99,10 @@ async function handleRequest(request) {
   }
 }
 ```
+
+<Warning>
+  In addition to your subpath, your Worker must proxy `/mintlify-assets/*`, which serves the CSS, JavaScript, and favicons for your documentation, and `/_mintlify/*`, which handles API playground requests. These paths are requested from the root of your domain, not your subpath. If you route traffic to your Worker with route patterns instead of a custom domain, add routes for `yoursite.com/mintlify-assets/*` and `yoursite.com/_mintlify/*` alongside your subpath route.
+</Warning>
 
 Click **Deploy** and wait for the changes to propagate.
 
@@ -154,8 +162,12 @@ If you use Webflow to host your main site and want to serve Mintlify docs at `/d
       return await fetch(request);
     }
     
-    // If the request is to the docs subpath
-    if (/^\/docs/.test(urlObject.pathname)) {
+    // If the request is to the docs subpath or a Mintlify asset or API path
+    if (
+      /^\/docs/.test(urlObject.pathname) ||
+      /^\/mintlify-assets\//.test(urlObject.pathname) ||
+      /^\/_mintlify\//.test(urlObject.pathname)
+    ) {
       // Proxy to Mintlify
       const DOCS_URL = "[SUBDOMAIN].mintlify.site";
       const CUSTOM_URL = "[YOUR_DOMAIN]";

--- a/deploy/route53-cloudfront.mdx
+++ b/deploy/route53-cloudfront.mdx
@@ -26,10 +26,11 @@ Route traffic to these paths with a Cache Policy of **CachingDisabled**:
 - `/.well-known/vercel/*` - Required for domain verification
 - `/docs/*` - Required for subpath routing
 - `/docs/` - Required for subpath routing
+- `/_mintlify/*` - Required for API playground requests
 
 Route traffic to these paths with a Cache Policy of **CachingEnabled**:
 
-- `/mintlify-assets/_next/static/*`
+- `/mintlify-assets/*` - Required for CSS, JavaScript, and favicons
 - `Default (*)` - Your website's landing page
 
 All Behaviors must have an **origin request policy** of `AllViewerExceptHostHeader`.
@@ -155,11 +156,22 @@ These settings should exactly match your base subpath behavior, with the excepti
 - Set "Viewer protocol policy" to **Redirect HTTP to HTTPS**.
 - Set "Allowed HTTP methods" to **GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE**.
 
-### `/mintlify-assets/_next/static/*`
+### `/mintlify-assets/*`
+
+Create a behavior with a **Path pattern** of `/mintlify-assets/*` with **Origin and origin groups** pointing to the `.mintlify.site` URL. This path serves the CSS, JavaScript, and favicons for your documentation from the root of your domain.
 
  - Set "Cache policy" to **CachingOptimized**.
  - Set "Origin request policy" to **AllViewerExceptHostHeader**.
  - Set "Viewer protocol policy" to **Redirect HTTP to HTTPS**.
+
+### `/_mintlify/*`
+
+Create a behavior with a **Path pattern** of `/_mintlify/*` with **Origin and origin groups** pointing to the `.mintlify.site` URL. This path handles API playground requests from the root of your domain.
+
+- Set "Cache policy" to **CachingDisabled**.
+- Set "Origin request policy" to **AllViewerExceptHostHeader**.
+- Set "Viewer protocol policy" to **Redirect HTTP to HTTPS**.
+- Set "Allowed HTTP methods" to **GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE**.
 
 ### `Default (*)`
 


### PR DESCRIPTION
## Summary
Subpath reverse proxies must forward two root-level paths to `<subdomain>.mintlify.site` in addition to the docs subpath:

- `/mintlify-assets/*` — CSS/JS chunks and favicons are emitted with a root-relative asset prefix, so they are requested from the domain root, not the subpath. Without this, docs render unstyled with broken scripts.
- `/_mintlify/*` — the API playground posts to `/_mintlify/api/request` at the domain root.

The Vercel guide's config generator already includes both rewrites, but the Cloudflare Workers guide covered neither (a customer had to discover the assets route themselves), and the AWS guide only covered `/mintlify-assets/_next/static/*`, which misses favicons and the playground path.

Changes:
- `deploy/cloudflare.mdx`: both example Worker scripts now match `/mintlify-assets/` and `/_mintlify/`; added a warning about covering these paths in Worker routes when not using a custom domain.
- `deploy/route53-cloudfront.mdx`: widened `/mintlify-assets/_next/static/*` to `/mintlify-assets/*` and added a `/_mintlify/*` behavior (CachingDisabled, all HTTP methods).

Note: the dashboard-generated Worker snippet (`AdditionalSettings.tsx` in mint) has the same gap and needs a separate fix.

## Test Plan
- `mint broken-links` passes.
- Verified live: a subpath deployment's HTML references `/mintlify-assets/...` at the domain root, and the API playground posts to root-level `/_mintlify/api/request` (`useSendPlaygroundRequest.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deployment guides; no application code or infrastructure behavior in this repo.
> 
> **Overview**
> Subpath reverse-proxy docs now require forwarding **root-level** `/mintlify-assets/*` and `/_mintlify/*` to Mintlify, not only the docs subpath—without them, styled assets and the API playground break.
> 
> **Cloudflare Workers** (`deploy/cloudflare.mdx`): both example Worker scripts proxy those paths alongside `/docs`; a new warning explains why they’re needed and that route patterns must include `yoursite.com/mintlify-assets/*` and `yoursite.com/_mintlify/*` when not using a custom domain.
> 
> **AWS CloudFront** (`deploy/route53-cloudfront.mdx`): overview and behaviors widen cached routing from `/mintlify-assets/_next/static/*` to **`/mintlify-assets/*`**, and add a **`/_mintlify/*`** behavior (caching disabled, all HTTP methods) for playground API traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936226a90c699af9b5b0b9e97ec4c620d1211c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->