### PR TITLE
feat: generate kiro power in agent-context

### DIFF
--- a/.github/workflows/agent-context-ci.yml
+++ b/.github/workflows/agent-context-ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
+      - run: npm ci
+        working-directory: agent-context
       - run: npm test
         working-directory: agent-context
       - run: npm run check

--- a/.github/workflows/sync-agent-context.yml
+++ b/.github/workflows/sync-agent-context.yml
@@ -9,7 +9,9 @@ on:
       - agent-context/targets/**
       - agent-context/scripts/**
       - agent-context/test/**
+      - agent-context/schemas/**
       - agent-context/package.json
+      - agent-context/package-lock.json
       - .github/workflows/sync-agent-context.yml
 
 permissions:
@@ -28,6 +30,8 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
+      - run: npm ci
+        working-directory: agent-context
       - run: npm test
         working-directory: agent-context
       - run: npm run check
@@ -71,6 +75,9 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
+
+      - run: npm ci
+        working-directory: source/agent-context
 
       - name: Create target repository token
         id: app-token

--- a/.github/workflows/sync-agent-context.yml
+++ b/.github/workflows/sync-agent-context.yml
@@ -44,14 +44,22 @@ jobs:
             repository: mintlify/codex-plugin
             repository_name: codex-plugin
             mcp_file: .mcp.json
+            manifest_file: ""
           - target: cursor
             repository: mintlify/cursor-plugin
             repository_name: cursor-plugin
             mcp_file: mcp.json
+            manifest_file: ""
           - target: claude
             repository: mintlify/mintlify-claude-plugin
             repository_name: mintlify-claude-plugin
             mcp_file: .mcp.json
+            manifest_file: ""
+          - target: kiro
+            repository: mintlify/kiro-power
+            repository_name: kiro-power
+            mcp_file: mcp.json
+            manifest_file: plugin.json
 
     steps:
       - name: Check out context source
@@ -106,6 +114,9 @@ jobs:
           git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"
           git add skills/mintlify .mintlify-agent-context.json "${{ matrix.mcp_file }}"
+          if [[ -n "${{ matrix.manifest_file }}" ]]; then
+            git add "${{ matrix.manifest_file }}"
+          fi
           git commit -m "Sync Mintlify agent context"
           git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
           git push --force-with-lease origin "HEAD:$BRANCH"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 package-lock.json
+!agent-context/package-lock.json
 .idea/
 .vscode/
 .pr-body.md

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -1,17 +1,17 @@
 # Mintlify agent context
 
-Single source of truth, maintained in the Mintlify documentation repository, for the Mintlify skill distributed through the Codex, Cursor, and Claude plugins.
+Single source of truth, maintained in the Mintlify documentation repository, for the Mintlify skill distributed through the Codex, Cursor, and Claude plugins and the Kiro power.
 
 ## Repository structure
 
 - `context/skills/mintlify/` contains canonical, client-neutral context.
 - `context/mcp-servers.json` contains canonical MCP names, URLs, and transport settings.
-- `targets/*.json` contains only client packaging differences such as MCP config file and schema names.
+- `targets/*.json` contains only client packaging differences such as MCP config and skill directory conventions. The Kiro target also contains its required Agent Plugins manifest.
 - `scripts/build.mjs` renders self-contained plugin artifacts into `dist/`.
 - `scripts/sync-target.mjs` replaces only `skills/mintlify/` in a target repository.
-- `../.github/workflows/sync-agent-context.yml` opens generated sync pull requests in all three plugin repositories.
+- `../.github/workflows/sync-agent-context.yml` opens generated sync pull requests in all four target repositories.
 
-Plugin manifests, assets, READMEs, and Cursor rules remain owned by their target repositories. This project generates the shared skill and each client's MCP configuration file.
+Plugin manifests, assets, READMEs, and Cursor rules remain owned by their target repositories, except for Kiro's required `plugin.json`, which is generated from its target configuration. This project generates the shared skill and each client's MCP configuration file.
 
 ## Local development
 
@@ -28,6 +28,7 @@ Build one target by passing its ID:
 
 ```bash
 node scripts/build.mjs codex
+node scripts/build.mjs kiro
 ```
 
 Preview a sync into a local checkout:
@@ -37,7 +38,7 @@ node scripts/sync-target.mjs codex ../../codex-plugin
 git -C ../../codex-plugin diff
 ```
 
-The sync command replaces `skills/mintlify/`, writes the client-specific MCP configuration file, and writes `.mintlify-agent-context.json` with the source commit. It does not change any other plugin files.
+The sync command replaces `skills/mintlify/`, writes the client-specific MCP configuration file, and writes `.mintlify-agent-context.json` with the source commit. For Kiro, it also writes the required `plugin.json`. It does not change any other plugin files.
 
 `npm run status` compares locally checked-out sibling plugin repositories with fresh builds and reports whether each one is current. Pass a workspace root as the final argument if the repositories do not share this repository's parent directory.
 
@@ -48,6 +49,7 @@ Create a GitHub App installed on these repositories:
 - `mintlify/codex-plugin`
 - `mintlify/cursor-plugin`
 - `mintlify/mintlify-claude-plugin`
+- `mintlify/kiro-power`
 
 Grant the app repository **Contents: read and write** and **Pull requests: read and write** permissions. Add its client ID as the `CONTEXT_SYNC_APP_CLIENT_ID` Actions variable and its private key as the `CONTEXT_SYNC_APP_PRIVATE_KEY` Actions secret in the `mintlify/docs` repository.
 

--- a/agent-context/README.md
+++ b/agent-context/README.md
@@ -6,6 +6,7 @@ Single source of truth, maintained in the Mintlify documentation repository, for
 
 - `context/skills/mintlify/` contains canonical, client-neutral context.
 - `context/mcp-servers.json` contains canonical MCP names, URLs, and transport settings.
+- `schemas/agent-plugins/` contains vendored schemas used to validate generated Agent Plugins artifacts.
 - `targets/*.json` contains only client packaging differences such as MCP config and skill directory conventions. The Kiro target also contains its required Agent Plugins manifest.
 - `scripts/build.mjs` renders self-contained plugin artifacts into `dist/`.
 - `scripts/sync-target.mjs` replaces only `skills/mintlify/` in a target repository.
@@ -18,6 +19,7 @@ Plugin manifests, assets, READMEs, and Cursor rules remain owned by their target
 Requires Node.js 22 or newer and has no package dependencies.
 
 ```bash
+npm ci
 npm test
 npm run check
 npm run build
@@ -39,6 +41,8 @@ git -C ../../codex-plugin diff
 ```
 
 The sync command replaces `skills/mintlify/`, writes the client-specific MCP configuration file, and writes `.mintlify-agent-context.json` with the source commit. For Kiro, it also writes the required `plugin.json`. It does not change any other plugin files.
+
+Treat the Kiro manifest version as a release version. Whenever a change modifies the generated Kiro skill, MCP configuration, or manifest, increment `pluginManifest.version` in `targets/kiro.json` according to Semantic Versioning before merging. Do not use a Git SHA or SemVer build metadata as the update version because build metadata does not affect version precedence.
 
 `npm run status` compares locally checked-out sibling plugin repositories with fresh builds and reports whether each one is current. Pass a workspace root as the final argument if the repositories do not share this repository's parent directory.
 

--- a/agent-context/package-lock.json
+++ b/agent-context/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "@mintlify/agent-context",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mintlify/agent-context",
+      "version": "0.1.0",
+      "devDependencies": {
+        "ajv": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/agent-context/package.json
+++ b/agent-context/package.json
@@ -11,5 +11,8 @@
     "check": "node scripts/check.mjs",
     "status": "node scripts/status.mjs",
     "test": "node --test"
+  },
+  "devDependencies": {
+    "ajv": "^8.18.0"
   }
 }

--- a/agent-context/schemas/agent-plugins/1.0.0/mcp.schema.json
+++ b/agent-context/schemas/agent-plugins/1.0.0/mcp.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "title": "Agent Plugins MCP Configuration",
+  "description": "Machine-readable schema for mcp.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+      "description": "Canonical identifier of the MCP configuration schema for the Agent Plugins version targeted by this document."
+    },
+    "mcpServers": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "required": ["$schema", "mcpServers"],
+  "additionalProperties": false,
+  "$defs": {
+    "server": {
+      "title": "MCP server",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/stdioServer"
+        },
+        {
+          "$ref": "#/$defs/streamableHttpServer"
+        },
+        {
+          "$ref": "#/$defs/sseServer"
+        }
+      ]
+    },
+    "stdioServer": {
+      "title": "stdio MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "stdio"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Executable token. Resolution rules are defined by the Agent Plugins specification."
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "object",
+          "propertyNames": {
+            "not": {
+              "enum": ["PLUGIN_ROOT", "PLUGIN_DATA"]
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "type": "string",
+          "pattern": "^(?:\\./|\\$\\{PLUGIN_ROOT\\}(?:/|$)|\\$\\{PLUGIN_DATA\\}(?:/|$))",
+          "description": "Plugin-relative, PLUGIN_ROOT-rooted, or PLUGIN_DATA-rooted working directory. Filesystem containment is validated separately."
+        }
+      },
+      "required": ["type", "command"],
+      "additionalProperties": false
+    },
+    "streamableHttpServer": {
+      "title": "Streamable HTTP MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "streamable-http"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "sseServer": {
+      "title": "Legacy HTTP+SSE MCP server",
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "sse"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "MCP endpoint URL. URL semantics are defined by the Agent Plugins specification."
+        },
+        "headers": {
+          "$ref": "#/$defs/headers"
+        }
+      },
+      "required": ["type", "url"],
+      "additionalProperties": false
+    },
+    "headers": {
+      "title": "HTTP headers",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/agent-context/schemas/agent-plugins/1.0.0/plugin.schema.json
+++ b/agent-context/schemas/agent-plugins/1.0.0/plugin.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "title": "Agent Plugins Manifest",
+  "description": "Machine-readable schema for plugin.json in Agent Plugins 1.0.0. The Agent Plugins specification defines additional semantic and operational requirements.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+      "description": "Canonical identifier of the plugin manifest schema for the Agent Plugins version targeted by this document."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^(?!.*(?:--|\\.\\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$",
+      "description": "Human-readable plugin name."
+    },
+    "version": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "author": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "homepage": {
+      "type": "string"
+    },
+    "repository": {
+      "type": "string"
+    },
+    "license": {
+      "type": "string"
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Client-specific manifest data keyed by reverse-domain extension namespace. Agent Plugins assigns no semantics to namespace object contents.",
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "required": ["$schema", "name"],
+  "additionalProperties": false
+}

--- a/agent-context/scripts/check.mjs
+++ b/agent-context/scripts/check.mjs
@@ -2,13 +2,15 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildAll } from './lib.mjs';
+import { buildAll, loadTargets } from './lib.mjs';
 
 const outputRoot = await mkdtemp(path.join(tmpdir(), 'mintlify-agent-context-'));
 
 try {
   const results = await buildAll({ outputRoot });
-  assert.equal(results.length, 3);
+  const targets = await loadTargets();
+  const targetsById = new Map(targets.map((target) => [target.id, target]));
+  assert.equal(results.length, 4);
 
   const sharedFiles = [
     'api-docs.md',
@@ -22,7 +24,14 @@ try {
     const contents = await Promise.all(
       results.map(({ provenance }) =>
         readFile(
-          path.join(outputRoot, provenance.target, 'skills', 'mintlify', 'reference', file),
+          path.join(
+            outputRoot,
+            provenance.target,
+            'skills',
+            'mintlify',
+            targetsById.get(provenance.target).skillReferenceDirectory ?? 'reference',
+            file,
+          ),
           'utf8',
         ),
       ),

--- a/agent-context/scripts/lib.mjs
+++ b/agent-context/scripts/lib.mjs
@@ -25,9 +25,31 @@ export async function loadTargets(selectedIds = []) {
       typeof target.id !== 'string' ||
       typeof target.repository !== 'string' ||
       !['.mcp.json', 'mcp.json'].includes(target.mcpConfigFile) ||
-      !['mcp_servers', 'mcpServers'].includes(target.mcpConfigKey)
+      !['mcp_servers', 'mcpServers'].includes(target.mcpConfigKey) ||
+      (target.skillReferenceDirectory !== undefined &&
+        !['reference', 'references'].includes(target.skillReferenceDirectory)) ||
+      (target.mcpSchema !== undefined && typeof target.mcpSchema !== 'string') ||
+      (target.mcpTypeOverrides !== undefined &&
+        (target.mcpTypeOverrides === null ||
+          typeof target.mcpTypeOverrides !== 'object' ||
+          Object.values(target.mcpTypeOverrides).some((value) => typeof value !== 'string')))
     ) {
       throw new Error(`Invalid target configuration: ${JSON.stringify(target)}`);
+    }
+
+    if (target.pluginManifest !== undefined) {
+      const manifest = target.pluginManifest;
+      if (
+        manifest?.$schema !== 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json' ||
+        typeof manifest.name !== 'string' ||
+        typeof manifest.version !== 'string' ||
+        typeof manifest.description !== 'string' ||
+        typeof manifest.author?.name !== 'string' ||
+        !Array.isArray(manifest.keywords) ||
+        manifest.keywords.length === 0
+      ) {
+        throw new Error(`Invalid plugin manifest: ${JSON.stringify(manifest)}`);
+      }
     }
   }
 
@@ -93,23 +115,47 @@ function validateSkill(skill, target) {
 export async function buildTarget(target, outputRoot) {
   const targetRoot = path.join(outputRoot, target.id);
   const skillOutput = path.join(targetRoot, 'skills', 'mintlify');
+  const referenceDirectory = target.skillReferenceDirectory ?? 'reference';
   await rm(targetRoot, { recursive: true, force: true });
   await mkdir(skillOutput, { recursive: true });
 
   const skillTemplate = await readFile(path.join(contextDirectory, 'SKILL.md'), 'utf8');
-  const skill = markGenerated(skillTemplate);
+  const skill = markGenerated(skillTemplate).replaceAll(
+    'reference/',
+    `${referenceDirectory}/`,
+  );
   validateSkill(skill, target);
   await writeFile(path.join(skillOutput, 'SKILL.md'), skill);
-  await cp(path.join(contextDirectory, 'reference'), path.join(skillOutput, 'reference'), {
-    recursive: true,
-  });
+  await cp(
+    path.join(contextDirectory, 'reference'),
+    path.join(skillOutput, referenceDirectory),
+    { recursive: true },
+  );
 
-  const mcpServers = JSON.parse(await readFile(mcpServersPath, 'utf8'));
-  const mcpConfig = { [target.mcpConfigKey]: mcpServers };
+  const canonicalMcpServers = JSON.parse(await readFile(mcpServersPath, 'utf8'));
+  const mcpServers = Object.fromEntries(
+    Object.entries(canonicalMcpServers).map(([name, server]) => [
+      name,
+      target.mcpTypeOverrides?.[server.type] === undefined
+        ? server
+        : { ...server, type: target.mcpTypeOverrides[server.type] },
+    ]),
+  );
+  const mcpConfig = {
+    ...(target.mcpSchema === undefined ? {} : { $schema: target.mcpSchema }),
+    [target.mcpConfigKey]: mcpServers,
+  };
   await writeFile(
     path.join(targetRoot, target.mcpConfigFile),
     `${JSON.stringify(mcpConfig, null, 2)}\n`,
   );
+
+  if (target.pluginManifest !== undefined) {
+    await writeFile(
+      path.join(targetRoot, 'plugin.json'),
+      `${JSON.stringify(target.pluginManifest, null, 2)}\n`,
+    );
+  }
 
   const provenance = {
     schemaVersion: 1,
@@ -147,6 +193,9 @@ export async function copyTargetToRepository(targetId, destination, outputRoot) 
     path.join(sourceRoot, target.mcpConfigFile),
     path.join(destination, target.mcpConfigFile),
   );
+  if (target.pluginManifest !== undefined) {
+    await cp(path.join(sourceRoot, 'plugin.json'), path.join(destination, 'plugin.json'));
+  }
   await cp(
     path.join(sourceRoot, '.mintlify-agent-context.json'),
     path.join(destination, '.mintlify-agent-context.json'),

--- a/agent-context/scripts/lib.mjs
+++ b/agent-context/scripts/lib.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
 
 const scriptsDirectory = path.dirname(fileURLToPath(import.meta.url));
 export const repositoryRoot = path.resolve(scriptsDirectory, '..');
@@ -9,6 +10,38 @@ export const repositoryRoot = path.resolve(scriptsDirectory, '..');
 const contextDirectory = path.join(repositoryRoot, 'context', 'skills', 'mintlify');
 const mcpServersPath = path.join(repositoryRoot, 'context', 'mcp-servers.json');
 const targetsDirectory = path.join(repositoryRoot, 'targets');
+const agentPluginsSchemaDirectory = path.join(
+  repositoryRoot,
+  'schemas',
+  'agent-plugins',
+  '1.0.0',
+);
+
+const ajv = new Ajv2020({ allErrors: true });
+const agentPluginValidators = {
+  mcp: ajv.compile(
+    JSON.parse(await readFile(path.join(agentPluginsSchemaDirectory, 'mcp.schema.json'), 'utf8')),
+  ),
+  plugin: ajv.compile(
+    JSON.parse(
+      await readFile(path.join(agentPluginsSchemaDirectory, 'plugin.schema.json'), 'utf8'),
+    ),
+  ),
+};
+
+export function validateAgentPluginArtifact(kind, value, targetId) {
+  const validate = agentPluginValidators[kind];
+  if (validate === undefined) {
+    throw new Error(`Unknown Agent Plugins artifact kind: ${kind}`);
+  }
+  if (!validate(value)) {
+    throw new Error(
+      `${targetId}: invalid Agent Plugins ${kind} artifact: ${ajv.errorsText(validate.errors, {
+        separator: '; ',
+      })}`,
+    );
+  }
+}
 
 export async function loadTargets(selectedIds = []) {
   const entries = (await readdir(targetsDirectory))
@@ -37,20 +70,6 @@ export async function loadTargets(selectedIds = []) {
       throw new Error(`Invalid target configuration: ${JSON.stringify(target)}`);
     }
 
-    if (target.pluginManifest !== undefined) {
-      const manifest = target.pluginManifest;
-      if (
-        manifest?.$schema !== 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json' ||
-        typeof manifest.name !== 'string' ||
-        typeof manifest.version !== 'string' ||
-        typeof manifest.description !== 'string' ||
-        typeof manifest.author?.name !== 'string' ||
-        !Array.isArray(manifest.keywords) ||
-        manifest.keywords.length === 0
-      ) {
-        throw new Error(`Invalid plugin manifest: ${JSON.stringify(manifest)}`);
-      }
-    }
   }
 
   const ids = new Set(targets.map((target) => target.id));
@@ -145,6 +164,12 @@ export async function buildTarget(target, outputRoot) {
     ...(target.mcpSchema === undefined ? {} : { $schema: target.mcpSchema }),
     [target.mcpConfigKey]: mcpServers,
   };
+  if (target.mcpSchema !== undefined) {
+    validateAgentPluginArtifact('mcp', mcpConfig, target.id);
+  }
+  if (target.pluginManifest !== undefined) {
+    validateAgentPluginArtifact('plugin', target.pluginManifest, target.id);
+  }
   await writeFile(
     path.join(targetRoot, target.mcpConfigFile),
     `${JSON.stringify(mcpConfig, null, 2)}\n`,

--- a/agent-context/targets/kiro.json
+++ b/agent-context/targets/kiro.json
@@ -1,0 +1,33 @@
+{
+  "id": "kiro",
+  "repository": "mintlify/kiro-power",
+  "skillReferenceDirectory": "references",
+  "mcpConfigFile": "mcp.json",
+  "mcpConfigKey": "mcpServers",
+  "mcpSchema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpTypeOverrides": {
+    "http": "streamable-http"
+  },
+  "pluginManifest": {
+    "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+    "name": "mintlify",
+    "version": "1.0.0",
+    "description": "Create, maintain, and improve Mintlify documentation with product guidance and Mintlify tools.",
+    "author": {
+      "name": "Mintlify",
+      "url": "https://mintlify.com"
+    },
+    "keywords": [
+      "mintlify",
+      "documentation",
+      "docs.json",
+      "api documentation",
+      "technical writing",
+      "mdx",
+      "openapi"
+    ],
+    "homepage": "https://mintlify.com/docs",
+    "repository": "https://github.com/mintlify/kiro-power",
+    "license": "MIT"
+  }
+}

--- a/agent-context/test/build.test.mjs
+++ b/agent-context/test/build.test.mjs
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { buildAll, copyTargetToRepository } from '../scripts/lib.mjs';
+import { buildAll, buildTarget, copyTargetToRepository, loadTargets } from '../scripts/lib.mjs';
 
 test('builds all client variants from one canonical skill', async () => {
   const outputRoot = await mkdtemp(path.join(tmpdir(), 'mintlify-agent-context-test-'));
@@ -124,6 +124,46 @@ test('sync writes the complete Kiro power without changing target-owned files', 
     );
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects unknown Agent Plugins manifest properties', async () => {
+  const outputRoot = await mkdtemp(path.join(tmpdir(), 'mintlify-agent-context-invalid-plugin-'));
+
+  try {
+    const [kiro] = await loadTargets(['kiro']);
+    const target = {
+      ...kiro,
+      pluginManifest: { ...kiro.pluginManifest, unknownProperty: true },
+    };
+    await assert.rejects(
+      buildTarget(target, outputRoot),
+      /invalid Agent Plugins plugin artifact.*additional properties/,
+    );
+    await assert.rejects(readFile(path.join(outputRoot, 'kiro', 'mcp.json')));
+    await assert.rejects(readFile(path.join(outputRoot, 'kiro', 'plugin.json')));
+  } finally {
+    await rm(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test('rejects unsupported Agent Plugins MCP transports', async () => {
+  const outputRoot = await mkdtemp(path.join(tmpdir(), 'mintlify-agent-context-invalid-mcp-'));
+
+  try {
+    const [kiro] = await loadTargets(['kiro']);
+    const target = {
+      ...kiro,
+      mcpTypeOverrides: { ...kiro.mcpTypeOverrides, http: 'websocket' },
+    };
+    await assert.rejects(
+      buildTarget(target, outputRoot),
+      /invalid Agent Plugins mcp artifact/,
+    );
+    await assert.rejects(readFile(path.join(outputRoot, 'kiro', 'mcp.json')));
+    await assert.rejects(readFile(path.join(outputRoot, 'kiro', 'plugin.json')));
+  } finally {
+    await rm(outputRoot, { recursive: true, force: true });
   }
 });
 

--- a/agent-context/test/build.test.mjs
+++ b/agent-context/test/build.test.mjs
@@ -22,6 +22,10 @@ test('builds all client variants from one canonical skill', async () => {
       path.join(outputRoot, 'claude', 'skills', 'mintlify', 'SKILL.md'),
       'utf8',
     );
+    const kiro = await readFile(
+      path.join(outputRoot, 'kiro', 'skills', 'mintlify', 'SKILL.md'),
+      'utf8',
+    );
     const codexMcp = JSON.parse(
       await readFile(path.join(outputRoot, 'codex', '.mcp.json'), 'utf8'),
     );
@@ -31,10 +35,19 @@ test('builds all client variants from one canonical skill', async () => {
     const claudeMcp = JSON.parse(
       await readFile(path.join(outputRoot, 'claude', '.mcp.json'), 'utf8'),
     );
+    const kiroMcp = JSON.parse(
+      await readFile(path.join(outputRoot, 'kiro', 'mcp.json'), 'utf8'),
+    );
+    const kiroManifest = JSON.parse(
+      await readFile(path.join(outputRoot, 'kiro', 'plugin.json'), 'utf8'),
+    );
 
     assert.equal(cursor, codex);
     assert.equal(claude, codex);
-    for (const skill of [codex, cursor, claude]) {
+    assert.equal(kiro.replaceAll('references/', 'reference/'), codex);
+    assert.match(kiro, /`references\/components\.md`/);
+    assert.doesNotMatch(kiro, /`reference\//);
+    for (const skill of [codex, cursor, claude, kiro]) {
       assert.match(skill, /Generated from mintlify\/docs\/agent-context/);
       assert.match(skill, /### Mintlify Search/);
       assert.match(skill, /### Mintlify Admin/);
@@ -44,12 +57,73 @@ test('builds all client variants from one canonical skill', async () => {
     }
     assert.deepEqual(codexMcp.mcp_servers, cursorMcp.mcpServers);
     assert.deepEqual(claudeMcp.mcpServers, cursorMcp.mcpServers);
+    assert.deepEqual(
+      Object.fromEntries(
+        Object.entries(kiroMcp.mcpServers).map(([name, server]) => [
+          name,
+          { ...server, type: 'http' },
+        ]),
+      ),
+      cursorMcp.mcpServers,
+    );
+    assert.ok(
+      Object.values(kiroMcp.mcpServers).every((server) => server.type === 'streamable-http'),
+    );
+    assert.equal(
+      kiroMcp.$schema,
+      'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json',
+    );
+    assert.equal(
+      kiroManifest.$schema,
+      'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+    );
+    assert.equal(kiroManifest.name, 'mintlify');
+    assert.ok(kiroManifest.keywords.includes('mintlify'));
     assert.deepEqual(Object.keys(cursorMcp.mcpServers), [
       'Mintlify Search',
       'Mintlify Admin',
     ]);
   } finally {
     await rm(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test('sync writes the complete Kiro power without changing target-owned files', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'mintlify-agent-context-kiro-sync-test-'));
+  const outputRoot = path.join(root, 'dist');
+  const destination = path.join(root, 'kiro-power');
+
+  try {
+    await mkdir(destination, { recursive: true });
+    await writeFile(path.join(destination, 'README.md'), 'target-owned\n');
+
+    await buildAll({ outputRoot, selectedIds: ['kiro'] });
+    await copyTargetToRepository('kiro', destination, outputRoot);
+
+    assert.equal(await readFile(path.join(destination, 'README.md'), 'utf8'), 'target-owned\n');
+    const manifest = JSON.parse(await readFile(path.join(destination, 'plugin.json'), 'utf8'));
+    const mcpConfig = JSON.parse(await readFile(path.join(destination, 'mcp.json'), 'utf8'));
+    assert.equal(manifest.name, 'mintlify');
+    assert.deepEqual(Object.keys(mcpConfig.mcpServers), [
+      'Mintlify Search',
+      'Mintlify Admin',
+    ]);
+    assert.match(
+      await readFile(path.join(destination, 'skills', 'mintlify', 'SKILL.md'), 'utf8'),
+      /### Mintlify Search/,
+    );
+    assert.match(
+      await readFile(
+        path.join(destination, 'skills', 'mintlify', 'references', 'components.md'),
+        'utf8',
+      ),
+      /# Components/,
+    );
+    await assert.rejects(
+      readFile(path.join(destination, 'skills', 'mintlify', 'reference', 'components.md')),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Documentation changes

Adds the generation pipeline for a [Kiro power](https://kiro.dev/docs/powers/create/).

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared build/sync pipeline and adds a new published target; risk is moderate due to scope and release semantics for Kiro manifest versioning, not security-sensitive code paths.
> 
> **Overview**
> Extends **agent-context** so the Mintlify skill and MCP config can be built and synced to **mintlify/kiro-power** alongside Codex, Cursor, and Claude.
> 
> The Kiro target uses Agent Plugins packaging: **`references/`** instead of **`reference/`** in the skill, **`mcp.json`** with **`$schema`** and **`streamable-http`** transport overrides, and a generated **`plugin.json`** from `targets/kiro.json`. Build and sync copy the manifest when present; the sync workflow commits **`plugin.json`** only for Kiro.
> 
> **AJV** validates generated MCP and plugin artifacts against vendored **Agent Plugins 1.0.0** schemas; invalid manifests or transports fail the build. CI and sync workflows run **`npm ci`** in `agent-context` (with **`package-lock.json`** tracked). Docs note bumping **`pluginManifest.version`** in SemVer when Kiro outputs change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1954d91b8576385569b94090e51909b641e455b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->