### PR TITLE
fix ParamField signature and fence nesting in components skill

### DIFF
--- a/agent-context/context/skills/mintlify/SKILL.md
+++ b/agent-context/context/skills/mintlify/SKILL.md
@@ -177,7 +177,7 @@ Below are the most commonly used components. For full props and all 25 component
 </Tabs>
 ```
 
-```mdx
+````mdx
 <CodeGroup>
 
 ```javascript example.js
@@ -189,7 +189,7 @@ greeting = "Hello, world!"
 ```
 
 </CodeGroup>
-```
+````
 
 ### Cards and columns
 

--- a/agent-context/context/skills/mintlify/SKILL.md
+++ b/agent-context/context/skills/mintlify/SKILL.md
@@ -17,7 +17,7 @@ Read these files **only when your task requires them**. They are in the `referen
 | `reference/configuration.md` | Changing docs.json settings (theme, colors, logo, fonts, appearance, navbar, footer, banner, redirects, SEO, integrations, API config). Also covers snippets, hidden pages, .mintignore, custom CSS/JS, and the complete frontmatter fields table. |
 | `reference/navigation.md` | Modifying site navigation structure (groups, tabs, anchors, dropdowns, products, versions, languages, OpenAPI in nav). |
 | `reference/api-docs.md` | Setting up API documentation (OpenAPI, AsyncAPI, MDX manual API pages, extensions, playground config). |
-| `reference/cli.md` | Running CLI commands (dev, validate, analytics, workflow, score, broken-links, a11y, config, and all flags). |
+| `reference/cli.md` | Running common CLI commands (dev, validate, add-domain, automations, score, broken-links, a11y, format, and config) and their key flags. |
 | `reference/product-context.md` | Before substantial content work (new site, broad restructure, first-time section setup) — check for and maintain `.mintlify/product-brief.md`. |
 
 ## MCP servers

--- a/agent-context/context/skills/mintlify/SKILL.md
+++ b/agent-context/context/skills/mintlify/SKILL.md
@@ -15,7 +15,7 @@ Read these files **only when your task requires them**. They are in the `referen
 |------|-------------|
 | `reference/components.md` | Adding or modifying components (callouts, cards, steps, tabs, accordions, code groups, fields, frames, icons, tooltips, badges, trees, mermaid, panels, prompts, colors, tiles, updates, views). |
 | `reference/configuration.md` | Changing docs.json settings (theme, colors, logo, fonts, appearance, navbar, footer, banner, redirects, SEO, integrations, API config). Also covers snippets, hidden pages, .mintignore, custom CSS/JS, and the complete frontmatter fields table. |
-| `reference/navigation.md` | Modifying site navigation structure (groups, tabs, anchors, dropdowns, products, versions, languages, OpenAPI in nav). |
+| `reference/navigation.md` | Modifying site navigation structure (groups, tabs, anchors, dropdowns, products, versions, languages, OpenAPI, and SDK references in nav). |
 | `reference/api-docs.md` | Setting up API documentation (OpenAPI, AsyncAPI, MDX manual API pages, extensions, playground config). |
 | `reference/cli.md` | Running common CLI commands (dev, validate, add-domain, automations, score, broken-links, a11y, format, and config) and their key flags. |
 | `reference/product-context.md` | Before substantial content work (new site, broad restructure, first-time section setup) — check for and maintain `.mintlify/product-brief.md`. |

--- a/agent-context/context/skills/mintlify/reference/cli.md
+++ b/agent-context/context/skills/mintlify/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-Full reference for every `mint` CLI command and flag.
+Condensed reference for common `mint` CLI commands and their key flags.
 
 Install with `npm i -g mint`.
 
@@ -16,16 +16,17 @@ Available on all commands.
 
 ## Local development
 
-- `mint dev` — Start local preview at localhost:3000. `--port` sets the port. `--no-open` skips browser launch. `--groups <names>` mocks user groups. `--disable-openapi` skips OpenAPI processing. `--local-schema` allows locally-hosted OpenAPI files over HTTP.
+- `mint dev` — Start local preview at localhost:3000. `--port` sets the port. `--no-open` skips browser launch. `--groups <names>` mocks user groups. `--disable-openapi` skips OpenAPI processing. `--disable-prefetch` disables navigation prefetching. `--local-schema` allows locally-hosted OpenAPI files over HTTP.
 - `mint validate` — Strict build validation; exits non-zero on warnings or errors. `--groups <names>` mocks user groups. `--disable-openapi` skips OpenAPI processing. `--local-schema` allows local OpenAPI files.
 - `mint export` — Export a static site zip for air-gapped deployment. `--output <file>` sets the output path (default: `export.zip`). `--groups <names>` includes restricted pages. `--disable-openapi` skips OpenAPI processing.
 
 ## Content quality
 
-- `mint broken-links` — Check for broken internal links. `--check-anchors` validates `#` anchors. `--check-external` checks external URLs. `--check-redirects` checks that redirect destinations in `docs.json` resolve. `--check-snippets` checks links inside `<Snippet>` components.
+- `mint broken-links` — Check for broken internal links. `--files <paths...>` limits the check to specific files or globs. `--check-anchors` validates `#` anchors. `--check-external` checks external URLs. `--check-redirects` checks that redirect destinations in `docs.json` resolve. `--check-snippets` checks links inside `<Snippet>` components.
 - `mint a11y` — Accessibility checks (alt text, color contrast). `--skip-contrast` or `--skip-alt-text` to narrow scope.
 - `mint score [url]` — Score a docs site's AI/agent readiness. Checks llms.txt, MCP discoverability, robots.txt, sitemap, structured data, response latency, and more. Requires `mint login`. Defaults to your configured subdomain. `--format` accepts `table` (default), `plain`, or `json`.
 - `mint deslop [files...]` — Check pages for AI-sounding prose and get rewrite suggestions. Requires `mint login`. Without `files`, checks the `.md`/`.mdx` pages changed in your working tree (Git diff plus untracked files). Flags: `--format` (`table`/`plain`/`json`), `--subdomain`, `--threshold` (0-1, default 0.5), `--fix-whitespace` (normalizes trailing spaces, blank-line runs, and invisible Unicode outside code blocks/frontmatter).
+- `mint format` — Format every `.mdx` file in the current directory and its subdirectories in place. Respects `.gitignore` and Mintlify ignore rules. Commit or stash changes first so you can review the rewrite.
 
 ## Authentication
 
@@ -33,6 +34,7 @@ Available on all commands.
 - `mint logout` — Log out of your account.
 - `mint status` — Show current authentication status (CLI version, email, org, subdomain).
 - `mint signup [flags]` — Create a new Mintlify account from the terminal. Flags: `--firstName`, `--lastName`, `--company`, `--email`; omit any to enter it interactively. Waits until you click the emailed verification link before it logs you in — run as a background process in scripts.
+- `mint add-domain <domain> [--basePath <path>]` — Add a custom domain to the current deployment. Requires `mint login`. Pass `--basePath` to serve the documentation from a subpath such as `/docs`.
 
 ## Configuration
 

--- a/agent-context/context/skills/mintlify/reference/components.md
+++ b/agent-context/context/skills/mintlify/reference/components.md
@@ -25,7 +25,7 @@ Custom callout with icon and color:
 
 ## Banner
 
-Not an MDX component. A site-wide announcement banner configured via the `banner` field in `docs.json`. See `reference/configuration.md`.
+Not an MDX component. A site-wide announcement banner configured via the `banner` field in `docs.json`. See `./configuration.md`.
 
 ## Accordions
 
@@ -164,7 +164,7 @@ Tab props:
 
 Tabbed code examples in multiple languages. Tabs sync with `<Tabs>` components that have matching titles.
 
-```mdx
+````mdx
 <CodeGroup>
 
 ```javascript example.js
@@ -178,7 +178,7 @@ print(greeting)
 ```
 
 </CodeGroup>
-```
+````
 
 For dropdown style instead of tabs:
 
@@ -210,21 +210,21 @@ Document API parameters and response structures.
 ### ParamField
 
 ```mdx
-<ParamField path="query.limit" type="number" required default="10" placeholder="1-100">
+<ParamField query="limit" type="number" required default="10" placeholder="1-100">
   Maximum number of results to return.
 </ParamField>
 
-<ParamField path="body.email" type="string" required>
+<ParamField body="email" type="string" required>
   User email address.
 </ParamField>
 
-<ParamField path="header.Authorization" type="string" required>
+<ParamField header="Authorization" type="string" required>
   Bearer token for authentication.
 </ParamField>
 ```
 
 Props:
-- First parameter format: `query.name`, `path.name`, `body.name`, or `header.name`.
+- Location prop: `query`, `path`, `body`, or `header`. The prop name is the parameter location, and its value is the parameter name.
 - `type` (string): `number`, `string`, `boolean`, `object`. Append `[]` for arrays.
 - `required` (boolean): Mark as required.
 - `deprecated` (boolean): Mark as deprecated.
@@ -259,7 +259,7 @@ Props:
 
 Display code examples in the right sidebar on API pages.
 
-```mdx
+````mdx
 <RequestExample>
 
 ```bash cURL
@@ -288,7 +288,7 @@ response = requests.post(
 ```
 
 </ResponseExample>
-```
+````
 
 ## Frames
 
@@ -498,7 +498,7 @@ Props:
 
 Language/framework-specific content sections that switch with a multi-view dropdown.
 
-```mdx
+````mdx
 <View title="JavaScript" icon="js">
   ```javascript
   console.log("Hello from JavaScript!");
@@ -510,7 +510,7 @@ Language/framework-specific content sections that switch with a multi-view dropd
   print("Hello from Python!")
   ```
 </View>
-```
+````
 
 Props:
 - `title` (string, required): View selector label.

--- a/agent-context/context/skills/mintlify/reference/configuration.md
+++ b/agent-context/context/skills/mintlify/reference/configuration.md
@@ -101,13 +101,13 @@ title: "Page title"
 mode: "custom"
 ---
 
-# Frame: like custom but keeps sidebar (Aspen, Almond, and Luma themes only)
+# Frame: like custom but keeps sidebar (Aspen, Almond, Luma, and Sequoia themes only)
 ---
 title: "Page title"
 mode: "frame"
 ---
 
-# Center: removes sidebar and TOC, centers content (Mint and Linden themes only)
+# Center: removes sidebar and TOC, centers content (Mint, Linden, Willow, and Maple themes only)
 ---
 title: "Page title"
 mode: "center"

--- a/agent-context/context/skills/mintlify/reference/configuration.md
+++ b/agent-context/context/skills/mintlify/reference/configuration.md
@@ -406,7 +406,7 @@ Controls whether clicking a navigation group navigates to its first page (`true`
 }
 ```
 
-- `options` (required): First item is the default action. Built-in values: `"assistant"`, `"copy"`, `"view"`, `"chatgpt"`, `"claude"`, `"perplexity"`, `"grok"`, `"aistudio"`, `"devin"`, `"windsurf"`, `"mcp"`, `"add-mcp"`, `"cursor"`, `"vscode"`, `"devin-mcp"`. Custom objects accepted with `title`, `description`, `icon`, and `href` fields.
+- `options` (required): First item is the default action. Built-in values: `"assistant"`, `"copy"`, `"view"`, `"download-pdf"`, `"download-spec"`, `"chatgpt"`, `"claude"`, `"perplexity"`, `"grok"`, `"aistudio"`, `"devin"`, `"devin-desktop"`, `"mcp"`, `"add-mcp"`, `"cursor"`, `"vscode"`, `"devin-mcp"`. Custom objects accepted with `title`, `description`, `icon`, and `href` fields.
 - `display`: Where to show the menu. `"header"` (default) or `"toc"`.
 
 ## Thumbnails

--- a/agent-context/context/skills/mintlify/reference/configuration.md
+++ b/agent-context/context/skills/mintlify/reference/configuration.md
@@ -465,7 +465,7 @@ Controls whether clicking a navigation group navigates to its first page (`true`
 - `params.expanded`: Expand all parameters by default. `"all"` or `"closed"` (default).
 - `params.post`: OpenAPI schema field keys to surface as pills next to parameter names.
 - `url`: Set to `"full"` to always show the full base URL (default: only shown when multiple base URLs exist).
-- `examples.languages`: `bash`, `go`, `java`, `javascript`, `node`, `php`, `powershell`, `python`, `ruby`, `swift`.
+- `examples.languages`: `bash`, `python`, `javascript`, `node`, `php`, `go`, `java`, `ruby`, `powershell`, `swift`, `csharp`, `dotnet`, `typescript`, `c`, `c++`, `kotlin`, `rust`, `dart`.
 - `examples.defaults`: `"required"` or `"all"` (include optional params).
 - `examples.prefill`: Pre-fill playground fields with spec example values. Default: `false`.
 - `examples.autogenerate`: Generate code samples from API specs. Default: `true`.

--- a/agent-context/context/skills/mintlify/reference/navigation.md
+++ b/agent-context/context/skills/mintlify/reference/navigation.md
@@ -333,6 +333,27 @@ Each language entry can include its own `banner`, `footer`, and `navbar` configu
 
 When you add `openapi` to a navigation element without specifying pages, Mintlify auto-generates pages for all endpoints.
 
+## SDK references
+
+Generate SDK reference pages from documentation-tool build artifacts by adding an `sdk` property to a tab. Set `format` to `typedoc`, `docfx`, `javadoc`, `sphinx`, or `phpdoc`; set `source` to an artifact path or HTTPS URL; and optionally set `directory` to control the generated pages' URL prefix.
+
+```json
+{
+  "navigation": {
+    "tabs": [
+      {
+        "tab": "TypeScript SDK",
+        "sdk": {
+          "format": "typedoc",
+          "source": "sdk-artifacts/typedoc.json",
+          "directory": "sdk/typescript"
+        }
+      }
+    ]
+  }
+}
+```
+
 ## Choosing a navigation pattern
 
 | Pattern | When to use |


### PR DESCRIPTION
ParamField examples used a dot-prefixed path prop (path="query.limit") that contradicts the documented signature, where the prop name is the parameter location and its value is the parameter name. CodeGroup, RequestExample/ResponseExample, and View examples nested fenced code inside a 3-backtick outer fence, which CommonMark closes early; switch to 4-backtick outer fences like the existing Mermaid example.

closes #6897

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent context skill files; no application code, auth, or data paths affected.
> 
> **Overview**
> Corrects **Mintlify agent skill** examples so they match current product behavior and render safely in Markdown.
> 
> **`ParamField`** examples now use location props (`query`, `body`, `header`) instead of a dot-prefixed `path="query.limit"` style, and the props text describes that pattern explicitly.
> 
> **Nested code in examples** (`CodeGroup`, `RequestExample`/`ResponseExample`, `View`, and the main `SKILL.md` snippet) use **four-backtick** outer fences so inner triple-backtick blocks are not closed early by CommonMark.
> 
> Beyond those fixes, the reference set is **brought up to date**: condensed CLI docs add `mint format`, `mint add-domain`, `--disable-prefetch`, and `--files` for `broken-links`; **configuration** adds contextual menu download options, expanded API example languages, and theme lists for `frame`/`center` modes; **navigation** documents **SDK references** via tab `sdk` config; minor cross-link and index wording updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad886faa935058e9fe6f7c88612c86c930f2828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->