### PR TITLE
Add learn tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -552,7 +552,7 @@
             "href": "https://www.mintlify.com/docs/contact-support"
           },
           {
-            "label": "Feature Requests",
+            "label": "Feature requests",
             "href": "https://github.com/orgs/mintlify/discussions/categories/feature-requests"
           },
           {
@@ -569,7 +569,7 @@
             "href": "https://mintlify.com/careers"
           },
           {
-            "label": "Wall of Love",
+            "label": "Wall of love",
             "href": "https://www.mintlify.com/wall-of-love"
           }
         ]
@@ -578,7 +578,7 @@
         "header": "Legal",
         "items": [
           {
-            "label": "Privacy Policy",
+            "label": "Privacy policy",
             "href": "https://mintlify.com/legal/privacy"
           },
           {

--- a/docs.json
+++ b/docs.json
@@ -300,79 +300,6 @@
             ]
           },
           {
-            "tab": "Guides",
-            "groups": [
-              {
-                "group": "Overview",
-                "icon": "book-open",
-                "pages": [
-                  "guides/index",
-                  "what-is-mintlify"
-                ]
-              },
-              {
-                "group": "AI",
-                "icon": "bot",
-                "pages": [
-                  "guides/assistant-embed",
-                  "guides/configure-automerge",
-                  "guides/use-automations",
-                  "guides/claude-code",
-                  "guides/codex",
-                  "guides/cursor",
-                  "guides/devin-desktop",
-                  "guides/geo"
-                ]
-              },
-              {
-                "group": "API docs",
-                "icon": "file-braces",
-                "pages": [
-                  "guides/migrating-from-mdx"
-                ]
-              },
-              {
-                "group": "Best practices",
-                "icon": "trophy",
-                "pages": [
-                  "guides/accessibility",
-                  "guides/content-types",
-                  "guides/content-templates",
-                  "guides/custom-layouts",
-                  "guides/improving-docs",
-                  "guides/internationalization",
-                  "guides/linking",
-                  "guides/maintenance",
-                  "guides/media",
-                  "migration",
-                  "guides/navigation",
-                  "guides/seo",
-                  "guides/style-and-tone",
-                  "guides/understand-your-audience"
-                ]
-              },
-              {
-                "group": "Git",
-                "icon": "git-merge",
-                "pages": [
-                  "guides/git-concepts",
-                  "guides/branches"
-                ]
-              },
-              {
-                "group": "Use cases",
-                "icon": "blocks",
-                "pages": [
-                  "guides/developer-documentation",
-                  "guides/knowledge-base",
-                  "guides/help-center",
-                  "guides/custom-frontend",
-                  "api/static-export/overview"
-                ]
-              }
-            ]
-          },
-          {
             "tab": "API reference",
             "groups": [
               {
@@ -451,6 +378,90 @@
                 "pages": [
                   "changelog"
                 ]
+              }
+            ]
+          },
+          {
+            "tab": "Learn",
+            "menu": [
+              {
+                "item": "Learn",
+                "href": "https://learn.mintlify.com/",
+                "description": "Self-paced lessons to get the most from Mintlify."
+              },
+              {
+                "item": "Guides",
+                "description": "How to guides for common tasks and best practices.",
+                "groups": [
+              {
+                "group": "Overview",
+                "icon": "book-open",
+                "pages": [
+                  "guides/index",
+                  "what-is-mintlify"
+                ]
+              },
+              {
+                "group": "AI",
+                "icon": "bot",
+                "pages": [
+                  "guides/assistant-embed",
+                  "guides/configure-automerge",
+                  "guides/use-automations",
+                  "guides/claude-code",
+                  "guides/codex",
+                  "guides/cursor",
+                  "guides/devin-desktop",
+                  "guides/geo"
+                ]
+              },
+              {
+                "group": "API docs",
+                "icon": "file-braces",
+                "pages": [
+                  "guides/migrating-from-mdx"
+                ]
+              },
+              {
+                "group": "Best practices",
+                "icon": "trophy",
+                "pages": [
+                  "guides/accessibility",
+                  "guides/content-types",
+                  "guides/content-templates",
+                  "guides/custom-layouts",
+                  "guides/improving-docs",
+                  "guides/internationalization",
+                  "guides/linking",
+                  "guides/maintenance",
+                  "guides/media",
+                  "migration",
+                  "guides/navigation",
+                  "guides/seo",
+                  "guides/style-and-tone",
+                  "guides/understand-your-audience"
+                ]
+              },
+              {
+                "group": "Git",
+                "icon": "git-merge",
+                "pages": [
+                  "guides/git-concepts",
+                  "guides/branches"
+                ]
+              },
+              {
+                "group": "Use cases",
+                "icon": "blocks",
+                "pages": [
+                  "guides/developer-documentation",
+                  "guides/knowledge-base",
+                  "guides/help-center",
+                  "guides/custom-frontend",
+                  "api/static-export/overview"
+                ]
+              }
+            ]
               }
             ]
           }


### PR DESCRIPTION
## Documentation changes

Adds a new tab `Learn` that includes a link to learn.mintlify.com and the Guides tab

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English-only navigation and footer label changes in `docs.json`; no runtime or content logic.
> 
> **Overview**
> Replaces the top-level **Guides** tab with a new **Learn** tab in `docs.json`. The Learn tab uses a **menu** layout: the first item links out to `https://learn.mintlify.com/`, and **Guides** is a second menu entry that keeps the same guide page groups (Overview, AI, API docs, Best practices, Git, Use cases) that previously lived under the Guides tab.
> 
> Footer link labels are normalized to sentence case (**Feature requests**, **Wall of love**, **Privacy policy**); hrefs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e00464eb961d2a5a2716871f7acb65da1ec1ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->