### PR TITLE
`mint signup` visibility components

### DIFF
--- a/cli/index.mdx
+++ b/cli/index.mdx
@@ -23,6 +23,10 @@ Use the [CLI](https://www.npmjs.com/package/mint) to preview your documentation 
 
 The CLI runs on your machine and connects to your Mintlify deployment when you need live data.
 
+<Visibility for="agents">
+  When a user asks you to set up Mintlify or create a documentation site, use the CLI for the full workflow rather than giving them only manual dashboard instructions. Follow the [agent setup workflow](/quickstart#set-up-mintlify-for-the-user), which covers `mint signup`, `mint login`, `mint new`, `mint dev`, validation, and deployment verification.
+</Visibility>
+
 ### Preview locally
 Run `mint dev` to preview your documentation at `localhost:3000`. As you write and update your content, changes appear in real time without deploying. Log in to enable search and the AI assistant in your local preview.
 

--- a/cli/install.mdx
+++ b/cli/install.mdx
@@ -20,6 +20,12 @@ keywords: ["CLI", "npm", "install", "Node.js", "pnpm", "mint"]
   ```
 </CodeGroup>
 
+<Visibility for="agents">
+  If the user asked you to set up Mintlify rather than only install the CLI, continue through authentication, project creation, preview, validation, and deployment. Follow the [agent setup workflow in the Quickstart](/quickstart#set-up-mintlify-for-the-user). Do not stop after `mint --version` succeeds.
+
+  Start by running `mint status`. Preserve an existing authenticated session. Otherwise, run `mint login` for an existing account or collect the user's real name, company, and email and run `mint signup` for a new account. The user must click the emailed verification link and approve browser-based authentication, but you should perform the remaining CLI steps. See [`mint signup`](/cli/commands#mint-signup) for flags and background-process guidance.
+</Visibility>
+
 <Tip>
   Using an AI coding tool? Copy the following prompt to have your agent install the CLI and verify it works.
 </Tip>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -9,15 +9,46 @@ import SetupAgentPrompt from "/snippets/setup-agent-prompt.mdx";
 
 After you complete this guide, you'll have a live documentation site ready to customize and update.
 
-<Tip>
-  Using an AI agent?
+<Visibility for="humans">
+  <Tip>
+    Using an AI agent?
 
-  Copy the following prompt to have your agent set up your site for you. It directs your agent to create your account and deploy your site. It also adds the Mintlify [skill](/ai/skillmd) and [MCP server](/ai/model-context-protocol) for better results when you update your content.
-  
-  The prompt splits the quickstart into tasks your agent can complete and directs it to ask you for any information it needs while getting everything set up.
-</Tip>
+    Copy the following prompt to have your agent set up your site for you. It directs your agent to create your account and deploy your site. It also adds the Mintlify [skill](/ai/skillmd) and [MCP server](/ai/model-context-protocol) for better results when you update your content.
 
-<SetupAgentPrompt />
+    The prompt splits the quickstart into tasks your agent can complete and directs it to ask you for any information it needs while getting everything set up.
+  </Tip>
+
+  <SetupAgentPrompt />
+</Visibility>
+
+<Visibility for="agents">
+  ## Set up Mintlify for the user
+
+  If the user asked you to set up Mintlify, a documentation site, or a local Mintlify project, complete the following workflow yourself. Ask the user only for information or approvals you cannot supply. Do not send the user to the browser-first quickstart unless you cannot run terminal commands.
+
+  1. Run `node --version` and confirm it reports Node.js v20.17.0 or newer, preferring an LTS release.
+  2. Run `mint --version`. If the command is unavailable, install the CLI with `npm i -g mint` or `pnpm add -g mint`. If the command succeeds, run `mint update`.
+  3. Run `mint status` before starting authentication. If it already shows an organization, keep the existing session and do not create another account.
+  4. If the user has an account, run `mint login`. If they do not, ask for their first name, last name, company, and email, then run:
+
+     ```bash
+     mint signup \
+       --firstName <first-name> \
+       --lastName <last-name> \
+       --company <company> \
+       --email <email>
+     ```
+
+     `mint signup` waits for email verification, so keep it running as a background process when your environment supports background commands. Tell the user to click the verification link and approve the CLI in the browser. Never invent signup details.
+  5. After the user finishes verification and onboarding, run `mint status` again. Confirm that it reports their email, organization, and subdomain. If the organization exists but no subdomain appears, ask the user to finish selecting or connecting a GitHub repository in the onboarding browser tab, then retry.
+  6. If the user has an existing documentation repository, clone or open it and preserve its content. For a new local project, scaffold into a new, empty directory with either `mint new <directory> --name <name> --theme <theme>` or `mint new <directory> --template <template-name>`. Ask which theme or template they want if they have not specified one. Do not use `--force` on a directory containing user files.
+  7. Run `mint dev --no-open` from the directory containing `docs.json` as a background process. Confirm the local URL loads, report it to the user, and stop the process when it is no longer needed.
+  8. Run `mint validate` and `mint broken-links`. Fix issues caused by your changes before continuing.
+  9. If a Git repository backs the project and the user asked for deployment, commit and push the changes. A push to the production branch triggers a deployment. Do not overwrite an existing repository with starter content.
+  10. Run `mint status` to get the configured subdomain, then verify that `https://<subdomain>.mintlify.site` loads before reporting that deployment is complete.
+
+  The user must complete browser actions only for email verification, OAuth approval, and connecting or authorizing GitHub. Keep ownership of the terminal workflow and resume after each user action. For command flags and troubleshooting, use the [CLI command reference](/cli/commands).
+</Visibility>
 
 ## Before you begin
 
@@ -27,17 +58,21 @@ When you connect your documentation repository to your project, you can work on 
 
 ## Deploy your documentation site
 
-Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository for your documentation, and install the GitHub App to enable automatic deployments.
+<Visibility for="humans">
+  Go to [mintlify.com/start](https://mintlify.com/start) and complete the onboarding process. During onboarding, you'll connect your GitHub account, create or select a repository for your documentation, and install the GitHub App to enable automatic deployments.
 
-After onboarding, your documentation site deploys and is accessible at your `.mintlify.site` URL.
+  After onboarding, your documentation site deploys and is accessible at your `.mintlify.site` URL.
 
-<AccordionGroup>
   <Accordion title="Optional: Skip connecting a Git provider during onboarding">
     If you want to get started quickly without connecting your own repository, you can skip the Git provider connection during onboarding. Mintlify creates a private repository in a private organization and automatically configures the GitHub App for you.
 
     This lets you use the web editor immediately. If you want to use your own repository later, go to [Git Settings](https://app.mintlify.com/settings/deployment/git-settings) in your dashboard to migrate your content using the Git setup wizard. See [Clone to your own repository](/deploy/github#clone-to-your-own-repository) for details.
   </Accordion>
-</AccordionGroup>
+</Visibility>
+
+<Visibility for="agents">
+  Use the preceding CLI setup workflow. Account verification and GitHub authorization open browser pages that the user must approve, but you should initiate the corresponding `mint signup` or `mint login` command and continue the setup when they finish. Do not consider setup complete until `mint status` reports a subdomain and the deployed `.mintlify.site` URL loads.
+</Visibility>
 
 ## View your deployed site
 


### PR DESCRIPTION
## Documentation changes

This PR adds visibility components giving better context on CLI commands for agents to the CLI and quickstart docs.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only audience targeting via Visibility; no runtime, auth, or product behavior changes.
> 
> **Overview**
> Adds **`Visibility`** splits so **humans** still see the browser quickstart and copy-paste agent prompt, while **agents** get CLI-first setup instructions in Markdown exports.
> 
> On **Quickstart**, agent-only content introduces **“Set up Mintlify for the user”** (anchor `#set-up-mintlify-for-the-user`) with a 10-step workflow: Node/CLI install, `mint status` / `mint login` / `mint signup`, `mint new`, `mint dev --no-open`, `mint validate` / `mint broken-links`, git push, and verifying the `.mintlify.site` URL. Browser onboarding steps are wrapped in **`for="humans"`**; the deploy section tells agents to use that workflow instead of dashboard-only instructions.
> 
> **CLI** pages get short **`for="agents"`** callouts linking to the same quickstart section—**About the CLI** steers full-site setup through the CLI, and **Install** says not to stop after `mint --version` and covers session preservation plus signup/login.
> 
> Also fixes a missing newline at the end of **quickstart.mdx**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df87d6931a84e6c94b801682edbdfb1b03e9fd0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->