### PR TITLE
Decouple search and assistant endpoints

### DIFF
--- a/api/introduction.mdx
+++ b/api/introduction.mdx
@@ -38,7 +38,8 @@ The Mintlify REST (Representational State Transfer) API enables you to programma
 - **CI/CD integration**: Update documentation as part of your deployment pipeline when code changes with [Trigger update](/api/update/trigger).
 - **Preview deployments**: Create or update preview deployments programmatically in your CI/CD pipeline with [Trigger preview deployment](/api/preview/trigger).
 - **On-demand automations**: Run scheduled automations from your CI/CD pipeline or release tooling with [Trigger automation](/api/automations/trigger).
-- **Custom integrations**: Embed the AI assistant into your product, support portal, or internal tools with [Create assistant message](/api/assistant/create-assistant-message-v2), [Search documentation](/api/assistant/search), and [Get page content](/api/assistant/get-page-content).
+- **Assistant integrations**: Embed the AI assistant into your product, support portal, or internal tools with [Create assistant message](/api/assistant/create-assistant-message-v2).
+- **Documentation retrieval**: Find and retrieve documentation for custom search experiences with [Search documentation](/api/assistant/search) and [Get page content](/api/assistant/get-page-content).
 - **Automated editing**: Use agent jobs to programmatically update documentation at scale with [Create agent job](/api/agent/v2/create-agent-job), [Get agent job](/api/agent/v2/get-agent-job), and [Send follow-up message](/api/agent/v2/send-message).
 - **Analytics export**: Export feedback, assistant conversations, search analytics, page views, and visitor data for external analysis with [Get user feedback](/api/analytics/feedback), [Get feedback by page](/api/analytics/feedback-by-page), [Get assistant conversations](/api/analytics/assistant-conversations), [Get assistant caller stats](/api/analytics/assistant-caller-stats), [Get search queries](/api/analytics/searches), [Get page views](/api/analytics/views), and [Get unique visitors](/api/analytics/visitors).
 
@@ -50,10 +51,10 @@ You can create up to 10 API keys per hour per organization.
 
 Mintlify uses two types of API keys, each scoped to a different set of endpoints:
 
-| Key type        | Prefix      | Use for                                                                              |
-| --------------- | ----------- | ------------------------------------------------------------------------------------ |
-| Admin API key   | `mint_`     | Updates, agent jobs, and analytics exports. Server-side only.                        |
-| Assistant API key | `mint_dsc_` | Assistant endpoints (create message, search, get page content). Proxy in production. |
+| Key type          | Prefix      | Use for                                                                                 |
+| ----------------- | ----------- | --------------------------------------------------------------------------------------- |
+| Admin API key     | `mint_`     | Updates, agent jobs, and analytics exports. Server-side only.                           |
+| Assistant API key | `mint_dsc_` | Assistant messages, documentation search, and page content. Proxy in production.        |
 
 ### Admin API key
 
@@ -82,12 +83,12 @@ The admin API key is a server-side secret. Do not expose it in client-side code.
 ### Assistant API key
 
 <Warning>
-  Do not directly embed the assistant API key in client-side code. Any visitor who extracts the key can send requests on your behalf, consuming credits and potentially triggering overage charges.
+  Do not directly embed the assistant API key in client-side code. Any visitor who extracts the key can call the assistant message endpoint on your behalf, consuming credits and potentially triggering overage charges.
 
-  For production deployments, proxy assistant API requests through your own backend and store the key as a server-side environment variable. Routing requests through a proxy also lets you add rate limiting, authentication, and bot protection to prevent abuse.
+  For production deployments, proxy requests that use an assistant API key through your own backend and store the key as a server-side environment variable. Routing requests through a proxy also lets you add rate limiting, authentication, and bot protection to prevent abuse.
 </Warning>
 
-Use the assistant API key for the assistant endpoints.
+Use the assistant API key to authenticate requests to the assistant, search, and page content endpoints.
 
 - [Create assistant message](/api/assistant/create-assistant-message-v2)
 - [Search documentation](/api/assistant/search)
@@ -96,5 +97,5 @@ Use the assistant API key for the assistant endpoints.
 Assistant API keys begin with the `mint_dsc_` prefix.
 
 <Note>
-  Calls using the assistant API token can incur costs: either using your assistant credits or incurring overages.
+  Search documentation and page content requests do not consume credits. Assistant message requests use credits and can incur overages.
 </Note>

--- a/discovery-openapi.json
+++ b/discovery-openapi.json
@@ -743,7 +743,7 @@
     "/v1/page/{domain}": {
       "post": {
         "summary": "Get page content",
-        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.\n\nAuthenticate with an assistant API key.",
+        "description": "Retrieve the full text content of a specific documentation page by its path. Use this after a search to fetch the complete content of a matching page.\n\nAuthenticate with an assistant API key. Page content requests do not consume credits.",
         "parameters": [
           {
             "name": "domain",
@@ -767,7 +767,7 @@
                 "properties": {
                   "path": {
                     "type": "string",
-                    "description": "The page slug or path to retrieve content for. This corresponds to the `page` field returned by the [Search documentation](/api/assistant/search) endpoint."
+                    "description": "The page slug or path to retrieve content for. This corresponds to the `path` field returned by the [Search documentation](/api/assistant/search) endpoint."
                   }
                 }
               }
@@ -822,7 +822,7 @@
           }
         },
         "summary": "Search documentation",
-        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.\n\nAuthenticate with an assistant API key.",
+        "description": "Perform semantic and keyword searches across your documentation with configurable filtering and pagination.\n\nAuthenticate with an assistant API key. Search requests do not consume credits.",
         "parameters": [
           {
             "name": "domain",

--- a/docs.json
+++ b/docs.json
@@ -377,7 +377,7 @@
             "groups": [
               {
                 "group": "API reference",
-                "icon": "file-json",
+                "icon": "file-braces",
                 "pages": [
                   "api/introduction"
                 ]

--- a/docs.json
+++ b/docs.json
@@ -406,15 +406,15 @@
                 "group": "Assistant",
                 "icon": "bot-message-square",
                 "pages": [
-                  "api/assistant/create-assistant-message-v2",
-                  "api/assistant/get-page-content"
+                  "api/assistant/create-assistant-message-v2"
                 ]
               },
               {
                 "group": "Search",
                 "icon": "search",
                 "pages": [
-                  "api/assistant/search"
+                  "api/assistant/search",
+                  "api/assistant/get-page-content"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -407,8 +407,14 @@
                 "icon": "bot-message-square",
                 "pages": [
                   "api/assistant/create-assistant-message-v2",
-                  "api/assistant/search",
                   "api/assistant/get-page-content"
+                ]
+              },
+              {
+                "group": "Search",
+                "icon": "search",
+                "pages": [
+                  "api/assistant/search"
                 ]
               },
               {


### PR DESCRIPTION
## Documentation changes

Closes https://linear.app/mintlify/issue/DOC-385/move-search-endpoint-out-of-assistant-docs

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI description-only changes with no runtime or API behavior changes.
> 
> **Overview**
> **Splits search/page-content endpoints out of the Assistant section** in `docs.json` into a dedicated **Search** nav group, leaving **Assistant** with only create-message. The API reference group icon changes from `file-json` to `file-braces`.
> 
> **Updates `api/introduction.mdx`** to treat assistant chat vs documentation retrieval as separate use cases, broaden assistant-key scope wording (messages, search, page content), and **clarify billing**: search and get-page-content do not consume credits; only assistant messages can incur overages. Security copy is tightened so credit-risk warnings focus on the message endpoint while still recommending proxying all assistant-key traffic.
> 
> **OpenAPI (`discovery-openapi.json`)** adds the no-credits note on search and page-content operations and **corrects** the get-page-content `path` parameter description to reference the search response’s `path` field (not `page`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 160640e424cff9d8b2fd50c52ca2755cc61996fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->