### PR TITLE
changelog edits

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,41 +5,44 @@ rss: true
 noindex: true
 ---
 
-<Update label="July 31, 2026" tags={["New releases","Improvements","Bug fixes"]} rss={{ title:"Private pages, Assistant Widget analytics, impressions analytics, and more" }}>
+<Update label="July 31, 2026" tags={["New releases","Improvements","Bug fixes"]} rss={{ title:"Introducing the widget, updated analytics, and more" }}>
 
+  ## Mintlify widget
+
+  Embed the assistant on any site or web app to give your users the same AI-powered chat experience trained on your content. See the [widget documentation](/assistant/widget) for more information. The widget can surface contact forms and hand off to your support team.
+  
   ## New features
 
-  - **Private pages:** Draft pages that stay hidden from your live site until you're ready to publish, without needing a separate branch. Manage visibility from the [editor](/editor).
-  - **Impressions analytics:** A new Impressions section in [analytics](/optimize/analytics) shows CTA click-through rates with a chart and ranked table, so you can see which calls-to-action drive engagement.
-  - **Assistant Widget analytics:** Track questions, deflections, and contact form activity from the [Assistant Widget](/assistant/widget) in the analytics dashboard.
-  - **Contact tools for the Assistant Widget:** The [Assistant Widget](/assistant/widget) can now surface contact forms and hand off to your support flows.
+  - **`mint signup`:** Create a Mintlify account directly from the CLI. See [Quickstart](/quickstart) for more information.
+  - **Actions for images:** Copy and download buttons now appear on images. See [Images and embeds](/create/image-embeds#copy-and-download-actions) for more information.
+  - **Impressions analytics:** A new Impressions section in [analytics](/optimize/analytics) shows CTA click-through rates with a chart and ranked table, so you can see which pages drive engagement.
   - **`window.mintlify.user` for custom JS:** Authenticated user info is now exposed to [custom scripts](/customize/custom-scripts) via `window.mintlify.user`, with a `mintlify:user` event dispatched when it resolves.
-  - **HTTP syntax highlighting:** Use ```` ```http ```` code blocks for request/response snippets. See [code blocks](/create/code).
+  - **HTTP syntax highlighting:** Use ```` ```http ```` code blocks for request/response snippets. See [Code blocks](/create/code).
   - **Custom base path from the dashboard:** Configure a [custom base path](/deploy/docs-subpath) through the same flow used for custom domains.
-  - **Search source selector in Top searches:** Filter [Top searches](/optimize/analytics#search) by source, including MCP search, from a single view.
 
   ## Improvements
 
-  - **Editor performance:** Navigation validation, page lookups, and tab switches in the editor are now linear instead of quadratic, so large sites open and edit noticeably faster.
+  - **Editor-first dashboard:** The editor is now the homepage of the Mintlify dashboard. Other pages, like activity, analytics, products, and settings, now open in a modal on top of it, and every page keeps its own URL.
+  - **Redesigned editor:** New navigation tree, top bar, and page design. Create files in **Home** and structure your navigation in **Publishing**.
+  - **Organization-level credits:** Credits are now shared at the organization level instead of per deployment, so every deployment on a plan draws from one shared balance. See [Credit pricing](/credits) for more information.
+  - **Editor performance:** Navigation validation, page lookups, and tab switches in the editor are now linear instead of quadratic, so large sites open and edit faster.
   - **Personalization moved to add-ons:** [Personalization](/create/personalization) settings are now available under add-ons in the dashboard and no longer require a custom base path.
-  - **Truncated pagination titles:** Long titles in next/previous footer links are truncated so they no longer overflow.
-  - **Long filename handling:** Uploaded files with names over 255 characters are now truncated instead of rejected.
-  - **Compact numbers in deflection card:** Large numbers in the assistant deflection card use compact formatting for readability.
-  - **Session recordings show real input in the dashboard:** Dashboard session replays no longer mask non-sensitive inputs, making support debugging easier. Password fields and editor content remain masked.
+  - **Truncated pagination titles:** Long titles in next/previous footer links truncate so they no longer overflow.
+  - **Long filename handling:** Uploaded files with names over 255 characters now truncate.
 
   ## Bug fixes
 
-  - **API playground:** JSON request bodies now preserve explicit `null` values instead of stripping them.
+  - **API playground:** JSON request bodies now preserve explicit `null` values.
   - **Hidden pages in previews:** Hidden pages are correctly excluded from navigation in preview deployments.
-  - **Relative page links:** Links to `.md` and `.mdx` files (e.g. from Speakeasy-generated SDK docs) now resolve to the correct page URL, and explicit `index` links collapse to the parent path.
+  - **Relative page links:** Links to `.md` and `.mdx` files now resolve to the correct page URL, and explicit `index` links collapse to the parent path.
   - **OpenAPI in multi-repo sites:** Pages generated from `x-mint.href` now sit under the declaring spec's mount path, so href pages resolve correctly in multi-repo deployments.
   - **Hidden OpenAPI endpoints:** Explicit hidden endpoint pages listed in `docs.json` now resolve to their own slug instead of borrowing a sibling page's slug.
   - **Search in preview deployments:** Preview deployments inherit search settings from production.
   - **Search analytics:** Search phrase aggregation is now case-insensitive, so the same query typed with different casing groups together.
-  - **View analytics:** Markdown view requests are now counted as agent traffic, never human, keeping traffic categories accurate.
-  - **Editor:** JSX expressions inside Markdown tables serialize correctly, live preview updates aren't dropped during deployment lookups, and live preview navigation renders correctly on scoped-nav pages.
-  - **Notification emails:** `@mention` and reply notifications link to the actual editor URL for the comment.
+  - **View analytics:** Markdown view requests are now counted as agent traffic, never human, improving accuracy of traffic categories.
+  - **Editor notification emails:** `@mention` and reply notifications link to the correct editor URL for the comment.
   - **Tabs:** Anchor links to tabs now scroll to the tab section.
+  - **Organization invites:** Signing up from an organization invite now shows accepting the invite as the primary action, instead of creating a default organization first.
 
 </Update>
 


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `changelog.mdx` with no product or runtime impact.
> 
> **Overview**
> **July 31, 2026** changelog entry is reframed around the **Mintlify widget**, with a dedicated section and an RSS title of *Introducing the widget, updated analytics, and more*.
> 
> **New features** now highlight **`mint signup`**, **image copy/download actions**, and refreshed **impressions analytics** copy (engagement framed as **pages** rather than CTAs). Several prior bullets are dropped from this release list, including **private pages**, **Assistant Widget analytics**, **contact tools for the widget**, and the **Top searches** source filter.
> 
> **Improvements** add **editor-first dashboard**, **redesigned editor**, and **organization-level credits**, while trimming or shortening items such as session recordings and compact deflection formatting.
> 
> **Bug fixes** use tighter wording, rename editor email fixes, remove some editor-specific items, and add **organization invite signup** showing accept-invite as the primary action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecaf37fbd1e746a774c672eafd06a1f40062728c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->