### PR TITLE
Clean up go-live checklist

### DIFF
--- a/migration-services/go-live-checklist.mdx
+++ b/migration-services/go-live-checklist.mdx
@@ -9,7 +9,6 @@ This is a comprehensive list of configurations to set up and settings to validat
 ## Core setup
 
 - **Connect your docs repo to Mintlify.** Install the [GitHub app](/deploy/github) or connect your [GitLab repository](/deploy/gitlab).
-  - If you already installed the GitHub app, uninstall and re-install it. To verify this step, make a change to your documentation locally, push to GitHub, and check that your site redeploys.
   - If you store your documentation in more than one repository, configure a [multi-repository structure](/deploy/multi-repo) to build your site from multiple repos. If all of your content is in a single repository, skip this step.
 - **Invite team members.** Invite anyone who needs access from the [Members](https://app.mintlify.com/settings/organization/members) page in your dashboard. See [Roles](/dashboard/roles) for more information.
 
@@ -28,10 +27,12 @@ This is a comprehensive list of configurations to set up and settings to validat
 - **Verify your information architecture.** Is this the proper navigation structure? Are there missing sections? See [content types](/guides/content-types) for reference.
 - **Verify your information is up-to-date.** Are all recent content changes reflected on your site? 
 - If required, set up [redirects](/create/redirects).
+- **Configure SEO settings.** Set your site description, meta tags, and indexing preferences in `docs.json`. See [SEO and search settings](/organize/settings-seo).
+- **Review page-level SEO.** Configure meta tags, Open Graph properties, and canonical URLs where needed. See [SEO](/optimize/seo).
 
 ## Dashboard features
 
-- **Turn on and configure the assistant.** See [Configure the assistant](/assistant/configure) and [Add assistant skills](/assistant/skills).
+- **Turn on and configure the assistant.** See [Configure the assistant](/assistant/configure).
   - Configure your [support and sales deflection emails](/assistant/configure#set-deflection-emails).
   - Configure your [search domains](/assistant/configure#search-domains).
   - Customize the [assistant's response patterns](/assistant/customize) and [add assistant skills](/assistant/skills). 
@@ -40,11 +41,6 @@ This is a comprehensive list of configurations to set up and settings to validat
 - **Set up the Slack agent.** This lets you make changes to your content directly in Slack. See [Add the agent to Slack](/agent/slack#add-the-agent-to-slack).
 - **Set up automations.** See [how to enable an automation](/automations/manage#enable-an-automation).
 - **Install relevant analytics plugins.** See the [list of analytics integrations](/integrations/analytics/overview).
-
-## SEO
-
-- **Configure SEO settings.** Set your site description, meta tags, and indexing preferences in `docs.json`. See [SEO and search settings](/organize/settings-seo).
-- **Review page-level SEO.** Configure meta tags, Open Graph properties, and canonical URLs where needed. See [SEO](/optimize/seo).
 
 ## Go live
 


### PR DESCRIPTION
## What changed

Edits to `migration-services/go-live-checklist.mdx`:

- Removed the "uninstall and re-install the GitHub app" sub-bullet from Core setup, including its verification instructions.
- Removed the duplicate "Add assistant skills" link from the top-level assistant bullet; the sub-bullet ("Customize the assistant's response patterns and add assistant skills") is now the single mention.
- Removed the standalone SEO section and moved its two bullets into Content validation, so SEO review happens before Dashboard features and the checklist flows setup → security → content → dashboard → go live.

## Checks

- Vale passes with no errors or warnings.
- Both SEO link targets (`/organize/settings-seo`, `/optimize/seo`) exist.
- Verified the page renders correctly with `mint dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to an internal go-live checklist; no product code, config, or deployment behavior changes.
> 
> **Overview**
> Updates **`migration-services/go-live-checklist.mdx`** so the pre-launch checklist reads more clearly and follows a logical order.
> 
> **Core setup** no longer tells teams to uninstall and re-install the GitHub app or how to verify that step—only multi-repo and team invites remain under repo connection.
> 
> **Content validation** now includes the two SEO bullets (site-level `docs.json` settings and page-level meta/OG/canonical), moved from a separate **SEO** section that was removed. The flow is setup → security → content (including SEO) → dashboard → go live.
> 
> **Dashboard features** drops the duplicate “Add assistant skills” link on the main assistant bullet; skills are mentioned once in the sub-bullet about customizing response patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43213ecd5118495dca15effa5e15b370fa63f2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->