### PR TITLE
Clarify PostHog key safety

### DIFF
--- a/integrations/analytics/posthog.mdx
+++ b/integrations/analytics/posthog.mdx
@@ -36,7 +36,7 @@ You only need to include `apiHost` if you are self-hosting PostHog. By default, 
 <ParamField path="apiKey" type="string" required>
   Your PostHog project API key. Must start with `phc_`.
 
-  This key is a client-side token meant to be public—the same key your browser sends with every analytics event. It's safe to commit to your documentation repository.
+  This key is a client-side token meant to be public. It's the same key your browser sends with every analytics event. It's safe to commit to your documentation repository.
 </ParamField>
 
 <ParamField path="apiHost" type="string">

--- a/integrations/analytics/posthog.mdx
+++ b/integrations/analytics/posthog.mdx
@@ -35,6 +35,8 @@ You only need to include `apiHost` if you are self-hosting PostHog. By default, 
 
 <ParamField path="apiKey" type="string" required>
   Your PostHog project API key. Must start with `phc_`.
+
+  This key is a client-side token meant to be public—the same key your browser sends with every analytics event. It's safe to commit to your documentation repository.
 </ParamField>
 
 <ParamField path="apiHost" type="string">


### PR DESCRIPTION
## Documentation changes

Closes https://linear.app/mintlify/issue/DOC-415/clarify-posthog-integration-api-key-exposure-and-env-var-handling

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime, security, or data-handling code impact.
> 
> **Overview**
> Adds guidance under the **`apiKey`** configuration option explaining that PostHog project keys starting with `phc_` are **client-side, public tokens** (the same value sent from the browser with events) and that **committing them in a docs repo is acceptable**.
> 
> This is documentation-only and addresses confusion about treating the key like a secret or relying on env vars for docs configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcdbaa6e01c1f5fb55ccabe9e35314ebe6b2b0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->