### PR TITLE
Analytics csv export fields

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -45,6 +45,7 @@ axios
 (?i)backlinks?
 bearerAuth
 Bing
+Bingbot
 blockIgnores
 (?i)blockquotes?
 boolean
@@ -61,6 +62,7 @@ Caddy
 camelCase
 (?i)captchas?
 Cascade
+CCBot
 CD
 CDK
 CDN
@@ -76,6 +78,7 @@ classnames
 Claude
 CLAUDE\.md
 Claude's
+ClaudeBot
 Clearbit
 CLI
 CloudConvert
@@ -177,6 +180,8 @@ GitHub
 GitLab
 GKE
 Golang
+Googlebot
+GPTBot
 GraphQL
 Grok
 gRPC

--- a/optimize/analytics.mdx
+++ b/optimize/analytics.mdx
@@ -144,6 +144,25 @@ Export analytics categories to CSV for deeper analysis, reporting, or archival. 
   />
 </Frame>
 
+### Traffic exports
+
+Traffic exports break down page views by visitor category so you can see how much of your traffic comes from humans compared to agents, search crawlers, and other bots.
+
+| Column | Description |
+| --- | --- |
+| `humanViews` | HTML page views from non-bot traffic. |
+| `aiViews` | Views from AI agents such as ChatGPT, Claude, and Cursor, plus Markdown page fetches from clients that aren't recognized crawlers. |
+| `searchIndexViews` | Views from search and indexing crawlers, such as Googlebot, Bingbot, and OAI-SearchBot. |
+| `trainingViews` | Views from crawlers that collect content for AI model training, such as GPTBot, ClaudeBot, and CCBot. |
+| `otherAiViews` | Views from other AI-related bots that don't fit the preceding categories. |
+| `totalViews` | The sum of `humanViews` and `aiViews`. |
+
+Mintlify classifies each view using known user-agent patterns for search crawlers, training crawlers, and AI assistants. Categories are mutually exclusive, so each view counts toward exactly one column.
+
+<Note>
+  `searchIndexViews`, `trainingViews`, and `otherAiViews` do not count toward `totalViews`.
+</Note>
+
 ### Assistant exports
 
 Assistant exports include the queries, responses, sources, and a `resolutionStatus` column that indicates whether the assistant successfully answered each question (`answered` or `unanswered`). Use the `resolutionStatus` column to identify documentation gaps surfaced by questions the assistant could not resolve.


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes https://linear.app/mintlify/issue/DOC-404/document-analytics-csv-export-field-definitions

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Vale vocabulary only; no product or runtime behavior changes.
> 
> **Overview**
> Documents **traffic analytics CSV exports** in `optimize/analytics.mdx` with a new **Traffic exports** subsection: a column table for `humanViews`, `aiViews`, `searchIndexViews`, `trainingViews`, `otherAiViews`, and `totalViews`, plus notes on user-agent classification, mutually exclusive categories, and that crawler/training/other-AI columns are excluded from `totalViews`.
> 
> Adds Vale accept-list terms (**Bingbot**, **CCBot**, **ClaudeBot**, **Googlebot**, **GPTBot**) so bot names in those examples pass spelling checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777fe2c65e38751a86b14af8cc332173eb535100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->