### PR TITLE
playground updates

### DIFF
--- a/assistant/widget.mdx
+++ b/assistant/widget.mdx
@@ -12,6 +12,12 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
+export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
+
+export const WidgetThemeIcon = () => (
+  <span aria-hidden="true" className="assistant-playground-theme-icon" />
+);
+
 The [assistant](/assistant) answers questions on your Mintlify site. To embed the same capability on another site or web app, use the widget. With the widget, you can give your users access to AI chat trained on your content in your product dashboard, marketing site, support portal, or elsewhere.
 
 Add the widget to any website or web application with a hosted script. The widget owns its trigger and renders inside a closed Shadow DOM, which prevents your application styles from affecting the widget.
@@ -39,7 +45,11 @@ Use the playground to configure the presentation, visual options, and observer h
 
 After you add the generated code to your site, reload the page. Confirm the trigger appears, then click it and send a test question to verify the connection.
 
-<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
+<AssistantWidgetPlayground
+  CodeBlockComponent={WidgetCodeBlock}
+  CustomizeIconComponent={WidgetCustomizeIcon}
+  ThemeIconComponent={WidgetThemeIcon}
+>
 
 <Warning>
   Module scripts defer and run in document order. Keep the hosted loader before the initialization block when you install the widget with HTML, or the widget fails to mount.

--- a/es/assistant/widget.mdx
+++ b/es/assistant/widget.mdx
@@ -12,6 +12,12 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
+export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
+
+export const WidgetThemeIcon = () => (
+  <span aria-hidden="true" className="assistant-playground-theme-icon" />
+);
+
 El [asistente](/es/assistant) responde preguntas en tu sitio de Mintlify. Para incrustar la misma capacidad en otro sitio o aplicación web, usa el widget. Con el widget, puedes ofrecer a tus usuarios acceso a un chat de IA entrenado con tu contenido en el panel de tu producto, sitio de marketing, portal de soporte u otros lugares.
 
 Añade el widget a cualquier sitio web o aplicación web con un script alojado. El widget gestiona su propio activador y se renderiza dentro de un Shadow DOM cerrado, lo que evita que los estilos de tu aplicación afecten al widget.
@@ -45,7 +51,11 @@ Usa el playground para configurar la presentación, las opciones visuales y los 
 
 Después de añadir el código generado a tu sitio, recarga la página. Confirma que aparece el activador y, luego, haz clic en él y envía una pregunta de prueba para verificar que el widget está conectado.
 
-<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
+<AssistantWidgetPlayground
+  CodeBlockComponent={WidgetCodeBlock}
+  CustomizeIconComponent={WidgetCustomizeIcon}
+  ThemeIconComponent={WidgetThemeIcon}
+>
 
 <Warning>
   Los scripts de módulo se difieren y se ejecutan en el orden del documento. Mantén el cargador alojado antes del bloque de inicialización cuando instales el widget con HTML, o el widget no se montará.

--- a/fr/assistant/widget.mdx
+++ b/fr/assistant/widget.mdx
@@ -12,6 +12,12 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
+export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
+
+export const WidgetThemeIcon = () => (
+  <span aria-hidden="true" className="assistant-playground-theme-icon" />
+);
+
 L'[assistant](/fr/assistant) répond aux questions sur votre site Mintlify. Pour intégrer la même capacité sur un autre site ou application web, utilisez le widget. Grâce au widget, vous pouvez donner à vos utilisateurs l'accès à un chat IA entraîné sur votre contenu dans le tableau de bord de votre produit, votre site marketing, votre portail d'assistance ou ailleurs.
 
 Ajoutez le widget à n'importe quel site web ou application web à l'aide d'un script hébergé. Le widget possède son propre déclencheur et s'affiche dans un Shadow DOM fermé, ce qui empêche les styles de votre application d'affecter le widget.
@@ -45,7 +51,11 @@ Utilisez le playground pour configurer la présentation, les options visuelles e
 
 Après avoir ajouté le code généré à votre site, rechargez la page. Vérifiez que le déclencheur apparaît, puis cliquez dessus et envoyez une question de test pour confirmer que le widget est connecté.
 
-<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
+<AssistantWidgetPlayground
+  CodeBlockComponent={WidgetCodeBlock}
+  CustomizeIconComponent={WidgetCustomizeIcon}
+  ThemeIconComponent={WidgetThemeIcon}
+>
 
 <Warning>
   Les scripts de module sont différés et exécutés dans l'ordre du document. Gardez le chargeur hébergé avant le bloc d'initialisation lorsque vous installez le widget en HTML, sinon le widget ne parvient pas à se monter.

--- a/playground.css
+++ b/playground.css
@@ -73,9 +73,11 @@ html[data-current-path$="/assistant/widget"]
 html[data-current-path$="/assistant/widget"]
   .assistant-playground-field__control:focus-visible,
 html[data-current-path$="/assistant/widget"]
-  .assistant-playground-accent:focus-within,
+  .assistant-playground-accent[data-keyboard-focus="true"],
 html[data-current-path$="/assistant/widget"]
-  .assistant-playground-switch:focus-within,
+  .assistant-playground-switch:has(
+    .assistant-playground-switch__input:focus-visible
+  ),
 html[data-current-path$="/assistant/widget"]
   .assistant-playground-code__tabs
   button:focus-visible {
@@ -385,7 +387,7 @@ html[data-current-path$="/assistant/widget"]
   button:hover,
 html[data-current-path$="/assistant/widget"]
   .assistant-playground-select__options
-  button[data-selected="true"] {
+  button[data-active="true"] {
   background: color-mix(
     in srgb,
     var(--assistant-playground-surface),
@@ -425,9 +427,21 @@ html[data-current-path$="/assistant/widget"]
 
 html[data-current-path$="/assistant/widget"]
   .assistant-playground-customizer__divider {
+  display: flex;
   height: 12px;
+  align-items: flex-start;
   margin-inline: -6px;
-  border-top: 1px dashed var(--assistant-playground-stroke);
+  color: var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-customizer__divider
+  svg {
+  display: block;
+  width: 100%;
+  height: 1px;
+  flex: 0 0 auto;
+  overflow: visible;
 }
 
 html[data-current-path$="/assistant/widget"] .assistant-playground-hook {

--- a/playground.css
+++ b/playground.css
@@ -327,6 +327,22 @@ html[data-current-path$="/assistant/widget"]
 }
 
 html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__end {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__detail {
+  color: var(--assistant-playground-text-weak);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+html[data-current-path$="/assistant/widget"]
   .assistant-playground-select__options {
   position: absolute;
   z-index: 7;
@@ -352,6 +368,8 @@ html[data-current-path$="/assistant/widget"]
   width: 100%;
   min-height: 28px;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   padding: 4px 7px;
   border: 0;
   border-radius: 4px;

--- a/playground.css
+++ b/playground.css
@@ -429,7 +429,7 @@ html[data-current-path$="/assistant/widget"]
   .assistant-playground-customizer__divider {
   display: flex;
   height: 12px;
-  align-items: flex-start;
+  align-items: center;
   margin-inline: -6px;
   color: var(--assistant-playground-stroke);
 }

--- a/playground.css
+++ b/playground.css
@@ -1,38 +1,587 @@
-@media (min-width: 1024px) {
-  html[data-current-path="/assistant/widget"] #content-area {
-    position: relative;
-    max-width: 1800px !important;
-    margin-inline: auto;
-    /* Percentage padding resolves against the parent, so cap it at half of the 1800px max-width */
-    padding-right: calc(min(50%, 900px) + 1rem);
-  }
-
-  html[data-current-path="/assistant/widget"] #content {
-    position: static;
-  }
-
-  html[data-current-path="/assistant/widget"] [data-assistant-preview] {
-    position: absolute;
-    inset: 0 1.5rem 0 auto;
-    width: calc(50% - 2.5rem);
-  }
+html[data-current-path$="/assistant/widget"] [data-assistant-playground-layout] {
+  --assistant-playground-frame: #f8f8f8;
+  --assistant-playground-surface: #fcfcfc;
+  --assistant-playground-text-strong: #171717;
+  --assistant-playground-text-default: #6f6f6f;
+  --assistant-playground-text-weak: #8f8f8f;
+  --assistant-playground-stroke: rgba(0, 0, 0, 0.07);
+  --assistant-playground-switch: #147d6f;
+  width: min(100%, 720px);
+  margin: 1.5rem auto;
+  font-family: var(--font-inter), Inter, ui-sans-serif, system-ui, sans-serif;
 }
 
-html[data-current-path="/assistant/widget"]
-  div:has(> iframe[title="Live Assistant Widget preview"]) {
-  min-height: 0;
-  flex: 1 1 0%;
+html.dark[data-current-path$="/assistant/widget"]
+  [data-assistant-playground-layout] {
+  --assistant-playground-frame: #1c1c1c;
+  --assistant-playground-surface: #242424;
+  --assistant-playground-text-strong: #f5f5f5;
+  --assistant-playground-text-default: #b8b8b8;
+  --assistant-playground-text-weak: #8f8f8f;
+  --assistant-playground-stroke: rgba(255, 255, 255, 0.12);
 }
 
-html[data-current-path="/assistant/widget"]
-  iframe[title="Live Assistant Widget preview"] {
+html[data-current-path$="/assistant/widget"] .assistant-playground-frame {
+  position: relative;
+  height: 720px;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--assistant-playground-frame);
+  box-shadow: 0 0 0 1px var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-toolbar {
+  position: absolute;
+  z-index: 4;
+  top: 10px;
+  left: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button {
+  display: inline-flex;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 0;
+  border-radius: 6px;
+  background: var(--assistant-playground-surface);
+  color: var(--assistant-playground-text-strong);
+  box-shadow:
+    0 4px 2px rgba(0, 0, 0, 0.04),
+    0 1px 1px rgba(0, 0, 0, 0.08),
+    0 1px 1px rgba(0, 0, 0, 0.04),
+    0 0 0 1px var(--assistant-playground-stroke);
+  cursor: pointer;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button:hover {
+  background: color-mix(
+    in srgb,
+    var(--assistant-playground-surface),
+    var(--assistant-playground-text-strong) 4%
+  );
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button:focus-visible,
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-field__control:focus-visible,
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-accent:focus-within,
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-switch:focus-within,
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__tabs
+  button:focus-visible {
+  outline: 2px solid #006adc;
+  outline-offset: 2px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button--labeled {
+  gap: 2px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.013px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button--labeled
+  > span {
+  padding-inline: 4px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button--icon {
+  width: 28px;
+  padding: 6px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-toolbar__button
+  svg {
+  width: 16px;
+  height: 16px;
+  background-color: var(--assistant-playground-text-default) !important;
+  color: var(--assistant-playground-text-default);
+  opacity: 1;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-theme-icon {
+  position: relative;
+  display: block;
+  width: 16px;
+  height: 16px;
+  overflow: hidden;
+  border: 1.5px solid var(--assistant-playground-text-default);
+  border-radius: 50%;
+  color: var(--assistant-playground-text-default);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-theme-icon::before {
+  position: absolute;
+  inset: 0 50% 0 0;
+  background: currentColor;
+  content: "";
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-preview {
+  position: absolute;
+  inset: 0;
+  width: 100%;
   height: 100%;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-preview
+  > div:has(> iframe[title="Live Assistant Widget preview"]) {
+  width: 100%;
+  height: 100%;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-preview
+  iframe[title="Live Assistant Widget preview"] {
+  display: block;
+  width: 100%;
+  height: 100% !important;
+  aspect-ratio: auto !important;
+  border: 0;
+  background: var(--assistant-playground-frame);
+  color-scheme: light dark;
+}
+
+html.dark[data-current-path$="/assistant/widget"]
+  .assistant-playground-preview
+  iframe[title="Live Assistant Widget preview"] {
+  color-scheme: dark;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-preview__status {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 20px;
+  color: var(--assistant-playground-text-default);
+  font-size: 12px;
+  line-height: 18px;
+  text-align: center;
+  pointer-events: none;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-preview__spinner {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+  border: 1.5px solid #d4d4d4;
+  border-top-color: var(--assistant-playground-text-default);
+  border-radius: 50%;
+  animation: assistant-playground-spin 700ms linear infinite;
+}
+
+@keyframes assistant-playground-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-current-path$="/assistant/widget"] .assistant-playground-frame {
+    transition: none;
+  }
+
+  html[data-current-path$="/assistant/widget"]
+    .assistant-playground-preview__spinner {
+    animation: none;
+  }
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-customizer {
+  position: absolute;
+  z-index: 3;
+  top: 50px;
+  left: 10px;
+  width: min(307px, calc(100% - 20px));
+  overflow: visible;
+  padding: 6px;
+  border-radius: 6px;
+  background: var(--assistant-playground-surface);
+  color: var(--assistant-playground-text-strong);
+  box-shadow:
+    0 4px 2px rgba(0, 0, 0, 0.04),
+    0 1px 1px rgba(0, 0, 0, 0.08),
+    0 1px 1px rgba(0, 0, 0, 0.04),
+    0 0 0 1px var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-customizer[hidden] {
+  display: none;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-customizer__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-customizer__heading {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  padding: 4px 8px;
+  color: var(--assistant-playground-text-weak);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.013px;
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-field {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  gap: 20px;
+  padding: 6px 8px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.014px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-field__label {
+  width: 91px;
+  flex: 0 0 91px;
+  color: var(--assistant-playground-text-strong);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-select,
+html[data-current-path$="/assistant/widget"] .assistant-playground-accent {
+  width: 168px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-field__control,
+html[data-current-path$="/assistant/widget"] .assistant-playground-accent {
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--assistant-playground-surface);
+  color: var(--assistant-playground-text-default);
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.1),
+    0 0 0 1px var(--assistant-playground-stroke);
+  font: inherit;
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-select {
+  position: relative;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select[data-open="true"] {
+  z-index: 6;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-field__control {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 9px;
+  text-align: left;
+  cursor: pointer;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__chevron {
+  display: block;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  color: var(--assistant-playground-text-default);
+  opacity: 1;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__options {
+  position: absolute;
+  z-index: 7;
+  top: calc(100% + 4px);
+  left: 0;
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 1px;
+  padding: 3px;
+  border-radius: 6px;
+  background: var(--assistant-playground-surface);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    0 0 0 1px var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__options
+  button {
+  display: flex;
+  width: 100%;
+  min-height: 28px;
+  align-items: center;
+  padding: 4px 7px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--assistant-playground-text-default);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__options
+  button:hover,
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-select__options
+  button[data-selected="true"] {
+  background: color-mix(
+    in srgb,
+    var(--assistant-playground-surface),
+    var(--assistant-playground-text-strong) 6%
+  );
+  color: var(--assistant-playground-text-strong);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-accent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-accent__input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  opacity: 0;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-accent__swatch {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  border-radius: 2px;
+  box-shadow:
+    0 0 0 1px var(--assistant-playground-surface),
+    0 0 0 2px rgba(0, 0, 0, 0.1);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-customizer__divider {
+  height: 12px;
+  margin-inline: -6px;
+  border-top: 1px dashed var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-hook {
+  display: flex;
+  min-height: 74px;
+  align-items: flex-start;
+  gap: 28px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-hook__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.014px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-hook__label {
+  color: var(--assistant-playground-text-strong);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-hook__description {
+  color: var(--assistant-playground-text-default);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-switch {
+  position: relative;
+  display: flex;
+  width: 26px;
+  height: 18px;
+  flex: 0 0 26px;
+  justify-content: flex-start;
+  overflow: hidden;
+  padding: 1px;
+  border-radius: 3px;
+  background: #d7d7d7;
+  box-shadow:
+    inset 0 1px 1px rgba(0, 0, 0, 0.1),
+    inset 0 2px 4px rgba(0, 0, 0, 0.08),
+    inset 0 0.2px 0 0.5px rgba(0, 0, 0, 0.08);
+  transition: background 120ms ease;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-switch[data-checked="true"] {
+  justify-content: flex-end;
+  background: var(--assistant-playground-switch);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-switch__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-switch__knob {
+  width: 12px;
+  height: 16px;
+  border-radius: 2px;
+  background: #fcfcfc;
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.05),
+    0 2px 2px rgba(0, 0, 0, 0.04),
+    0 1px 1px rgba(0, 0, 0, 0.12);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-code {
+  margin-top: 24px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__title {
+  color: var(--assistant-playground-text-strong);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__description {
+  margin-top: 2px;
+  color: var(--assistant-playground-text-default);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 8px;
+  background: var(--assistant-playground-frame);
+  box-shadow: 0 0 0 1px var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__tabs
+  button {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--assistant-playground-text-default);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  cursor: pointer;
+}
+
+html[data-current-path$="/assistant/widget"]
+  .assistant-playground-code__tabs
+  button[data-active="true"] {
+  background: var(--assistant-playground-surface);
+  color: var(--assistant-playground-text-strong);
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.08),
+    0 0 0 1px var(--assistant-playground-stroke);
+}
+
+html[data-current-path$="/assistant/widget"] .assistant-playground-children {
+  margin-top: 32px;
+}
+
+@media (max-width: 540px) {
+  html[data-current-path$="/assistant/widget"]
+    .assistant-playground-frame[data-customize-open="true"]
+    .assistant-playground-preview {
+    visibility: hidden;
+  }
+
+  html[data-current-path$="/assistant/widget"]
+    .assistant-playground-customizer {
+    max-height: 475px;
+    overflow-y: auto;
+  }
+
+  html[data-current-path$="/assistant/widget"]
+    .assistant-playground-code__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 /* The widget playground embeds /assistant/widget-preview in its preview
    iframe. The suffix match keeps localized paths covered. Hide every piece of
-   docs chrome so only the widget renders, and keep the document transparent
-   so the playground card provides the visible frame. */
+   docs chrome so only the widget renders. */
 html[data-current-path$="/assistant/widget-preview"] #navbar,
 html[data-current-path$="/assistant/widget-preview"] #navbar-transition,
 html[data-current-path$="/assistant/widget-preview"] #mobile-nav,
@@ -52,5 +601,10 @@ html[data-current-path$="/assistant/widget-preview"] body {
   height: 100%;
   margin: 0;
   overflow: hidden !important;
-  background: transparent !important;
+  background: #f8f8f8 !important;
+}
+
+html.dark[data-current-path$="/assistant/widget-preview"],
+html.dark[data-current-path$="/assistant/widget-preview"] body {
+  background: #1c1c1c !important;
 }

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -1,12 +1,18 @@
-export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
+export const AssistantWidgetPlayground = ({
+  children,
+  CodeBlockComponent,
+  CustomizeIconComponent,
+  ThemeIconComponent,
+}) => {
   // Mintlify evaluates snippet exports independently, so shared values must stay in this scope.
   const EXAMPLE_WIDGET_ID = "YOUR_WIDGET_ID";
   const EMBED_URL =
     "https://cdn.jsdelivr.net/npm/@mintlify/assistant-widget@0.0/dist/browser/embed.js";
   // The preview loads the hidden /assistant/widget-preview page through the
-  // chromeless `/_minimal/` renderer instead of a srcdoc iframe: captcha
-  // providers reject documents without a hostname, and srcdoc documents have
-  // none. Message names must stay in sync with
+  // chromeless `/_minimal/` renderer when deployed, and directly in local
+  // previews where that renderer is unavailable. A real page URL is required
+  // because captcha providers reject srcdoc documents without a hostname.
+  // Message names must stay in sync with
   // snippets/assistant-widget-preview-host.jsx.
   const PREVIEW_READY_MESSAGE = "mintlify-assistant-playground:ready";
   const PREVIEW_UPDATE_MESSAGE = "mintlify-assistant-playground:update";
@@ -22,18 +28,20 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
     { value: "modal", label: "Modal" },
     { value: "panel", label: "Panel" },
   ];
-  const THEME_OPTIONS = [
-    { value: "system", label: "System" },
-    { value: "light", label: "Light" },
-    { value: "dark", label: "Dark" },
+  const RADIUS_OPTIONS = [
+    { value: 8, label: "Small" },
+    { value: 18, label: "Medium" },
+    { value: 28, label: "Large" },
   ];
+  // Mentha labels the direction the assistant opens; the widget API stores
+  // the trigger's screen edge, so each label maps to the opposite edge.
   const SIDE_OPTIONS = [
-    { value: "top", label: "Top" },
-    { value: "bottom", label: "Bottom" },
-    { value: "left", label: "Left" },
-    { value: "right", label: "Right" },
-    { value: "inline-start", label: "Inline start" },
-    { value: "inline-end", label: "Inline end" },
+    { value: "bottom", label: "Top" },
+    { value: "top", label: "Bottom" },
+    { value: "right", label: "Left" },
+    { value: "left", label: "Right" },
+    { value: "inline-end", label: "Inline start" },
+    { value: "inline-start", label: "Inline end" },
   ];
   const ALIGN_OPTIONS = [
     { value: "start", label: "Start" },
@@ -48,12 +56,14 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
   const [installTarget, setInstallTarget] = useState("html");
   const [variant, setVariant] = useState("widget");
   const [theme, setTheme] = useState("system");
-  const [accent, setAccent] = useState("#16a34a");
-  const [radius, setRadius] = useState(18);
+  const [accent, setAccent] = useState("#006ADC");
+  const [radius, setRadius] = useState(8);
   const [side, setSide] = useState("bottom");
   const [align, setAlign] = useState("end");
   const [trackEvents, setTrackEvents] = useState(false);
   const [reportErrors, setReportErrors] = useState(false);
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [openSelect, setOpenSelect] = useState(null);
   const [previewHostReady, setPreviewHostReady] = useState(false);
   const [previewUrl, setPreviewUrl] = useState(null);
   const [previewStatus, setPreviewStatus] = useState("loading");
@@ -72,8 +82,13 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
     const mode = document.documentElement.classList.contains("dark")
       ? "dark"
       : "light";
+    const rendererPrefix =
+      window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1"
+        ? ""
+        : "/_minimal";
     setPreviewUrl(
-      `${basePath}/_minimal${locale}/assistant/widget-preview?mode=${mode}`,
+      `${basePath}${rendererPrefix}${locale}/assistant/widget-preview?mode=${mode}`,
     );
   }, []);
 
@@ -120,91 +135,163 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
     return () => observer.disconnect();
   }, []);
 
-  const classNames = (...classes) => classes.filter(Boolean).join(" ");
+  useEffect(() => {
+    if (!openSelect) return undefined;
 
-  const renderSegmentedControl = ({
-    ariaLabel,
-    onChange,
-    options,
-    threeColumns = false,
-    value,
-  }) => (
-    <div
-      role="group"
-      aria-label={ariaLabel}
-      className="grid gap-1 rounded-lg bg-gray-100 p-1 dark:bg-white/10"
-      style={{
-        gridTemplateColumns: `repeat(${threeColumns ? 3 : options.length}, minmax(0, 1fr))`,
-      }}
-    >
-      {options.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          aria-pressed={value === option.value}
-          onClick={() => onChange(option.value)}
-          className={classNames(
-            "min-h-8 rounded-md px-2 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-            value === option.value
-              ? "bg-white text-gray-950 shadow-sm dark:bg-white/15 dark:text-white"
-              : "text-gray-600 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white",
-          )}
+    const closeOnPointerDown = (event) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest(`[data-assistant-select="${openSelect}"]`)
+      ) {
+        return;
+      }
+      setOpenSelect(null);
+    };
+    const closeOnEscape = (event) => {
+      if (event.key === "Escape") setOpenSelect(null);
+    };
+
+    document.addEventListener("pointerdown", closeOnPointerDown);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnPointerDown);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [openSelect]);
+
+  const renderSelectField = ({ id, label, onChange, options, value }) => {
+    const isOpen = openSelect === id;
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    const selectedOption = options[selectedIndex] ?? options[0];
+
+    const selectByIndex = (index) => {
+      const option = options[index];
+      if (option) onChange(option.value);
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        if (!isOpen) {
+          setOpenSelect(id);
+          return;
+        }
+
+        const direction = event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex =
+          (Math.max(selectedIndex, 0) + direction + options.length) %
+          options.length;
+        selectByIndex(nextIndex);
+        return;
+      }
+      if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        selectByIndex(event.key === "Home" ? 0 : options.length - 1);
+      }
+    };
+
+    return (
+      <div className="assistant-playground-field">
+        <span
+          id={`assistant-playground-${id}-label`}
+          className="assistant-playground-field__label"
         >
-          {option.label}
-        </button>
-      ))}
-    </div>
-  );
-
-  const renderSelectField = ({ label, onChange, options, value }) => (
-    <label className="flex min-w-0 flex-col text-sm font-medium text-gray-700 dark:text-gray-300">
-      <span className="mb-2">{label}</span>
-      <select
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="h-10 w-full rounded-xl border border-gray-950/10 bg-transparent px-3 text-sm font-normal text-gray-950 outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-primary/30 dark:border-white/10 dark:text-white"
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-
-  const renderToggleRow = ({ checked, description, label, onChange }) => (
-    <label className="flex cursor-pointer items-center justify-between gap-5 py-3">
-      <span className="min-w-0">
-        <span className="block text-sm font-medium text-gray-950 dark:text-white">
           {label}
         </span>
-        <span className="block text-sm text-gray-600 dark:text-gray-400">
-          {description}
-        </span>
+        <div
+          className="assistant-playground-select"
+          data-assistant-select={id}
+          data-open={isOpen ? "true" : "false"}
+          onBlur={(event) => {
+            if (
+              !(event.relatedTarget instanceof Node) ||
+              !event.currentTarget.contains(event.relatedTarget)
+            ) {
+              setOpenSelect(null);
+            }
+          }}
+        >
+          <button
+            type="button"
+            className="assistant-playground-field__control"
+            aria-haspopup="listbox"
+            aria-expanded={isOpen}
+            aria-controls={`assistant-playground-${id}-options`}
+            aria-labelledby={`assistant-playground-${id}-label assistant-playground-${id}-value`}
+            onClick={() =>
+              setOpenSelect((currentSelect) =>
+                currentSelect === id ? null : id,
+              )
+            }
+            onKeyDown={handleKeyDown}
+          >
+            <span id={`assistant-playground-${id}-value`}>
+              {selectedOption?.label}
+            </span>
+            <svg
+              aria-hidden="true"
+              className="assistant-playground-select__chevron"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M4 6L8 10L12 6"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+              />
+            </svg>
+          </button>
+          {isOpen ? (
+            <div
+              id={`assistant-playground-${id}-options`}
+              className="assistant-playground-select__options"
+              role="listbox"
+              aria-labelledby={`assistant-playground-${id}-label`}
+            >
+              {options.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  tabIndex={-1}
+                  aria-selected={option.value === value}
+                  data-selected={option.value === value ? "true" : "false"}
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    onChange(option.value);
+                    setOpenSelect(null);
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const renderToggleRow = ({ checked, description, label, onChange }) => (
+    <label className="assistant-playground-hook">
+      <span className="assistant-playground-hook__copy">
+        <span className="assistant-playground-hook__label">{label}</span>
+        <span className="assistant-playground-hook__description">{description}</span>
       </span>
-      <span className="relative inline-flex shrink-0 rounded-full focus-within:ring-2 focus-within:ring-primary/40">
+      <span
+        className="assistant-playground-switch"
+        data-checked={checked ? "true" : "false"}
+      >
         <input
           type="checkbox"
           role="switch"
           checked={checked}
           onChange={(event) => onChange(event.target.checked)}
-          className="sr-only"
+          className="assistant-playground-switch__input"
         />
-        <span
-          aria-hidden="true"
-          className={classNames(
-            "h-5 w-9 rounded-full transition-colors",
-            checked ? "bg-primary" : "bg-gray-200 dark:bg-white/15",
-          )}
-        />
-        <span
-          aria-hidden="true"
-          className={classNames(
-            "pointer-events-none absolute left-0.5 top-0.5 size-4 rounded-full bg-white shadow-sm transition-all",
-            checked && "ml-4",
-          )}
-        />
+        <span aria-hidden="true" className="assistant-playground-switch__knob" />
       </span>
     </label>
   );
@@ -220,6 +307,21 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
     }),
     [accent, align, radius, side, theme, variant],
   );
+
+  const togglePreviewTheme = () => {
+    setTheme((currentTheme) => {
+      const isDark =
+        currentTheme === "dark" ||
+        (currentTheme === "system" &&
+          document.documentElement.classList.contains("dark"));
+      return isDark ? "light" : "dark";
+    });
+  };
+
+  const toggleCustomizer = () => {
+    setCustomizeOpen((isOpen) => !isOpen);
+    setOpenSelect(null);
+  };
 
   const updatePreview = useCallback(() => {
     const previewWindow = previewRef.current?.contentWindow;
@@ -276,8 +378,8 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
   }, [updatePreview]);
 
   useEffect(() => {
-    // Local docs previews don't serve the `/_minimal/` renderer, and a broken
-    // embed never reports readiness. Surface a hint instead of spinning.
+    // Stop showing the loading state if the preview page never reports readiness.
+    // Leave the iframe untouched so local 404 pages remain visible while developing.
     if (!previewHostReady || !previewUrl || previewStatus !== "loading") {
       return undefined;
     }
@@ -353,165 +455,122 @@ export const AssistantWidget = () => (
   const installCode = installTarget === "html" ? htmlCode : nextCode;
 
   return (
-    <div className="my-6 grid gap-8" data-assistant-playground-layout="">
-      <div className="min-w-0">
-        <div className="not-prose overflow-hidden rounded-xl border border-gray-950/10 dark:border-white/10">
-          <div className="px-5 py-4">
-            <div className="text-sm font-medium text-gray-950 dark:text-white">
-              Widget playground
+    <div className="not-prose" data-assistant-playground-layout="">
+      <section
+        className="assistant-playground-frame"
+        data-customize-open={customizeOpen ? "true" : "false"}
+        aria-label="Assistant widget playground"
+      >
+        <div className="assistant-playground-toolbar">
+          <button
+            type="button"
+            className="assistant-playground-toolbar__button assistant-playground-toolbar__button--labeled"
+            aria-controls="assistant-playground-customizer"
+            aria-expanded={customizeOpen}
+            onClick={toggleCustomizer}
+          >
+            {CustomizeIconComponent ? <CustomizeIconComponent /> : null}
+            <span>Customize</span>
+          </button>
+          <button
+            type="button"
+            className="assistant-playground-toolbar__button assistant-playground-toolbar__button--icon"
+            aria-label="Toggle preview theme"
+            onClick={togglePreviewTheme}
+          >
+            {ThemeIconComponent ? <ThemeIconComponent /> : null}
+          </button>
+        </div>
+
+        <div
+          id="assistant-playground-customizer"
+          className="assistant-playground-customizer"
+          role="dialog"
+          aria-label="Customize assistant widget"
+          hidden={!customizeOpen}
+        >
+          <div className="assistant-playground-customizer__section">
+            <div className="assistant-playground-customizer__heading">
+              Component
             </div>
-            <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-400">
-              Changes apply to the widget preview.
-            </p>
-          </div>
-
-          <div className="border-t border-gray-950/10 px-5 py-5 dark:border-white/10">
-            <div className="space-y-6">
-              <fieldset>
-                <legend className="mb-2 text-sm font-medium text-gray-950 dark:text-white">
-                  Variants
-                </legend>
-                {renderSegmentedControl({
-                  ariaLabel: "Variants",
-                  value: variant,
-                  options: VARIANT_OPTIONS,
-                  onChange: setVariant,
-                })}
-              </fieldset>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                {renderSelectField({
-                  label: "Theme",
-                  value: theme,
-                  options: THEME_OPTIONS,
-                  onChange: setTheme,
-                })}
-
-                <label className="flex min-w-0 flex-col text-sm font-medium text-gray-700 dark:text-gray-300">
-                  <span className="mb-2">Accent</span>
-                  <span className="flex h-10 items-center gap-2 rounded-xl border border-gray-950/10 px-2 dark:border-white/10">
-                    <input
-                      type="color"
-                      value={accent}
-                      onChange={(event) => setAccent(event.target.value)}
-                      aria-label="Accent color"
-                      className="h-7 w-8 cursor-pointer rounded border-0 bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-                    />
-                    <span className="font-mono text-xs font-normal text-gray-600 dark:text-gray-400">
-                      {accent}
-                    </span>
-                  </span>
-                </label>
-              </div>
-
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                <span className="mb-2 flex items-center justify-between">
-                  Corner radius
-                  <output className="font-mono text-xs font-normal text-gray-500 dark:text-gray-400">
-                    {radius}px
-                  </output>
-                </span>
+            {renderSelectField({
+              id: "variant",
+              label: "Variant",
+              value: variant,
+              options: VARIANT_OPTIONS,
+              onChange: setVariant,
+            })}
+            {renderSelectField({
+              id: "radius",
+              label: "Corner radius",
+              value: radius,
+              options: RADIUS_OPTIONS,
+              onChange: setRadius,
+            })}
+            <label className="assistant-playground-field">
+              <span className="assistant-playground-field__label">Accent</span>
+              <span className="assistant-playground-accent">
                 <input
-                  type="range"
-                  min="0"
-                  max="32"
-                  step="2"
-                  value={radius}
-                  onChange={(event) =>
-                    setRadius(Number.parseInt(event.target.value))
-                  }
-                  className="block w-full accent-primary"
+                  type="color"
+                  value={accent}
+                  onChange={(event) => setAccent(event.target.value.toUpperCase())}
+                  aria-label="Accent color"
+                  className="assistant-playground-accent__input"
                 />
-              </label>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <fieldset>
-                  <legend className="mb-2 text-sm font-medium text-gray-950 dark:text-white">
-                    Trigger side
-                  </legend>
-                  {renderSegmentedControl({
-                    ariaLabel: "Trigger side",
-                    threeColumns: true,
-                    value: side,
-                    options: SIDE_OPTIONS,
-                    onChange: setSide,
-                  })}
-                </fieldset>
-
-                <fieldset>
-                  <legend className="mb-2 text-sm font-medium text-gray-950 dark:text-white">
-                    Trigger alignment
-                  </legend>
-                  {renderSegmentedControl({
-                    ariaLabel: "Trigger alignment",
-                    value: align,
-                    options: ALIGN_OPTIONS,
-                    onChange: setAlign,
-                  })}
-                </fieldset>
-              </div>
-
-              <fieldset>
-                <legend className="text-sm font-medium text-gray-950 dark:text-white">
-                  Hooks
-                </legend>
-                <div className="mt-1 divide-y divide-gray-950/10 dark:divide-white/10">
-                  {renderToggleRow({
-                    label: "Lifecycle events",
-                    description:
-                      "Observe open, close, ask, update, and navigation events.",
-                    checked: trackEvents,
-                    onChange: setTrackEvents,
-                  })}
-                  {renderToggleRow({
-                    label: "Structured errors",
-                    description:
-                      "Receive stable error codes and retry metadata.",
-                    checked: reportErrors,
-                    onChange: setReportErrors,
-                  })}
-                </div>
-              </fieldset>
-            </div>
+                <span
+                  aria-hidden="true"
+                  className="assistant-playground-accent__swatch"
+                  style={{ backgroundColor: accent }}
+                />
+                <span>{accent}</span>
+              </span>
+            </label>
           </div>
 
-          <div className="border-t border-gray-950/10 p-5 dark:border-white/10">
-            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <div className="text-sm font-medium text-gray-950 dark:text-white">
-                  Install
-                </div>
-                <div className="mt-0.5 text-sm text-gray-600 dark:text-gray-400">
-                  Copy the generated setup for your stack.
-                </div>
-              </div>
-              {renderSegmentedControl({
-                ariaLabel: "Installation target",
-                value: installTarget,
-                options: INSTALL_OPTIONS,
-                onChange: setInstallTarget,
-              })}
-            </div>
+          <div className="assistant-playground-customizer__divider" />
 
-            <CodeBlockComponent
-              // always use jsx as langugae to render code highlighting correctly
-              language= "jsx"
-              filename={
-                installTarget === "html" ? "index.html" : "assistant-widget.jsx"
-              }
-              wrap
-            >
-              {installCode}
-            </CodeBlockComponent>
+          <div className="assistant-playground-customizer__section">
+            <div className="assistant-playground-customizer__heading">Trigger</div>
+            {renderSelectField({
+              id: "side",
+              label: "Alignment",
+              value: side,
+              options: SIDE_OPTIONS,
+              onChange: setSide,
+            })}
+            {renderSelectField({
+              id: "align",
+              label: "Placement",
+              value: align,
+              options: ALIGN_OPTIONS,
+              onChange: setAlign,
+            })}
+          </div>
+
+          <div className="assistant-playground-customizer__divider" />
+
+          <div className="assistant-playground-customizer__section">
+            <div className="assistant-playground-customizer__heading">Hooks</div>
+            {renderToggleRow({
+              label: "Lifecycle events",
+              description:
+                "Observe open, close, ask, update, and navigation events.",
+              checked: trackEvents,
+              onChange: setTrackEvents,
+            })}
+            {renderToggleRow({
+              label: "Structured errors",
+              description: "Receive stable error codes and retry metadata.",
+              checked: reportErrors,
+              onChange: setReportErrors,
+            })}
           </div>
         </div>
-        {children ? <div className="mt-8">{children}</div> : null}
-      </div>
 
-      <aside className="not-prose" data-assistant-preview="">
         <div
           ref={previewHostRef}
-          className="relative flex h-[42rem] min-h-0 flex-col overflow-hidden rounded-xl border border-gray-950/10 bg-transparent dark:border-white/10 lg:sticky lg:top-20 lg:h-[calc(100vh-6rem)]"
+          className="assistant-playground-preview"
+          data-assistant-preview=""
           data-assistant-preview-card=""
         >
           {previewHostReady && previewUrl ? (
@@ -521,30 +580,63 @@ export const AssistantWidget = () => (
               src={previewUrl}
               onLoad={updatePreview}
               scrolling="no"
-              className="min-h-0 w-full flex-1 border-0 bg-transparent [color-scheme:light_dark] dark:[color-scheme:dark]"
             />
           ) : null}
-          {previewStatus !== "ready" ? (
+          {previewStatus === "loading" ? (
             <div
               aria-live="polite"
               role="status"
-              className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-3 px-6 text-center text-sm text-gray-600 dark:text-gray-400"
+              className="assistant-playground-preview__status"
             >
-              {previewStatus === "loading" ? (
-                <span
-                  aria-hidden="true"
-                  className="size-[18px] shrink-0 animate-spin rounded-full border-[1.5px] border-gray-300 border-t-gray-600 motion-reduce:animate-none dark:border-gray-600 dark:border-t-gray-300"
-                />
-              ) : null}
-              <span>
-                {previewStatus === "loading"
-                  ? "Loading assistant preview..."
-                  : "The live preview could not load. It requires a deployed docs site and the browser console may have details."}
-              </span>
+              <span
+                aria-hidden="true"
+                className="assistant-playground-preview__spinner"
+              />
+              <span>Loading assistant preview...</span>
             </div>
           ) : null}
         </div>
-      </aside>
+      </section>
+
+      <div className="assistant-playground-code" data-assistant-code="">
+        <div className="assistant-playground-code__header">
+          <div>
+            <div className="assistant-playground-code__title">Install</div>
+            <div className="assistant-playground-code__description">
+              Copy the generated setup for your stack.
+            </div>
+          </div>
+          <div
+            role="group"
+            aria-label="Installation target"
+            className="assistant-playground-code__tabs"
+          >
+            {INSTALL_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                data-active={installTarget === option.value ? "true" : "false"}
+                aria-pressed={installTarget === option.value}
+                onClick={() => setInstallTarget(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <CodeBlockComponent
+          // Always use JSX to render the generated HTML and Next.js snippets consistently.
+          language="jsx"
+          filename={
+            installTarget === "html" ? "index.html" : "assistant-widget.jsx"
+          }
+          wrap
+        >
+          {installCode}
+        </CodeBlockComponent>
+      </div>
+
+      {children ? <div className="assistant-playground-children">{children}</div> : null}
     </div>
   );
 };

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -8,12 +8,9 @@ export const AssistantWidgetPlayground = ({
   const EXAMPLE_WIDGET_ID = "YOUR_WIDGET_ID";
   const EMBED_URL =
     "https://cdn.jsdelivr.net/npm/@mintlify/assistant-widget@0.0/dist/browser/embed.js";
-  // The preview loads the hidden /assistant/widget-preview page through the
-  // chromeless `/_minimal/` renderer when deployed, and directly in local
-  // previews where that renderer is unavailable. A real page URL is required
+  // The preview loads the hidden /assistant/widget-preview page at a real URL
   // because captcha providers reject srcdoc documents without a hostname.
-  // Message names must stay in sync with
-  // snippets/assistant-widget-preview-host.jsx.
+  // Message names must stay in sync with snippets/assistant-widget-preview-host.jsx.
   const PREVIEW_READY_MESSAGE = "mintlify-assistant-playground:ready";
   const PREVIEW_UPDATE_MESSAGE = "mintlify-assistant-playground:update";
   const PREVIEW_STATE_MESSAGE = "mintlify-assistant-playground:state";
@@ -63,6 +60,8 @@ export const AssistantWidgetPlayground = ({
   const [variant, setVariant] = useState("widget");
   const [theme, setTheme] = useState("system");
   const [accent, setAccent] = useState("#166E3F");
+  const [accentDraft, setAccentDraft] = useState("#166E3F");
+  const [accentKeyboardFocus, setAccentKeyboardFocus] = useState(false);
   const [radius, setRadius] = useState(16);
   const [side, setSide] = useState("bottom");
   const [align, setAlign] = useState("end");
@@ -70,16 +69,18 @@ export const AssistantWidgetPlayground = ({
   const [reportErrors, setReportErrors] = useState(false);
   const [customizeOpen, setCustomizeOpen] = useState(false);
   const [openSelect, setOpenSelect] = useState(null);
+  const [activeSelectOptionIndex, setActiveSelectOptionIndex] = useState(0);
   const [previewHostReady, setPreviewHostReady] = useState(false);
   const [previewUrl, setPreviewUrl] = useState(null);
   const [previewStatus, setPreviewStatus] = useState("loading");
+  const accentInputRef = useRef(null);
+  const accentPointerFocusRef = useRef(false);
   const previewRef = useRef(null);
   const previewHostRef = useRef(null);
 
   useEffect(() => {
     // Resolve the preview page against the deployment base path (for example
-    // /docs on mintlify.com). Translated pages keep their locale segment
-    // after the /_minimal/ renderer prefix.
+    // /docs on mintlify.com). Translated pages keep their locale segment.
     const pageMatch = window.location.pathname
       .replace(/\/$/, "")
       .match(/^(.*?)(\/[a-z]{2}(?:-[A-Za-z]{2,4})?)?\/assistant\/widget$/);
@@ -88,13 +89,8 @@ export const AssistantWidgetPlayground = ({
     const mode = document.documentElement.classList.contains("dark")
       ? "dark"
       : "light";
-    const rendererPrefix =
-      window.location.hostname === "localhost" ||
-      window.location.hostname === "127.0.0.1"
-        ? ""
-        : "/_minimal";
     setPreviewUrl(
-      `${basePath}${rendererPrefix}${locale}/assistant/widget-preview?mode=${mode}`,
+      `${basePath}${locale}/assistant/widget-preview?mode=${mode}`,
     );
   }, []);
 
@@ -165,34 +161,77 @@ export const AssistantWidgetPlayground = ({
     };
   }, [openSelect]);
 
+  useEffect(() => {
+    const accentInput = accentInputRef.current;
+    if (!accentInput) return undefined;
+
+    // React's color-input change handler fires while the native picker moves.
+    // Commit from the native change event instead, which fires on confirmation.
+    const commitAccent = () => {
+      const nextAccent = accentInput.value.toUpperCase();
+      setAccentDraft(nextAccent);
+      setAccent(nextAccent);
+    };
+
+    accentInput.addEventListener("change", commitAccent);
+    return () => accentInput.removeEventListener("change", commitAccent);
+  }, []);
+
   const renderSelectField = ({ id, label, onChange, options, value }) => {
     const isOpen = openSelect === id;
     const selectedIndex = options.findIndex((option) => option.value === value);
     const selectedOption = options[selectedIndex] ?? options[0];
 
+    const openMenu = (initialIndex = selectedIndex) => {
+      setActiveSelectOptionIndex(Math.max(initialIndex, 0));
+      setOpenSelect(id);
+    };
+
+    const closeMenu = () => setOpenSelect(null);
+
     const selectByIndex = (index) => {
       const option = options[index];
-      if (option) onChange(option.value);
+      if (!option) return;
+      onChange(option.value);
+      closeMenu();
     };
 
     const handleKeyDown = (event) => {
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         if (!isOpen) {
-          setOpenSelect(id);
+          openMenu();
           return;
         }
 
         const direction = event.key === "ArrowDown" ? 1 : -1;
-        const nextIndex =
-          (Math.max(selectedIndex, 0) + direction + options.length) %
-          options.length;
-        selectByIndex(nextIndex);
+        setActiveSelectOptionIndex(
+          (currentIndex) =>
+            (currentIndex + direction + options.length) % options.length,
+        );
         return;
       }
       if (event.key === "Home" || event.key === "End") {
         event.preventDefault();
-        selectByIndex(event.key === "Home" ? 0 : options.length - 1);
+        if (!isOpen) openMenu();
+        setActiveSelectOptionIndex(
+          event.key === "Home" ? 0 : options.length - 1,
+        );
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        if (isOpen) {
+          selectByIndex(activeSelectOptionIndex);
+        } else {
+          openMenu();
+        }
+        return;
+      }
+      if (event.key === "Escape" && isOpen) {
+        event.preventDefault();
+        event.stopPropagation();
+        closeMenu();
       }
     };
 
@@ -223,12 +262,19 @@ export const AssistantWidgetPlayground = ({
             aria-haspopup="listbox"
             aria-expanded={isOpen}
             aria-controls={`assistant-playground-${id}-options`}
-            aria-labelledby={`assistant-playground-${id}-label assistant-playground-${id}-value`}
-            onClick={() =>
-              setOpenSelect((currentSelect) =>
-                currentSelect === id ? null : id,
-              )
+            aria-activedescendant={
+              isOpen
+                ? `assistant-playground-${id}-option-${activeSelectOptionIndex}`
+                : undefined
             }
+            aria-labelledby={`assistant-playground-${id}-label assistant-playground-${id}-value`}
+            onClick={() => {
+              if (isOpen) {
+                closeMenu();
+              } else {
+                openMenu();
+              }
+            }}
             onKeyDown={handleKeyDown}
           >
             <span id={`assistant-playground-${id}-value`}>
@@ -263,18 +309,22 @@ export const AssistantWidgetPlayground = ({
               role="listbox"
               aria-labelledby={`assistant-playground-${id}-label`}
             >
-              {options.map((option) => (
+              {options.map((option, index) => (
                 <button
                   key={option.value}
+                  id={`assistant-playground-${id}-option-${index}`}
                   type="button"
                   role="option"
                   tabIndex={-1}
                   aria-selected={option.value === value}
+                  data-active={
+                    activeSelectOptionIndex === index ? "true" : "false"
+                  }
                   data-selected={option.value === value ? "true" : "false"}
                   onPointerDown={(event) => event.preventDefault()}
+                  onPointerMove={() => setActiveSelectOptionIndex(index)}
                   onClick={() => {
-                    onChange(option.value);
-                    setOpenSelect(null);
+                    selectByIndex(index);
                   }}
                 >
                   <span>{option.label}</span>
@@ -312,6 +362,35 @@ export const AssistantWidgetPlayground = ({
         <span aria-hidden="true" className="assistant-playground-switch__knob" />
       </span>
     </label>
+  );
+
+  const renderDivider = () => (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      className="assistant-playground-customizer__divider"
+    >
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        width="100%"
+        height="1"
+        preserveAspectRatio="none"
+        viewBox="0 0 100 1"
+      >
+        <line
+          x1="0"
+          y1="0.5"
+          x2="100"
+          y2="0.5"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeDasharray="5 5"
+          strokeLinecap="butt"
+          vectorEffect="non-scaling-stroke"
+        />
+      </svg>
+    </div>
   );
 
   const appearance = useMemo(
@@ -527,25 +606,54 @@ export const AssistantWidget = () => (
             })}
             <label className="assistant-playground-field">
               <span className="assistant-playground-field__label">Accent</span>
-              <span className="assistant-playground-accent">
+              <span
+                className="assistant-playground-accent"
+                data-keyboard-focus={accentKeyboardFocus ? "true" : "false"}
+              >
                 <input
+                  ref={accentInputRef}
                   type="color"
-                  value={accent}
-                  onChange={(event) => setAccent(event.target.value.toUpperCase())}
+                  value={accentDraft}
+                  onInput={(event) =>
+                    setAccentDraft(event.currentTarget.value.toUpperCase())
+                  }
+                  onPointerDown={() => {
+                    accentPointerFocusRef.current = true;
+                    setAccentKeyboardFocus(false);
+                  }}
+                  onFocus={() => {
+                    setAccentKeyboardFocus(!accentPointerFocusRef.current);
+                    accentPointerFocusRef.current = false;
+                  }}
+                  onBlur={(event) => {
+                    setAccentKeyboardFocus(false);
+                    const nextAccent = event.currentTarget.value.toUpperCase();
+                    setAccentDraft(nextAccent);
+                    setAccent(nextAccent);
+                  }}
+                  onKeyDown={(event) => {
+                    setAccentKeyboardFocus(true);
+                    if (event.key === "Enter") {
+                      const nextAccent =
+                        event.currentTarget.value.toUpperCase();
+                      setAccentDraft(nextAccent);
+                      setAccent(nextAccent);
+                    }
+                  }}
                   aria-label="Accent color"
                   className="assistant-playground-accent__input"
                 />
                 <span
                   aria-hidden="true"
                   className="assistant-playground-accent__swatch"
-                  style={{ backgroundColor: accent }}
+                  style={{ backgroundColor: accentDraft }}
                 />
-                <span>{accent}</span>
+                <span>{accentDraft}</span>
               </span>
             </label>
           </div>
 
-          <div className="assistant-playground-customizer__divider" />
+          {renderDivider()}
 
           <div className="assistant-playground-customizer__section">
             <div className="assistant-playground-customizer__heading">Trigger</div>
@@ -565,7 +673,7 @@ export const AssistantWidget = () => (
             })}
           </div>
 
-          <div className="assistant-playground-customizer__divider" />
+          {renderDivider()}
 
           <div className="assistant-playground-customizer__section">
             <div className="assistant-playground-customizer__heading">Hooks</div>

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -56,7 +56,7 @@ export const AssistantWidgetPlayground = ({
 
   const [installTarget, setInstallTarget] = useState("html");
   const [variant, setVariant] = useState("widget");
-  const [theme, setTheme] = useState("system");
+  const [previewTheme, setPreviewTheme] = useState(null);
   const [accent, setAccent] = useState("#166E3F");
   const [accentDraft, setAccentDraft] = useState("#166E3F");
   const [accentKeyboardFocus, setAccentKeyboardFocus] = useState(false);
@@ -78,18 +78,16 @@ export const AssistantWidgetPlayground = ({
 
   useEffect(() => {
     // Resolve the preview page against the deployment base path (for example
-    // /docs on mintlify.com). Translated pages keep their locale segment.
+    // /docs on mintlify.com). Every locale can reuse the same host document
+    // because the preview UI is configured by this component.
     const pageMatch = window.location.pathname
       .replace(/\/$/, "")
       .match(/^(.*?)(\/[a-z]{2}(?:-[A-Za-z]{2,4})?)?\/assistant\/widget$/);
     const basePath = pageMatch?.[1] ?? "";
-    const locale = pageMatch?.[2] ?? "";
     const mode = document.documentElement.classList.contains("dark")
       ? "dark"
       : "light";
-    setPreviewUrl(
-      `${basePath}${locale}/assistant/widget-preview?mode=${mode}`,
-    );
+    setPreviewUrl(`${basePath}/assistant/widget-preview?mode=${mode}`);
   }, []);
 
   useEffect(() => {
@@ -394,20 +392,19 @@ export const AssistantWidgetPlayground = ({
   const appearance = useMemo(
     () => ({
       variant,
-      theme,
       accent,
       radius: `${radius}px`,
       side,
       align,
     }),
-    [accent, align, radius, side, theme, variant],
+    [accent, align, radius, side, variant],
   );
 
   const togglePreviewTheme = () => {
-    setTheme((currentTheme) => {
+    setPreviewTheme((currentTheme) => {
       const isDark =
         currentTheme === "dark" ||
-        (currentTheme === "system" &&
+        (currentTheme === null &&
           document.documentElement.classList.contains("dark"));
       return isDark ? "light" : "dark";
     });
@@ -422,13 +419,11 @@ export const AssistantWidgetPlayground = ({
     const previewWindow = previewRef.current?.contentWindow;
     if (!previewWindow) return;
 
-    // Match the docs theme in the iframe while generated examples retain "system".
+    // Match the docs theme until the preview-only toggle overrides it.
+    // Generated examples always retain "system".
     const liveTheme =
-      appearance.theme === "system"
-        ? document.documentElement.classList.contains("dark")
-          ? "dark"
-          : "light"
-        : appearance.theme;
+      previewTheme ??
+      (document.documentElement.classList.contains("dark") ? "dark" : "light");
 
     previewWindow.postMessage(
       {
@@ -443,7 +438,7 @@ export const AssistantWidgetPlayground = ({
       // The preview page is same-origin (served by this docs site).
       window.location.origin,
     );
-  }, [appearance, reportErrors, trackEvents]);
+  }, [appearance, previewTheme, reportErrors, trackEvents]);
 
   useEffect(() => {
     const handlePreviewMessage = (event) => {
@@ -494,7 +489,7 @@ export const AssistantWidgetPlayground = ({
     "  ],",
     "  appearance: {",
     `    variant: '${variant}',`,
-    `    theme: '${theme}',`,
+    "    theme: 'system',",
     `    accent: '${accent}',`,
     `    radius: '${radius}px',`,
     `    side: '${side}',`,
@@ -550,9 +545,9 @@ export const AssistantWidget = () => (
   const installCode = installTarget === "html" ? htmlCode : nextCode;
 
   return (
-    <div className="not-prose" data-assistant-playground-layout="">
+    <div data-assistant-playground-layout="">
       <section
-        className="assistant-playground-frame"
+        className="assistant-playground-frame not-prose"
         data-customize-open={customizeOpen ? "true" : "false"}
         aria-label="Assistant widget playground"
       >
@@ -722,7 +717,10 @@ export const AssistantWidget = () => (
         </div>
       </section>
 
-      <div className="assistant-playground-code" data-assistant-code="">
+      <div
+        className="assistant-playground-code not-prose"
+        data-assistant-code=""
+      >
         <div className="assistant-playground-code__header">
           <div>
             <div className="assistant-playground-code__title">Install</div>

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -33,8 +33,6 @@ export const AssistantWidgetPlayground = ({
     { value: 16, label: "Large", detail: "16px" },
     { value: 20, label: "Extra large", detail: "20px" },
     { value: 24, label: "2X large", detail: "24px" },
-    { value: 28, label: "3X large", detail: "28px" },
-    { value: 32, label: "4X large", detail: "32px" },
   ];
   // Mentha labels the direction the assistant opens; the widget API stores
   // the trigger's screen edge, so each label maps to the opposite edge.

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -29,9 +29,15 @@ export const AssistantWidgetPlayground = ({
     { value: "panel", label: "Panel" },
   ];
   const RADIUS_OPTIONS = [
-    { value: 8, label: "Small" },
-    { value: 18, label: "Medium" },
-    { value: 28, label: "Large" },
+    { value: 0, label: "None", detail: "0px" },
+    { value: 4, label: "Extra small", detail: "4px" },
+    { value: 8, label: "Small", detail: "8px" },
+    { value: 12, label: "Medium", detail: "12px" },
+    { value: 16, label: "Large", detail: "16px" },
+    { value: 20, label: "Extra large", detail: "20px" },
+    { value: 24, label: "2X large", detail: "24px" },
+    { value: 28, label: "3X large", detail: "28px" },
+    { value: 32, label: "4X large", detail: "32px" },
   ];
   // Mentha labels the direction the assistant opens; the widget API stores
   // the trigger's screen edge, so each label maps to the opposite edge.
@@ -56,8 +62,8 @@ export const AssistantWidgetPlayground = ({
   const [installTarget, setInstallTarget] = useState("html");
   const [variant, setVariant] = useState("widget");
   const [theme, setTheme] = useState("system");
-  const [accent, setAccent] = useState("#006ADC");
-  const [radius, setRadius] = useState(8);
+  const [accent, setAccent] = useState("#166E3F");
+  const [radius, setRadius] = useState(16);
   const [side, setSide] = useState("bottom");
   const [align, setAlign] = useState("end");
   const [trackEvents, setTrackEvents] = useState(false);
@@ -228,20 +234,27 @@ export const AssistantWidgetPlayground = ({
             <span id={`assistant-playground-${id}-value`}>
               {selectedOption?.label}
             </span>
-            <svg
-              aria-hidden="true"
-              className="assistant-playground-select__chevron"
-              viewBox="0 0 16 16"
-            >
-              <path
-                d="M4 6L8 10L12 6"
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="1.5"
-              />
-            </svg>
+            <span className="assistant-playground-select__end">
+              {selectedOption?.detail ? (
+                <span className="assistant-playground-select__detail">
+                  {selectedOption.detail}
+                </span>
+              ) : null}
+              <svg
+                aria-hidden="true"
+                className="assistant-playground-select__chevron"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="M4 6L8 10L12 6"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                />
+              </svg>
+            </span>
           </button>
           {isOpen ? (
             <div
@@ -264,7 +277,12 @@ export const AssistantWidgetPlayground = ({
                     setOpenSelect(null);
                   }}
                 >
-                  {option.label}
+                  <span>{option.label}</span>
+                  {option.detail ? (
+                    <span className="assistant-playground-select__detail">
+                      {option.detail}
+                    </span>
+                  ) : null}
                 </button>
               ))}
             </div>

--- a/snippets/assistant-widget-preview-host.jsx
+++ b/snippets/assistant-widget-preview-host.jsx
@@ -1,7 +1,7 @@
 export const AssistantWidgetPreviewHost = () => {
   // This component only runs on /assistant/widget-preview, which the widget
-  // playground embeds through the chromeless `/_minimal/` renderer so the
-  // captcha provider sees a real hostname (srcdoc iframes have none).
+  // playground embeds at a real URL so the captcha provider sees a hostname
+  // (srcdoc iframes have none).
   // Mintlify evaluates snippet exports independently, so these constants must
   // stay in sync with snippets/assistant-widget-playground.jsx.
   const EMBED_URL =

--- a/zh/assistant/widget.mdx
+++ b/zh/assistant/widget.mdx
@@ -12,6 +12,12 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
+export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
+
+export const WidgetThemeIcon = () => (
+  <span aria-hidden="true" className="assistant-playground-theme-icon" />
+);
+
 [助手](/zh/assistant)可回答关于你 Mintlify 站点的问题。若要在其他站点或 Web 应用中嵌入相同能力,请使用小组件。借助小组件,你可以在产品仪表板、营销站点、支持门户或其他位置为用户提供基于你内容训练的 AI 聊天服务。
 
 通过一段托管脚本,即可将小组件添加到任何网站或 Web 应用。小组件自带触发器,并在封闭的 Shadow DOM 内渲染,可防止你的应用样式影响小组件。
@@ -45,7 +51,11 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
 
 将生成的代码添加到站点后,重新加载页面。确认触发器已显示,然后点击它并发送一个测试问题,以验证小组件是否已连接。
 
-<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
+<AssistantWidgetPlayground
+  CodeBlockComponent={WidgetCodeBlock}
+  CustomizeIconComponent={WidgetCustomizeIcon}
+  ThemeIconComponent={WidgetThemeIcon}
+>
 
 <Warning>
   Module 脚本会延迟加载并按文档顺序执行。当你使用 HTML 安装小组件时,请将托管加载器保持在初始化代码块之前,否则小组件将无法挂载。


### PR DESCRIPTION
## Documentation changes
<img width="1492" height="1540" alt="CleanShot 2026-07-29 at 11 26 32@2x" src="https://github.com/user-attachments/assets/59a3a944-4f81-432e-8de1-3fd6d2d419a4" />

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site-only UI and preview iframe URL changes; no auth, API, or customer embed runtime changes beyond how the docs page loads the preview.
> 
> **Overview**
> **Redesigns the assistant widget playground** on the widget docs pages (en/es/fr/zh): a centered 720px frame with live iframe preview, **Customize** panel (variant, corner radius presets, accent picker, trigger alignment/placement, hook toggles), and a **preview-only** light/dark toggle. Generated install snippets always use `theme: 'system'`; theme is no longer a customizer field.
> 
> **Replaces the old two-column sticky preview** and Tailwind-heavy controls with dedicated `playground.css` (light/dark tokens, toolbar, custom listbox selects, mobile behavior when the customizer is open).
> 
> **Preview hosting:** iframe loads `{basePath}/assistant/widget-preview?mode=…` instead of `/_minimal{locale}/assistant/widget-preview`. Widget MDX passes `CustomizeIconComponent` and `ThemeIconComponent`; preview-host comments updated to match.
> 
> **Behavior tweaks:** `SIDE_OPTIONS` labels map to the opposite widget API `side` edge; default accent/radius updated; accessible custom selects and accent color commit on native `change`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b793fbd565a3494534701ce7a8f6c7e84d34ef28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->