### PR TITLE
update widget url

### DIFF
--- a/snippets/assistant-widget-playground.jsx
+++ b/snippets/assistant-widget-playground.jsx
@@ -2,7 +2,7 @@ export const AssistantWidgetPlayground = ({ children, CodeBlockComponent }) => {
   // Mintlify evaluates snippet exports independently, so shared values must stay in this scope.
   const EXAMPLE_WIDGET_ID = "YOUR_WIDGET_ID";
   const EMBED_URL =
-    "https://cdn.jsdelivr.net/npm/@mintlify/assistant-widget@0.0/dist/browser/embed.js";
+    "https://widget.mintlify.com/v1/embed.js";
   // The preview loads the hidden /assistant/widget-preview page at a real URL
   // because captcha providers reject srcdoc documents without a hostname.
   // Message names must stay in sync with snippets/assistant-widget-preview-host.jsx.

--- a/snippets/assistant-widget-preview-host.jsx
+++ b/snippets/assistant-widget-preview-host.jsx
@@ -5,7 +5,7 @@ export const AssistantWidgetPreviewHost = () => {
   // Mintlify evaluates snippet exports independently, so these constants must
   // stay in sync with snippets/assistant-widget-playground.jsx.
   const EMBED_URL =
-    "https://cdn.jsdelivr.net/npm/@mintlify/assistant-widget@0.0/dist/browser/embed.js";
+    "https://widget.mintlify.com/v1/embed.js";
   const PREVIEW_WIDGET_ID = "mint_widget_ce2bb750-8cc9-4057-96b3-cbd3aedd7acb";
   const PREVIEW_READY_MESSAGE = "mintlify-assistant-playground:ready";
   const PREVIEW_UPDATE_MESSAGE = "mintlify-assistant-playground:update";


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site snippet change only; no auth or backend logic, though the playground preview depends on the new CDN serving the same embed API.
> 
> **Overview**
> **Switches the documented and live-loaded assistant widget embed script** from the jsDelivr `@mintlify/assistant-widget` URL to **`https://widget.mintlify.com/v1/embed.js`**.
> 
> The same `EMBED_URL` constant is updated in **`assistant-widget-playground.jsx`** (generated HTML/Next.js install snippets and preview wiring) and **`assistant-widget-preview-host.jsx`** (iframe preview script load), keeping the two snippets aligned as their comments require.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf7bde8c3bbd7f86b0ced108e8dcdf63906c441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->