### PR TITLE
SDK reference polish

### DIFF
--- a/api-playground/sdk-reference-setup.mdx
+++ b/api-playground/sdk-reference-setup.mdx
@@ -65,23 +65,33 @@ Add an `sdk` property to a tab in your `docs.json`. Mintlify parses the artifact
 }
 ```
 
-<ResponseField name="format" type="string" required>
+<Note>
+  You must declare `sdk` on a [tab](/organize/navigation#tabs). A tab with `sdk` may include `groups`, but no other navigation structures, such as `pages`, `versions`, or `languages`. It also cannot include an `openapi`, `asyncapi`, or `graphql` property.
+</Note>
+
+<ParamField path="format" type="string" required>
   The documentation tool that produced the artifact: `typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`.
-</ResponseField>
+</ParamField>
 
-<ResponseField name="source" type="string" required>
-  Relative path to the artifact file or directory in your docs repository, or an HTTPS URL.
-</ResponseField>
+<ParamField path="source" type="string" required>
+  Relative path to the artifact file or directory in your docs repository, or an HTTPS URL. Does not accept HTTP URLs.
+</ParamField>
 
-<ResponseField name="directory" type="string">
+<ParamField path="directory" type="string">
   The URL path prefix for generated pages. Defaults to `sdk-reference`.
-</ResponseField>
+</ParamField>
 
-Add multiple tabs to document multiple libraries. Each tab needs a unique `directory`.
+Add multiple tabs to document multiple libraries. Use a unique `directory` for each library to avoid route collisions.
 
 <Tip>
   Add your artifact directory to [`.mintignore`](/organize/mintignore) so Mintlify treats artifacts as build inputs rather than publishing them as static assets.
 </Tip>
+
+## Generated pages
+
+Mintlify adds the generated navigation groups after any hand-written `groups` on the tab. The groups vary by format and may represent modules, packages, namespaces, or symbol types.
+
+Each generated page documents a class, interface, function, type, or other symbol from the artifact and links to related generated pages. If a converter produces pages that do not belong to a group, Mintlify collects them under a `Reference` group.
 
 ## Use remote sources
 

--- a/api-playground/sdk-reference-setup.mdx
+++ b/api-playground/sdk-reference-setup.mdx
@@ -89,7 +89,7 @@ Add multiple tabs to document multiple libraries. Use a unique `directory` for e
 
 ## Generated pages
 
-Mintlify adds the generated navigation groups after any hand-written `groups` on the tab. The groups vary by format and may represent modules, packages, namespaces, or symbol types.
+Mintlify adds the generated navigation groups after any `groups` on the tab. The groups vary by format and may represent modules, packages, namespaces, or symbol types.
 
 Each generated page documents a class, interface, function, type, or other symbol from the artifact and links to related generated pages. If a converter produces pages that do not belong to a group, Mintlify collects them under a `Reference` group.
 


### PR DESCRIPTION
## Documentation changes

Copy edits to the SDK reference setup guide

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy and component changes with no runtime or configuration behavior changes.
> 
> **Overview**
> **Polishes** the SDK reference setup guide in `sdk-reference-setup.mdx` so it matches patterns used in sibling API playground docs (e.g. GraphQL setup).
> 
> Adds a **`<Note>`** on tab-only `sdk` usage: allowed `groups`, forbidden nav structures (`pages`, `versions`, `languages`), and incompatibility with `openapi`, `asyncapi`, and `graphql`.
> 
> Replaces **`ResponseField`** with **`ParamField`** for `format`, `source`, and `directory`. **`source`** now explicitly states **HTTPS only** (no HTTP). Multi-library guidance now stresses a **unique `directory`** to avoid route collisions.
> 
> Adds a new **Generated pages** section describing how Mintlify orders nav groups after tab `groups`, how grouping varies by format, per-symbol pages with cross-links, and the fallback **`Reference`** group for ungrouped pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79e695208d7e7c9045cd44faa1386120d1da0b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->