### PR TITLE
Document SDK reference generation (typedoc, docfx, javadoc, sphinx, phpdoc)

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -111,6 +111,7 @@ Devin
 DevTools
 Di(?:á|a)taxis
 Discord
+doclet(s)?
 discoverability
 dismissibility
 Django

--- a/api-playground/sdk-reference-setup.mdx
+++ b/api-playground/sdk-reference-setup.mdx
@@ -1,0 +1,106 @@
+---
+title: "SDK reference setup"
+description: "Generate SDK reference pages from your existing documentation tooling: TypeDoc, DocFX, Javadoc, Sphinx, or phpDocumentor."
+keywords: ["sdk", "typedoc", "docfx", "javadoc", "sphinx", "phpdocumentor", "reference"]
+---
+
+Use the `sdk` navigation property to generate reference pages for your SDK libraries from the documentation tools you already run. Mintlify reads each tool's build artifact and creates a page for every class, interface, module, and function, with navigation groups, cross-page links, and search indexing included.
+
+## Supported formats
+
+| `format` | Tool | Artifact |
+| --- | --- | --- |
+| `typedoc` | [TypeDoc](https://typedoc.org) (TypeScript/JavaScript) | JSON export file |
+| `docfx` | [DocFX](https://dotnet.github.io/docfx/) (.NET) | `docfx metadata` output directory (ManagedReference YAML) |
+| `javadoc` | [Javadoc](https://docs.oracle.com/en/java/javase/17/javadoc/javadoc.html) (Java) | Standard doclet HTML directory |
+| `sphinx` | [Sphinx](https://www.sphinx-doc.org) (Python) | JSON builder output directory |
+| `phpdoc` | [phpDocumentor](https://phpdoc.org) (PHP) | `structure.xml` file |
+
+## Generate an artifact
+
+Run your documentation tool with a machine-readable output format. If you already publish generated docs from CI, this is usually a one-flag change to the same command.
+
+<CodeGroup>
+
+```bash TypeDoc
+npx typedoc --json typedoc.json src/index.ts
+```
+
+```bash DocFX
+docfx metadata docfx.json
+```
+
+```bash Javadoc
+javadoc -d javadoc-output -sourcepath src/main/java -subpackages com.example
+# Or download the published javadoc jar from Maven Central
+```
+
+```bash Sphinx
+python -m sphinx -b json docs/source artifacts/json
+```
+
+```bash phpDocumentor
+phpdoc -d src -t artifacts --template=xml
+```
+
+</CodeGroup>
+
+## Auto-populate SDK pages
+
+Add an `sdk` property to a tab in your `docs.json`. Mintlify parses the artifact and creates navigation groups and pages for the library.
+
+```json
+"navigation": {
+  "tabs": [
+    {
+      "tab": "SDK Reference",
+      "sdk": {
+        "format": "typedoc",
+        "source": "sdk-artifacts/typedoc.json",
+        "directory": "sdk/typescript"
+      }
+    }
+  ]
+}
+```
+
+<ResponseField name="format" type="string" required>
+  The documentation tool that produced the artifact: `typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`.
+</ResponseField>
+
+<ResponseField name="source" type="string" required>
+  Relative path to the artifact file or directory in your docs repository, or an HTTPS URL.
+</ResponseField>
+
+<ResponseField name="directory" type="string">
+  The URL path prefix for generated pages. Defaults to `sdk-reference`.
+</ResponseField>
+
+Add multiple tabs to document multiple libraries. Each tab needs a unique `directory`.
+
+<Tip>
+  Add your artifact directory to [`.mintignore`](/organize/mintignore) so artifacts are treated as build inputs rather than published as static assets.
+</Tip>
+
+## Use remote sources
+
+Set `source` to an HTTPS URL to fetch the artifact at build time instead of committing it to your docs repository.
+
+Single-file formats (`typedoc`, `phpdoc`) accept a direct file URL. Directory formats (`docfx`, `javadoc`, `sphinx`) accept a zip archive. Javadoc jars published to Maven Central work without repackaging:
+
+```json
+{
+  "tab": "Java SDK",
+  "sdk": {
+    "format": "javadoc",
+    "source": "https://repo1.maven.org/maven2/com/example/my-library/1.0.0/my-library-1.0.0-javadoc.jar",
+    "directory": "sdk/java"
+  }
+}
+```
+
+Remote artifacts are limited to 50 MB downloaded and 200 MB extracted.
+
+## Keep references up to date
+
+Regenerate the artifact whenever your SDK changes. A common pattern is a CI job in each SDK repository that runs the documentation tool on release and either commits the artifact to your docs repository or uploads it to a stable URL that `source` points to.

--- a/api-playground/sdk-reference-setup.mdx
+++ b/api-playground/sdk-reference-setup.mdx
@@ -79,7 +79,7 @@ Add an `sdk` property to a tab in your `docs.json`. Mintlify parses the artifact
 Add multiple tabs to document multiple libraries. Each tab needs a unique `directory`.
 
 <Tip>
-  Add your artifact directory to [`.mintignore`](/organize/mintignore) so artifacts are treated as build inputs rather than published as static assets.
+  Add your artifact directory to [`.mintignore`](/organize/mintignore) so Mintlify treats artifacts as build inputs rather than publishing them as static assets.
 </Tip>
 
 ## Use remote sources
@@ -99,7 +99,7 @@ Single-file formats (`typedoc`, `phpdoc`) accept a direct file URL. Directory fo
 }
 ```
 
-Remote artifacts are limited to 50 MB downloaded and 200 MB extracted.
+Remote artifacts have a 50 MB download limit and a 200 MB extracted size limit.
 
 ## Keep references up to date
 

--- a/docs.json
+++ b/docs.json
@@ -178,6 +178,7 @@
                   "api-playground/mdx-setup",
                   "api-playground/asyncapi-setup",
                   "api-playground/graphql-setup",
+                  "api-playground/sdk-reference-setup",
                   "api-playground/troubleshooting"
                 ]
               },

--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -585,7 +585,7 @@ For more information about referencing OpenAPI endpoints in your docs, see the [
 
 ## SDK references
 
-Generate SDK reference pages from your documentation tooling's build artifacts. Add an `sdk` property to a tab with the artifact `format` (`typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`), a `source` path or HTTPS URL, and an optional `directory` for the URL prefix of generated pages.
+Generate SDK reference pages from the build artifacts of your documentation tools. Add an `sdk` property to a tab with the artifact `format` (`typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`), a `source` path or HTTPS URL, and an optional `directory` for the URL prefix of generated pages.
 
 Mintlify parses the artifact and generates navigation groups and pages for every class, interface, module, and function in the library.
 

--- a/organize/navigation.mdx
+++ b/organize/navigation.mdx
@@ -583,6 +583,31 @@ For more information about referencing OpenAPI endpoints in your docs, see the [
 }
 ```
 
+## SDK references
+
+Generate SDK reference pages from your documentation tooling's build artifacts. Add an `sdk` property to a tab with the artifact `format` (`typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`), a `source` path or HTTPS URL, and an optional `directory` for the URL prefix of generated pages.
+
+Mintlify parses the artifact and generates navigation groups and pages for every class, interface, module, and function in the library.
+
+For more information about generating artifacts and configuring sources, see the [SDK reference setup](/api-playground/sdk-reference-setup).
+
+```json
+{
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "TypeScript SDK",
+        "sdk": {
+          "format": "typedoc",
+          "source": "sdk-artifacts/typedoc.json",
+          "directory": "sdk/typescript"
+        }
+      }
+    ]
+  }
+}
+```
+
 ## Versions
 
 Partition your navigation into different versions. Versions are selectable from a dropdown menu.


### PR DESCRIPTION
New page `api-playground/sdk-reference-setup` documenting the `sdk` navigation property shipped in mintlify/mint#9449 + mintlify/server#6963:

- Supported formats and their artifacts
- Per-tool artifact generation commands
- docs.json configuration with property reference
- Remote HTTPS sources (incl. Maven Central javadoc jars) and size limits
- `.mintignore` convention and CI update pattern

Nav entry added after `graphql-setup`. Follows the graphql-setup page structure.

Note: the `sdk` property on non-tab divisions is in flight in mintlify/mint#9459 — this page documents tab usage, which works today.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation wiring only; no product code or runtime behavior changes.
> 
> **Overview**
> Documents the **`sdk` navigation property** for auto-generating SDK reference pages from TypeDoc, DocFX, Javadoc, Sphinx, and phpDocumentor artifacts.
> 
> Adds **`api-playground/sdk-reference-setup`**, covering supported formats, artifact generation commands, tab-level `docs.json` config (`format`, `source`, `directory`), remote HTTPS sources (including Maven Central Javadoc jars) with size limits, `.mintignore`, and CI refresh patterns. The page is linked in **Document APIs** nav (after GraphQL setup).
> 
> **`organize/navigation.mdx`** gains an **SDK references** section (parallel to OpenAPI) with a tab `sdk` example and a link to the new guide. Vale accepts **`doclet(s)?`** for Javadoc terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2780c4098d189cefc94ae5be13b5c9d5a93fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->