### PR TITLE
document cookie consent options

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -293,6 +293,7 @@
                         "group": "Privacy",
                         "root": "integrations/privacy/overview",
                         "pages": [
+                          "integrations/privacy/transcend",
                           "integrations/privacy/osano"
                         ]
                       }

--- a/docs.json
+++ b/docs.json
@@ -296,6 +296,7 @@
                         "group": "Privacy",
                         "root": "integrations/privacy/overview",
                         "pages": [
+                          "integrations/privacy/onetrust",
                           "integrations/privacy/transcend",
                           "integrations/privacy/osano"
                         ]

--- a/integrations/privacy/onetrust.mdx
+++ b/integrations/privacy/onetrust.mdx
@@ -1,0 +1,67 @@
+---
+title: "OneTrust"
+description: "Connect OneTrust Cookie Consent to your Mintlify documentation site and prevent analytics from loading without consent."
+keywords: ["OneTrust integration", "cookie consent manager", "analytics consent", "GDPR compliance"]
+---
+
+Connect a [OneTrust Cookie Consent](https://www.onetrust.com/products/cookie-consent/) domain in your `docs.json` file.
+
+## Before you begin
+
+In OneTrust, add your documentation domains, configure and publish your consent banner, then copy the domain script ID from the generated script.
+
+Your OneTrust configuration must include the category that controls analytics. Mintlify uses `C0002`, OneTrust's performance and analytics category, by default.
+
+## Configure OneTrust
+
+Add your domain script ID under `integrations.onetrust`:
+
+```json
+{
+  "integrations": {
+    "onetrust": {
+      "domainScript": "YOUR_DOMAIN_SCRIPT_ID"
+    }
+  }
+}
+```
+
+If your OneTrust setup uses a different analytics category, specify its ID:
+
+```json
+{
+  "integrations": {
+    "onetrust": {
+      "domainScript": "YOUR_DOMAIN_SCRIPT_ID",
+      "categoryId": "C0004"
+    }
+  }
+}
+```
+
+Mintlify loads OneTrust's consent script and listens for changes to the configured category. Mintlify analytics, configured analytics integrations, and page feedback remain disabled while consent is unresolved or the category is inactive.
+
+<Note>
+  OneTrust must be configured for your documentation domains. A banner configured only for another
+  domain does not automatically run on your Mintlify site.
+</Note>
+
+If your organization hosts the OneTrust script at a different URL, set `scriptSource` to the full HTTPS URL:
+
+```json
+{
+  "integrations": {
+    "onetrust": {
+      "domainScript": "YOUR_DOMAIN_SCRIPT_ID",
+      "scriptSource": "https://privacy.example.com/otSDKStub.js"
+    }
+  }
+}
+```
+
+Consent reporting, audit history, legal regimes, and policy configuration remain in your OneTrust account. Mintlify does not copy individual consent decisions into the Mintlify dashboard.
+
+When OneTrust is configured, it takes precedence over Mintlify's native consent banner so visitors
+see only one consent experience. To switch back to the native banner, remove
+`integrations.onetrust` and enable **Show Mintlify consent banner** under **Settings** → **Privacy**
+in the Mintlify dashboard.

--- a/integrations/privacy/overview.mdx
+++ b/integrations/privacy/overview.mdx
@@ -25,7 +25,10 @@ Your organization configures and maintains its account with the consent manager.
 Transcend or OneTrust integration takes precedence over Mintlify's native banner so that visitors
 see one consent experience. If you load Osano with a custom script, turn off the native banner.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card title="OneTrust" href="/integrations/privacy/onetrust" icon="shield-check">
+    Connect a OneTrust domain and use its analytics category to control tracking.
+  </Card>
   <Card title="Transcend" href="/integrations/privacy/transcend" icon="shield-check">
     Connect a Transcend Consent Management bundle and use its Analytics purpose to control tracking.
   </Card>

--- a/integrations/privacy/overview.mdx
+++ b/integrations/privacy/overview.mdx
@@ -1,43 +1,91 @@
 ---
-title: "Privacy integrations"
-description: "Connect your Mintlify documentation site to privacy platforms like Osano to manage cookie consent, compliance banners, and user preferences."
+title: "Privacy and cookie consent"
+description: "Show Mintlify's native consent banner or connect a consent management platform to control analytics on your documentation site."
 keywords: ["data privacy platforms", "compliance integrations", "privacy tools", "cookie consent"]
 ---
 
-<Card
+Mintlify provides a native consent banner for every documentation site. The banner is off by default so that existing sites don't change behavior without an administrator choosing to enable it.
+
+## Enable the native consent banner
+
+In the dashboard, open your project's **Settings** → **Privacy**, then turn on **Show Mintlify consent banner**.
+
+The banner asks visitors for consent before Mintlify analytics, configured analytics integrations, and page feedback load. A visitor's choice is stored locally in their browser. Revoking measurement consent reloads the page to stop analytics that have already loaded.
+
+<Note>
+  The native banner does not send consent decisions to a centralized dashboard or create an audit
+  log.
+</Note>
+
+## Connect a consent manager
+
+Use a consent manager when your organization needs its own policy configuration, cross-domain consent, reporting, or consent records.
+
+Your organization configures and maintains its account with the consent manager. A configured
+Transcend or OneTrust integration takes precedence over Mintlify's native banner so that visitors
+see one consent experience. If you load Osano with a custom script, turn off the native banner.
+
+<CardGroup cols={2}>
+  <Card title="Transcend" href="/integrations/privacy/transcend" icon="shield-check">
+    Connect a Transcend Consent Management bundle and use its Analytics purpose to control tracking.
+  </Card>
+  <Card
     title="Osano"
     href="/integrations/privacy/osano"
-    icon={<svg width="32" height="32" className="h-6 w-6" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" clipRule="evenodd" d="M128 256C198.692 256 256 198.692 256 128C256 57.3076 198.692 0 128 0C57.3076 0 0 57.3076 0 128C0 198.692 57.3076 256 128 256ZM128 192C163.346 192 192 163.346 192 128C192 92.6538 163.346 64 128 64C92.6538 64 64 92.6538 64 128C64 163.346 92.6538 192 128 192Z" fill="#7764FA"/></svg>}
-    horizontal
+    icon={
+      <svg
+        width="32"
+        height="32"
+        className="h-6 w-6"
+        viewBox="0 0 256 256"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M128 256C198.692 256 256 198.692 256 128C256 57.3076 198.692 0 128 0C57.3076 0 0 57.3076 0 128C0 198.692 57.3076 256 128 256ZM128 192C163.346 192 192 163.346 192 128C192 92.6538 163.346 64 128 64C92.6538 64 64 92.6538 64 128C64 163.346 92.6538 192 128 192Z"
+          fill="#7764FA"
+        />
+      </svg>
+    }
   >
-  Manage cookie consent with [Osano](https://www.osano.com/).
-</Card>
+    Add an Osano consent manager with a custom script.
+  </Card>
+</CardGroup>
 
-## Cookie consent and disabling telemetry
+## Use an existing local storage consent signal
 
-If you need to check if a user has already consented to cookies for GDPR compliance, you can specify a local storage key and value under `cookies`:
+If another consent tool stores a visitor's choice in local storage, specify its key and accepted value under `cookies`:
 
 ```json
+{
   "integrations": {
     "cookies": {
-      "key": "LOCAL STORAGE KEY",
-      "value": "LOCAL STORAGE VALUE"
+      "key": "LOCAL_STORAGE_KEY",
+      "value": "LOCAL_STORAGE_VALUE"
     }
   }
+}
 ```
 
-If you set these values, your site checks local storage for the specified key and value to determine if a user consented to cookies. If a user has not consented to cookies, your site disables telemetry for that user.
+Your site disables analytics until the local storage value matches.
+
+## Disable telemetry
 
 If you'd like to disable telemetry for all users, add the following to your `docs.json` file:
 
 ```json
+{
   "integrations": {
     "telemetry": {
       "enabled": false
     }
   }
+}
 ```
 
 <Note>
-  If you disable telemetry, you cannot collect feedback on your documentation pages, even if you enable feedback in your dashboard.
+  If you disable telemetry, you cannot collect feedback on your documentation pages, even if you
+  enable feedback in your dashboard.
 </Note>

--- a/integrations/privacy/transcend.mdx
+++ b/integrations/privacy/transcend.mdx
@@ -1,0 +1,56 @@
+---
+title: "Transcend"
+description: "Connect Transcend Consent Management to your Mintlify documentation site and prevent analytics from loading without consent."
+keywords:
+  ["Transcend integration", "cookie consent manager", "analytics consent", "GDPR compliance"]
+---
+
+Connect a [Transcend Consent Management](https://transcend.io/consent-management) bundle in your `docs.json` file.
+
+## Before you begin
+
+In Transcend, configure your documentation domains and deploy the consent manager bundle. Note the bundle ID from **Consent Management** → **Developer Settings**.
+
+Your bundle must include the purpose that should control analytics. The default purpose name in Mintlify is `Analytics`.
+
+## Configure Transcend
+
+Add your bundle ID under `integrations.transcend`:
+
+```json
+{
+  "integrations": {
+    "transcend": {
+      "bundleId": "YOUR_BUNDLE_ID"
+    }
+  }
+}
+```
+
+Mintlify uses the `Analytics` purpose by default. If your bundle uses a different purpose name,
+specify its exact, case-sensitive name:
+
+```json
+{
+  "integrations": {
+    "transcend": {
+      "bundleId": "YOUR_BUNDLE_ID",
+      "analyticsPurpose": "Performance"
+    }
+  }
+}
+```
+
+Mintlify loads Transcend's `airgap.js` before other scripts and prompts visitors with the consent interface. Mintlify analytics, configured analytics integrations, and page feedback remain disabled while consent is unresolved or the configured purpose is denied.
+
+<Warning>
+  If the configured purpose name doesn't match a purpose in your Transcend bundle, Mintlify treats
+  analytics consent as denied.
+</Warning>
+
+Consent reporting, audit history, legal regimes, and policy configuration remain in your Transcend account. Mintlify does not copy individual consent decisions into the Mintlify dashboard.
+
+When Transcend is configured, it takes precedence over Mintlify's native consent banner so visitors
+see only one consent experience. To switch back to the native banner, remove
+`integrations.transcend` and enable **Show Mintlify consent banner** under **Settings** → **Privacy**
+in the Mintlify dashboard.


### PR DESCRIPTION
## Documentation changes
documents the native cookie consent banner and how to enable it under Settings → Privacy

adds Transcend setup, precedence, and analytics purpose configuration

implementations:
- https://github.com/mintlify/mint/pull/9528
- https://github.com/mintlify/mint/pull/9529

## Test Plan
preview the Privacy and cookie consent pages
verify the config examples pass `docs.json` validation
