### PR TITLE
widget nits

### DIFF
--- a/assistant/widget.mdx
+++ b/assistant/widget.mdx
@@ -12,12 +12,6 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
-export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
-
-export const WidgetThemeIcon = () => (
-  <span aria-hidden="true" className="assistant-playground-theme-icon" />
-);
-
 The [assistant](/assistant) answers questions on your Mintlify site. To embed the same capability on another site or web app, use the widget. With the widget, you can give your users access to AI chat trained on your content in your product dashboard, marketing site, support portal, or elsewhere.
 
 Add the widget to any website or web application with a hosted script. The widget owns its trigger and renders inside a closed Shadow DOM, which prevents your application styles from affecting the widget.
@@ -45,11 +39,7 @@ Use the playground to configure the presentation, visual options, and observer h
 
 After you add the generated code to your site, reload the page. Confirm the trigger appears, then click it and send a test question to verify the connection.
 
-<AssistantWidgetPlayground
-  CodeBlockComponent={WidgetCodeBlock}
-  CustomizeIconComponent={WidgetCustomizeIcon}
-  ThemeIconComponent={WidgetThemeIcon}
->
+<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
 
 <Warning>
   Module scripts defer and run in document order. Keep the hosted loader before the initialization block when you install the widget with HTML, or the widget fails to mount.

--- a/es/assistant/widget.mdx
+++ b/es/assistant/widget.mdx
@@ -12,12 +12,6 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
-export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
-
-export const WidgetThemeIcon = () => (
-  <span aria-hidden="true" className="assistant-playground-theme-icon" />
-);
-
 El [asistente](/es/assistant) responde preguntas en tu sitio de Mintlify. Para incrustar la misma capacidad en otro sitio o aplicación web, usa el widget. Con el widget, puedes ofrecer a tus usuarios acceso a un chat de IA entrenado con tu contenido en el panel de tu producto, sitio de marketing, portal de soporte u otros lugares.
 
 Añade el widget a cualquier sitio web o aplicación web con un script alojado. El widget gestiona su propio activador y se renderiza dentro de un Shadow DOM cerrado, lo que evita que los estilos de tu aplicación afecten al widget.
@@ -51,11 +45,7 @@ Usa el playground para configurar la presentación, las opciones visuales y los 
 
 Después de añadir el código generado a tu sitio, recarga la página. Confirma que aparece el activador y, luego, haz clic en él y envía una pregunta de prueba para verificar que el widget está conectado.
 
-<AssistantWidgetPlayground
-  CodeBlockComponent={WidgetCodeBlock}
-  CustomizeIconComponent={WidgetCustomizeIcon}
-  ThemeIconComponent={WidgetThemeIcon}
->
+<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
 
 <Warning>
   Los scripts de módulo se difieren y se ejecutan en el orden del documento. Mantén el cargador alojado antes del bloque de inicialización cuando instales el widget con HTML, o el widget no se montará.

--- a/fr/assistant/widget.mdx
+++ b/fr/assistant/widget.mdx
@@ -12,12 +12,6 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
-export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
-
-export const WidgetThemeIcon = () => (
-  <span aria-hidden="true" className="assistant-playground-theme-icon" />
-);
-
 L'[assistant](/fr/assistant) répond aux questions sur votre site Mintlify. Pour intégrer la même capacité sur un autre site ou application web, utilisez le widget. Grâce au widget, vous pouvez donner à vos utilisateurs l'accès à un chat IA entraîné sur votre contenu dans le tableau de bord de votre produit, votre site marketing, votre portail d'assistance ou ailleurs.
 
 Ajoutez le widget à n'importe quel site web ou application web à l'aide d'un script hébergé. Le widget possède son propre déclencheur et s'affiche dans un Shadow DOM fermé, ce qui empêche les styles de votre application d'affecter le widget.
@@ -51,11 +45,7 @@ Utilisez le playground pour configurer la présentation, les options visuelles e
 
 Après avoir ajouté le code généré à votre site, rechargez la page. Vérifiez que le déclencheur apparaît, puis cliquez dessus et envoyez une question de test pour confirmer que le widget est connecté.
 
-<AssistantWidgetPlayground
-  CodeBlockComponent={WidgetCodeBlock}
-  CustomizeIconComponent={WidgetCustomizeIcon}
-  ThemeIconComponent={WidgetThemeIcon}
->
+<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
 
 <Warning>
   Les scripts de module sont différés et exécutés dans l'ordre du document. Gardez le chargeur hébergé avant le bloc d'initialisation lorsque vous installez le widget en HTML, sinon le widget ne parvient pas à se monter.

--- a/playground.css
+++ b/playground.css
@@ -112,29 +112,8 @@ html[data-current-path$="/assistant/widget"]
   svg {
   width: 16px;
   height: 16px;
-  background-color: var(--assistant-playground-text-default) !important;
   color: var(--assistant-playground-text-default);
   opacity: 1;
-}
-
-html[data-current-path$="/assistant/widget"]
-  .assistant-playground-theme-icon {
-  position: relative;
-  display: block;
-  width: 16px;
-  height: 16px;
-  overflow: hidden;
-  border: 1.5px solid var(--assistant-playground-text-default);
-  border-radius: 50%;
-  color: var(--assistant-playground-text-default);
-}
-
-html[data-current-path$="/assistant/widget"]
-  .assistant-playground-theme-icon::before {
-  position: absolute;
-  inset: 0 50% 0 0;
-  background: currentColor;
-  content: "";
 }
 
 html[data-current-path$="/assistant/widget"] .assistant-playground-preview {

--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -1,9 +1,4 @@
-export const AssistantWidgetPlayground = ({
-  children,
-  CodeBlockComponent,
-  CustomizeIconComponent,
-  ThemeIconComponent,
-}) => {
+export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
   // Mintlify evaluates snippet exports independently, so shared values must stay in this scope.
   const EXAMPLE_WIDGET_ID = "YOUR_WIDGET_ID";
   const EMBED_URL =
@@ -34,15 +29,14 @@ export const AssistantWidgetPlayground = ({
     { value: 20, label: "Extra large", detail: "20px" },
     { value: 24, label: "2X large", detail: "24px" },
   ];
-  // Mentha labels the direction the assistant opens; the widget API stores
-  // the trigger's screen edge, so each label maps to the opposite edge.
+  // Labels match the widget API: `side` is the trigger's screen edge.
   const SIDE_OPTIONS = [
-    { value: "bottom", label: "Top" },
-    { value: "top", label: "Bottom" },
-    { value: "right", label: "Left" },
-    { value: "left", label: "Right" },
-    { value: "inline-end", label: "Inline start" },
-    { value: "inline-start", label: "Inline end" },
+    { value: "bottom", label: "Bottom" },
+    { value: "top", label: "Top" },
+    { value: "left", label: "Left" },
+    { value: "right", label: "Right" },
+    { value: "inline-start", label: "Inline start" },
+    { value: "inline-end", label: "Inline end" },
   ];
   const ALIGN_OPTIONS = [
     { value: "start", label: "Start" },
@@ -53,6 +47,93 @@ export const AssistantWidgetPlayground = ({
     { value: "html", label: "HTML" },
     { value: "next", label: "Next.js" },
   ];
+
+  const CustomizeIcon = () => (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2.83337 4.83325V12.1666"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M13.1666 3.83325V11.1666"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <circle
+        cx="2.83337"
+        cy="3.33325"
+        r="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <circle
+        cx="13.1666"
+        cy="12.6667"
+        r="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M6.5 3.83325H7.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M9.83337 3.83325H10.8334"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M5.16663 12.1667H6.16663"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+      <path
+        d="M8.5 12.1667H9.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="square"
+      />
+    </svg>
+  );
+
+  const ThemeIcon = () => (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 5.33333C6.52724 5.33333 5.33333 6.52724 5.33333 8C5.33333 9.47276 6.52724 10.6667 8 10.6667V14C4.68629 14 2 11.3137 2 8C2 4.68629 4.68629 2 8 2V5.33333ZM8 5.33333C9.47276 5.33333 10.6667 6.52724 10.6667 8C10.6667 9.47276 9.47276 10.6667 8 10.6667V5.33333Z"
+        fill="currentColor"
+      />
+      <circle
+        cx="8.00004"
+        cy="7.99992"
+        r="6.16667"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
 
   const [installTarget, setInstallTarget] = useState("html");
   const [variant, setVariant] = useState("widget");
@@ -559,7 +640,7 @@ export const AssistantWidget = () => (
             aria-expanded={customizeOpen}
             onClick={toggleCustomizer}
           >
-            {CustomizeIconComponent ? <CustomizeIconComponent /> : null}
+            <CustomizeIcon />
             <span>Customize</span>
           </button>
           <button
@@ -568,7 +649,7 @@ export const AssistantWidget = () => (
             aria-label="Toggle preview theme"
             onClick={togglePreviewTheme}
           >
-            {ThemeIconComponent ? <ThemeIconComponent /> : null}
+            <ThemeIcon />
           </button>
         </div>
 
@@ -652,14 +733,14 @@ export const AssistantWidget = () => (
             <div className="assistant-playground-customizer__heading">Trigger</div>
             {renderSelectField({
               id: "side",
-              label: "Alignment",
+              label: "Placement",
               value: side,
               options: SIDE_OPTIONS,
               onChange: setSide,
             })}
             {renderSelectField({
               id: "align",
-              label: "Placement",
+              label: "Alignment",
               value: align,
               options: ALIGN_OPTIONS,
               onChange: setAlign,

--- a/zh/assistant/widget.mdx
+++ b/zh/assistant/widget.mdx
@@ -12,12 +12,6 @@ export const WidgetCodeBlock = ({ children, ...props }) => (
   <CodeBlock {...props}>{children}</CodeBlock>
 );
 
-export const WidgetCustomizeIcon = () => <Icon icon="scan-text" size={16} />;
-
-export const WidgetThemeIcon = () => (
-  <span aria-hidden="true" className="assistant-playground-theme-icon" />
-);
-
 [助手](/zh/assistant)可回答关于你 Mintlify 站点的问题。若要在其他站点或 Web 应用中嵌入相同能力,请使用小组件。借助小组件,你可以在产品仪表板、营销站点、支持门户或其他位置为用户提供基于你内容训练的 AI 聊天服务。
 
 通过一段托管脚本,即可将小组件添加到任何网站或 Web 应用。小组件自带触发器,并在封闭的 Shadow DOM 内渲染,可防止你的应用样式影响小组件。
@@ -51,11 +45,7 @@ export const WidgetThemeIcon = () => (
 
 将生成的代码添加到站点后,重新加载页面。确认触发器已显示,然后点击它并发送一个测试问题,以验证小组件是否已连接。
 
-<AssistantWidgetPlayground
-  CodeBlockComponent={WidgetCodeBlock}
-  CustomizeIconComponent={WidgetCustomizeIcon}
-  ThemeIconComponent={WidgetThemeIcon}
->
+<AssistantWidgetPlayground CodeBlockComponent={WidgetCodeBlock}>
 
 <Warning>
   Module 脚本会延迟加载并按文档顺序执行。当你使用 HTML 安装小组件时,请将托管加载器保持在初始化代码块之前,否则小组件将无法挂载。


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only playground and styling tweaks with no auth, API, or runtime widget behavior changes.
> 
> **Overview**
> **Polishes the assistant widget docs playground** so trigger controls match the widget API and toolbar icons are self-contained.
> 
> The playground **inlines customize/theme toolbar icons** in `assistant-widget-playground.jsx` and drops `CustomizeIconComponent` / `ThemeIconComponent` from the snippet API. EN/ES/FR/ZH `widget.mdx` pages only pass `CodeBlockComponent` now.
> 
> **Trigger customizer fixes:** `side` options are labeled by screen edge (Bottom, Top, Left, …) instead of the previous inverted labels, and the fields are renamed so **`side` → Placement** and **`align` → Alignment**.
> 
> **CSS cleanup** removes the old half-circle theme icon styles and extra SVG `background-color` override on the widget playground page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e6b3c3cedf86a205c9654e550491ffefeb2cd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->