### PR TITLE
Fix missing localized redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -4,6 +4,18 @@
       "destination": "/editor/branching-and-publishing"
     },
     {
+      "source": "/es/editor/drafts",
+      "destination": "/es/editor/branching-and-publishing"
+    },
+    {
+      "source": "/fr/editor/drafts",
+      "destination": "/fr/editor/branching-and-publishing"
+    },
+    {
+      "source": "/zh/editor/drafts",
+      "destination": "/zh/editor/branching-and-publishing"
+    },
+    {
       "source": "/agent/integrations",
       "destination": "/automations/integrations"
     },
@@ -24,16 +36,60 @@
       "destination": "/guides/devin-desktop"
     },
     {
+      "source": "/es/guides/windsurf",
+      "destination": "/es/guides/devin-desktop"
+    },
+    {
+      "source": "/fr/guides/windsurf",
+      "destination": "/fr/guides/devin-desktop"
+    },
+    {
+      "source": "/zh/guides/windsurf",
+      "destination": "/zh/guides/devin-desktop"
+    },
+    {
       "source": "/cli/analytics",
       "destination": "/cli/commands"
+    },
+    {
+      "source": "/es/cli/analytics",
+      "destination": "/es/cli/commands"
+    },
+    {
+      "source": "/fr/cli/analytics",
+      "destination": "/fr/cli/commands"
+    },
+    {
+      "source": "/zh/cli/analytics",
+      "destination": "/zh/cli/commands"
     },
     {
       "source": "/optimize/search-boost",
       "destination": "/optimize/search"
     },
     {
+      "source": "/es/optimize/search-boost",
+      "destination": "/es/optimize/search"
+    },
+    {
+      "source": "/fr/optimize/search-boost",
+      "destination": "/fr/optimize/search"
+    },
+    {
       "source": "/ai/assistant",
       "destination": "/assistant/index"
+    },
+    {
+      "source": "/es/ai/assistant",
+      "destination": "/es/assistant/index"
+    },
+    {
+      "source": "/fr/ai/assistant",
+      "destination": "/fr/assistant/index"
+    },
+    {
+      "source": "/zh/ai/assistant",
+      "destination": "/zh/assistant/index"
     },
     {
       "source": "/agent/linear",
@@ -54,6 +110,18 @@
     {
       "source": "/guides/support-center",
       "destination": "/guides/help-center"
+    },
+    {
+      "source": "/es/guides/support-center",
+      "destination": "/es/guides/help-center"
+    },
+    {
+      "source": "/fr/guides/support-center",
+      "destination": "/fr/guides/help-center"
+    },
+    {
+      "source": "/zh/guides/support-center",
+      "destination": "/zh/guides/help-center"
     },
     {
       "source": "/content/components/accordions",
@@ -132,8 +200,32 @@
       "destination": "/deploy/authentication-setup"
     },
     {
+      "source": "/es/authentication-personalization/*",
+      "destination": "/es/deploy/authentication-setup"
+    },
+    {
+      "source": "/fr/authentication-personalization/*",
+      "destination": "/fr/deploy/authentication-setup"
+    },
+    {
+      "source": "/zh/authentication-personalization/*",
+      "destination": "/zh/deploy/authentication-setup"
+    },
+    {
       "source": "/deploy/personalization-setup",
       "destination": "/create/personalization"
+    },
+    {
+      "source": "/es/deploy/personalization-setup",
+      "destination": "/es/create/personalization"
+    },
+    {
+      "source": "/fr/deploy/personalization-setup",
+      "destination": "/fr/create/personalization"
+    },
+    {
+      "source": "/zh/deploy/personalization-setup",
+      "destination": "/zh/create/personalization"
     },
     {
       "source": "/ai-ingestion",
@@ -152,12 +244,12 @@
       "destination": "/api/*"
     },
     {
-      "source": "/fr/api-reference/*",
-      "destination": "/fr/api/*"
-    },
-    {
       "source": "/es/api-reference/*",
       "destination": "/es/api/*"
+    },
+    {
+      "source": "/fr/api-reference/*",
+      "destination": "/fr/api/*"
     },
     {
       "source": "/zh/api-reference/*",
@@ -184,16 +276,64 @@
       "destination": "/editor/index"
     },
     {
+      "source": "/es/editor/getting-started",
+      "destination": "/es/editor/index"
+    },
+    {
+      "source": "/fr/editor/getting-started",
+      "destination": "/fr/editor/index"
+    },
+    {
+      "source": "/zh/editor/getting-started",
+      "destination": "/zh/editor/index"
+    },
+    {
       "source": "/editor/content-management",
       "destination": "/editor/index"
+    },
+    {
+      "source": "/es/editor/content-management",
+      "destination": "/es/editor/index"
+    },
+    {
+      "source": "/fr/editor/content-management",
+      "destination": "/fr/editor/index"
+    },
+    {
+      "source": "/zh/editor/content-management",
+      "destination": "/zh/editor/index"
     },
     {
       "source": "/editor/publishing",
       "destination": "/editor/branching-and-publishing"
     },
     {
+      "source": "/es/editor/publishing",
+      "destination": "/es/editor/branching-and-publishing"
+    },
+    {
+      "source": "/fr/editor/publishing",
+      "destination": "/fr/editor/branching-and-publishing"
+    },
+    {
+      "source": "/zh/editor/publishing",
+      "destination": "/zh/editor/branching-and-publishing"
+    },
+    {
       "source": "/editor/troubleshooting",
       "destination": "/editor/index"
+    },
+    {
+      "source": "/es/editor/troubleshooting",
+      "destination": "/es/editor/index"
+    },
+    {
+      "source": "/fr/editor/troubleshooting",
+      "destination": "/fr/editor/index"
+    },
+    {
+      "source": "/zh/editor/troubleshooting",
+      "destination": "/zh/editor/index"
     },
     {
       "source": "/guides/analytics",
@@ -204,6 +344,18 @@
       "destination": "/analytics"
     },
     {
+      "source": "/es/optimize/analytics",
+      "destination": "/es/analytics"
+    },
+    {
+      "source": "/fr/optimize/analytics",
+      "destination": "/fr/analytics"
+    },
+    {
+      "source": "/zh/optimize/analytics",
+      "destination": "/zh/analytics"
+    },
+    {
       "source": "/optimize/analytics/*",
       "destination": "/analytics/*"
     },
@@ -212,192 +364,768 @@
       "destination": "/assistant/index"
     },
     {
+      "source": "/es/guides/assistant",
+      "destination": "/es/assistant/index"
+    },
+    {
+      "source": "/fr/guides/assistant",
+      "destination": "/fr/assistant/index"
+    },
+    {
+      "source": "/zh/guides/assistant",
+      "destination": "/zh/assistant/index"
+    },
+    {
       "source": "/api-playground/customization/adding-sdk-examples",
       "destination": "/api-playground/adding-sdk-examples"
+    },
+    {
+      "source": "/es/api-playground/customization/adding-sdk-examples",
+      "destination": "/es/api-playground/adding-sdk-examples"
+    },
+    {
+      "source": "/fr/api-playground/customization/adding-sdk-examples",
+      "destination": "/fr/api-playground/adding-sdk-examples"
+    },
+    {
+      "source": "/zh/api-playground/customization/adding-sdk-examples",
+      "destination": "/zh/api-playground/adding-sdk-examples"
     },
     {
       "source": "/api-playground/customization/complex-data-types",
       "destination": "/api-playground/complex-data-types"
     },
     {
+      "source": "/es/api-playground/customization/complex-data-types",
+      "destination": "/es/api-playground/complex-data-types"
+    },
+    {
+      "source": "/fr/api-playground/customization/complex-data-types",
+      "destination": "/fr/api-playground/complex-data-types"
+    },
+    {
+      "source": "/zh/api-playground/customization/complex-data-types",
+      "destination": "/zh/api-playground/complex-data-types"
+    },
+    {
       "source": "/api-playground/customization/managing-page-visibility",
       "destination": "/api-playground/managing-page-visibility"
+    },
+    {
+      "source": "/es/api-playground/customization/managing-page-visibility",
+      "destination": "/es/api-playground/managing-page-visibility"
+    },
+    {
+      "source": "/fr/api-playground/customization/managing-page-visibility",
+      "destination": "/fr/api-playground/managing-page-visibility"
+    },
+    {
+      "source": "/zh/api-playground/customization/managing-page-visibility",
+      "destination": "/zh/api-playground/managing-page-visibility"
     },
     {
       "source": "/api-playground/customization/multiple-responses",
       "destination": "/api-playground/multiple-responses"
     },
     {
+      "source": "/es/api-playground/customization/multiple-responses",
+      "destination": "/es/api-playground/multiple-responses"
+    },
+    {
+      "source": "/fr/api-playground/customization/multiple-responses",
+      "destination": "/fr/api-playground/multiple-responses"
+    },
+    {
+      "source": "/zh/api-playground/customization/multiple-responses",
+      "destination": "/zh/api-playground/multiple-responses"
+    },
+    {
       "source": "/settings/broken-links",
       "destination": "/create/redirects"
+    },
+    {
+      "source": "/es/settings/broken-links",
+      "destination": "/es/create/redirects"
+    },
+    {
+      "source": "/fr/settings/broken-links",
+      "destination": "/fr/create/redirects"
+    },
+    {
+      "source": "/zh/settings/broken-links",
+      "destination": "/zh/create/redirects"
     },
     {
       "source": "/guides/changelogs",
       "destination": "/create/changelogs"
     },
     {
+      "source": "/es/guides/changelogs",
+      "destination": "/es/create/changelogs"
+    },
+    {
+      "source": "/fr/guides/changelogs",
+      "destination": "/fr/create/changelogs"
+    },
+    {
+      "source": "/zh/guides/changelogs",
+      "destination": "/zh/create/changelogs"
+    },
+    {
       "source": "/code",
       "destination": "/create/code"
+    },
+    {
+      "source": "/es/code",
+      "destination": "/es/create/code"
+    },
+    {
+      "source": "/fr/code",
+      "destination": "/fr/create/code"
+    },
+    {
+      "source": "/zh/code",
+      "destination": "/zh/create/code"
     },
     {
       "source": "/components/files",
       "destination": "/create/files"
     },
     {
+      "source": "/es/components/files",
+      "destination": "/es/create/files"
+    },
+    {
+      "source": "/fr/components/files",
+      "destination": "/fr/create/files"
+    },
+    {
+      "source": "/zh/components/files",
+      "destination": "/zh/create/files"
+    },
+    {
       "source": "/image-embeds",
       "destination": "/create/image-embeds"
+    },
+    {
+      "source": "/es/image-embeds",
+      "destination": "/es/create/image-embeds"
+    },
+    {
+      "source": "/fr/image-embeds",
+      "destination": "/fr/create/image-embeds"
+    },
+    {
+      "source": "/zh/image-embeds",
+      "destination": "/zh/create/image-embeds"
     },
     {
       "source": "/list-table",
       "destination": "/create/list-table"
     },
     {
+      "source": "/es/list-table",
+      "destination": "/es/create/list-table"
+    },
+    {
+      "source": "/fr/list-table",
+      "destination": "/fr/create/list-table"
+    },
+    {
+      "source": "/zh/list-table",
+      "destination": "/zh/create/list-table"
+    },
+    {
       "source": "/reusable-snippets",
       "destination": "/create/reusable-snippets"
+    },
+    {
+      "source": "/es/reusable-snippets",
+      "destination": "/es/create/reusable-snippets"
+    },
+    {
+      "source": "/fr/reusable-snippets",
+      "destination": "/fr/create/reusable-snippets"
+    },
+    {
+      "source": "/zh/reusable-snippets",
+      "destination": "/zh/create/reusable-snippets"
     },
     {
       "source": "/text",
       "destination": "/create/text"
     },
     {
+      "source": "/es/text",
+      "destination": "/es/create/text"
+    },
+    {
+      "source": "/fr/text",
+      "destination": "/fr/create/text"
+    },
+    {
+      "source": "/zh/text",
+      "destination": "/zh/create/text"
+    },
+    {
       "source": "/settings/custom-404-page",
       "destination": "/customize/custom-404-page"
+    },
+    {
+      "source": "/es/settings/custom-404-page",
+      "destination": "/es/customize/custom-404-page"
+    },
+    {
+      "source": "/fr/settings/custom-404-page",
+      "destination": "/fr/customize/custom-404-page"
+    },
+    {
+      "source": "/zh/settings/custom-404-page",
+      "destination": "/zh/customize/custom-404-page"
     },
     {
       "source": "/settings/custom-domain",
       "destination": "/customize/custom-domain"
     },
     {
+      "source": "/es/settings/custom-domain",
+      "destination": "/es/customize/custom-domain"
+    },
+    {
+      "source": "/fr/settings/custom-domain",
+      "destination": "/fr/customize/custom-domain"
+    },
+    {
+      "source": "/zh/settings/custom-domain",
+      "destination": "/zh/customize/custom-domain"
+    },
+    {
       "source": "/settings/custom-scripts",
       "destination": "/customize/custom-scripts"
+    },
+    {
+      "source": "/es/settings/custom-scripts",
+      "destination": "/es/customize/custom-scripts"
+    },
+    {
+      "source": "/fr/settings/custom-scripts",
+      "destination": "/fr/customize/custom-scripts"
+    },
+    {
+      "source": "/zh/settings/custom-scripts",
+      "destination": "/zh/customize/custom-scripts"
     },
     {
       "source": "/react-components",
       "destination": "/customize/react-components"
     },
     {
+      "source": "/es/react-components",
+      "destination": "/es/customize/react-components"
+    },
+    {
+      "source": "/fr/react-components",
+      "destination": "/fr/customize/react-components"
+    },
+    {
+      "source": "/zh/react-components",
+      "destination": "/zh/customize/react-components"
+    },
+    {
       "source": "/themes",
       "destination": "/customize/themes"
+    },
+    {
+      "source": "/es/themes",
+      "destination": "/es/customize/themes"
+    },
+    {
+      "source": "/fr/themes",
+      "destination": "/fr/customize/themes"
+    },
+    {
+      "source": "/zh/themes",
+      "destination": "/zh/customize/themes"
     },
     {
       "source": "/advanced/dashboard/permissions",
       "destination": "/dashboard/permissions"
     },
     {
+      "source": "/es/advanced/dashboard/permissions",
+      "destination": "/es/dashboard/permissions"
+    },
+    {
+      "source": "/fr/advanced/dashboard/permissions",
+      "destination": "/fr/dashboard/permissions"
+    },
+    {
+      "source": "/zh/advanced/dashboard/permissions",
+      "destination": "/zh/dashboard/permissions"
+    },
+    {
       "source": "/advanced/dashboard/roles",
       "destination": "/dashboard/roles"
+    },
+    {
+      "source": "/es/advanced/dashboard/roles",
+      "destination": "/es/dashboard/roles"
+    },
+    {
+      "source": "/fr/advanced/dashboard/roles",
+      "destination": "/fr/dashboard/roles"
+    },
+    {
+      "source": "/zh/advanced/dashboard/roles",
+      "destination": "/zh/dashboard/roles"
     },
     {
       "source": "/advanced/dashboard/sso",
       "destination": "/dashboard/sso"
     },
     {
+      "source": "/es/advanced/dashboard/sso",
+      "destination": "/es/dashboard/sso"
+    },
+    {
+      "source": "/fr/advanced/dashboard/sso",
+      "destination": "/fr/dashboard/sso"
+    },
+    {
+      "source": "/zh/advanced/dashboard/sso",
+      "destination": "/zh/dashboard/sso"
+    },
+    {
       "source": "/settings/ci",
       "destination": "/deploy/ci"
+    },
+    {
+      "source": "/es/settings/ci",
+      "destination": "/es/deploy/ci"
+    },
+    {
+      "source": "/fr/settings/ci",
+      "destination": "/fr/deploy/ci"
+    },
+    {
+      "source": "/zh/settings/ci",
+      "destination": "/zh/deploy/ci"
     },
     {
       "source": "/advanced/subpath/cloudflare",
       "destination": "/deploy/cloudflare"
     },
     {
+      "source": "/es/advanced/subpath/cloudflare",
+      "destination": "/es/deploy/cloudflare"
+    },
+    {
+      "source": "/fr/advanced/subpath/cloudflare",
+      "destination": "/fr/deploy/cloudflare"
+    },
+    {
+      "source": "/zh/advanced/subpath/cloudflare",
+      "destination": "/zh/deploy/cloudflare"
+    },
+    {
       "source": "/guides/csp-configuration",
       "destination": "/deploy/csp-configuration"
+    },
+    {
+      "source": "/es/guides/csp-configuration",
+      "destination": "/es/deploy/csp-configuration"
+    },
+    {
+      "source": "/fr/guides/csp-configuration",
+      "destination": "/fr/deploy/csp-configuration"
+    },
+    {
+      "source": "/zh/guides/csp-configuration",
+      "destination": "/zh/deploy/csp-configuration"
     },
     {
       "source": "/guides/deployments",
       "destination": "/deploy/deployments"
     },
     {
+      "source": "/es/guides/deployments",
+      "destination": "/es/deploy/deployments"
+    },
+    {
+      "source": "/fr/guides/deployments",
+      "destination": "/fr/deploy/deployments"
+    },
+    {
+      "source": "/zh/guides/deployments",
+      "destination": "/zh/deploy/deployments"
+    },
+    {
       "source": "/settings/github",
       "destination": "/deploy/github"
+    },
+    {
+      "source": "/es/settings/github",
+      "destination": "/es/deploy/github"
+    },
+    {
+      "source": "/fr/settings/github",
+      "destination": "/fr/deploy/github"
+    },
+    {
+      "source": "/zh/settings/github",
+      "destination": "/zh/deploy/github"
     },
     {
       "source": "/settings/gitlab",
       "destination": "/deploy/gitlab"
     },
     {
+      "source": "/es/settings/gitlab",
+      "destination": "/es/deploy/gitlab"
+    },
+    {
+      "source": "/fr/settings/gitlab",
+      "destination": "/fr/deploy/gitlab"
+    },
+    {
+      "source": "/zh/settings/gitlab",
+      "destination": "/zh/deploy/gitlab"
+    },
+    {
       "source": "/guides/monorepo",
       "destination": "/deploy/monorepo"
+    },
+    {
+      "source": "/es/guides/monorepo",
+      "destination": "/es/deploy/monorepo"
+    },
+    {
+      "source": "/fr/guides/monorepo",
+      "destination": "/fr/deploy/monorepo"
+    },
+    {
+      "source": "/zh/guides/monorepo",
+      "destination": "/zh/deploy/monorepo"
     },
     {
       "source": "/settings/preview-deployments",
       "destination": "/deploy/preview-deployments"
     },
     {
+      "source": "/es/settings/preview-deployments",
+      "destination": "/es/deploy/preview-deployments"
+    },
+    {
+      "source": "/fr/settings/preview-deployments",
+      "destination": "/fr/deploy/preview-deployments"
+    },
+    {
+      "source": "/zh/settings/preview-deployments",
+      "destination": "/zh/deploy/preview-deployments"
+    },
+    {
       "source": "/guides/reverse-proxy",
       "destination": "/deploy/reverse-proxy"
+    },
+    {
+      "source": "/es/guides/reverse-proxy",
+      "destination": "/es/deploy/reverse-proxy"
+    },
+    {
+      "source": "/fr/guides/reverse-proxy",
+      "destination": "/fr/deploy/reverse-proxy"
+    },
+    {
+      "source": "/zh/guides/reverse-proxy",
+      "destination": "/zh/deploy/reverse-proxy"
     },
     {
       "source": "/advanced/subpath/route53-cloudfront",
       "destination": "/deploy/route53-cloudfront"
     },
     {
+      "source": "/es/advanced/subpath/route53-cloudfront",
+      "destination": "/es/deploy/route53-cloudfront"
+    },
+    {
+      "source": "/fr/advanced/subpath/route53-cloudfront",
+      "destination": "/fr/deploy/route53-cloudfront"
+    },
+    {
+      "source": "/zh/advanced/subpath/route53-cloudfront",
+      "destination": "/zh/deploy/route53-cloudfront"
+    },
+    {
       "source": "/advanced/subpath/vercel",
       "destination": "/deploy/vercel"
+    },
+    {
+      "source": "/es/advanced/subpath/vercel",
+      "destination": "/es/deploy/vercel"
+    },
+    {
+      "source": "/fr/advanced/subpath/vercel",
+      "destination": "/fr/deploy/vercel"
+    },
+    {
+      "source": "/zh/advanced/subpath/vercel",
+      "destination": "/zh/deploy/vercel"
     },
     {
       "source": "/editor/branches",
       "destination": "/guides/branches"
     },
     {
+      "source": "/es/editor/branches",
+      "destination": "/es/guides/branches"
+    },
+    {
+      "source": "/fr/editor/branches",
+      "destination": "/fr/guides/branches"
+    },
+    {
+      "source": "/zh/editor/branches",
+      "destination": "/zh/guides/branches"
+    },
+    {
       "source": "/editor/git-concepts",
       "destination": "/guides/git-concepts"
+    },
+    {
+      "source": "/es/editor/git-concepts",
+      "destination": "/es/guides/git-concepts"
+    },
+    {
+      "source": "/fr/editor/git-concepts",
+      "destination": "/fr/guides/git-concepts"
+    },
+    {
+      "source": "/zh/editor/git-concepts",
+      "destination": "/zh/guides/git-concepts"
     },
     {
       "source": "/analytics/improving-docs",
       "destination": "/guides/improving-docs"
     },
     {
+      "source": "/es/analytics/improving-docs",
+      "destination": "/es/guides/improving-docs"
+    },
+    {
+      "source": "/fr/analytics/improving-docs",
+      "destination": "/fr/guides/improving-docs"
+    },
+    {
+      "source": "/zh/analytics/improving-docs",
+      "destination": "/zh/guides/improving-docs"
+    },
+    {
       "source": "/api-playground/migrating-from-mdx",
       "destination": "/guides/migrating-from-mdx"
+    },
+    {
+      "source": "/es/api-playground/migrating-from-mdx",
+      "destination": "/es/guides/migrating-from-mdx"
+    },
+    {
+      "source": "/fr/api-playground/migrating-from-mdx",
+      "destination": "/fr/guides/migrating-from-mdx"
+    },
+    {
+      "source": "/zh/api-playground/migrating-from-mdx",
+      "destination": "/zh/guides/migrating-from-mdx"
     },
     {
       "source": "/guides/migration",
       "destination": "/migration"
     },
     {
+      "source": "/es/guides/migration",
+      "destination": "/es/migration"
+    },
+    {
+      "source": "/fr/guides/migration",
+      "destination": "/fr/migration"
+    },
+    {
+      "source": "/zh/guides/migration",
+      "destination": "/zh/migration"
+    },
+    {
       "source": "/settings/seo",
       "destination": "/optimize/seo"
+    },
+    {
+      "source": "/es/settings/seo",
+      "destination": "/es/optimize/seo"
+    },
+    {
+      "source": "/fr/settings/seo",
+      "destination": "/fr/optimize/seo"
+    },
+    {
+      "source": "/zh/settings/seo",
+      "destination": "/zh/optimize/seo"
     },
     {
       "source": "/guides/hidden-page-example",
       "destination": "/organize/hidden-page-example"
     },
     {
+      "source": "/es/guides/hidden-page-example",
+      "destination": "/es/organize/hidden-page-example"
+    },
+    {
+      "source": "/fr/guides/hidden-page-example",
+      "destination": "/fr/organize/hidden-page-example"
+    },
+    {
+      "source": "/zh/guides/hidden-page-example",
+      "destination": "/zh/organize/hidden-page-example"
+    },
+    {
       "source": "/guides/hidden-pages",
       "destination": "/organize/hidden-pages"
+    },
+    {
+      "source": "/es/guides/hidden-pages",
+      "destination": "/es/organize/hidden-pages"
+    },
+    {
+      "source": "/fr/guides/hidden-pages",
+      "destination": "/fr/organize/hidden-pages"
+    },
+    {
+      "source": "/zh/guides/hidden-pages",
+      "destination": "/zh/organize/hidden-pages"
     },
     {
       "source": "/navigation",
       "destination": "/organize/navigation"
     },
     {
+      "source": "/es/navigation",
+      "destination": "/es/organize/navigation"
+    },
+    {
+      "source": "/fr/navigation",
+      "destination": "/fr/organize/navigation"
+    },
+    {
+      "source": "/zh/navigation",
+      "destination": "/zh/organize/navigation"
+    },
+    {
       "source": "/pages",
       "destination": "/organize/pages"
+    },
+    {
+      "source": "/es/pages",
+      "destination": "/es/organize/pages"
+    },
+    {
+      "source": "/fr/pages",
+      "destination": "/fr/organize/pages"
+    },
+    {
+      "source": "/zh/pages",
+      "destination": "/zh/organize/pages"
     },
     {
       "source": "/settings",
       "destination": "/organize/settings"
     },
     {
+      "source": "/es/settings",
+      "destination": "/es/organize/settings"
+    },
+    {
+      "source": "/fr/settings",
+      "destination": "/fr/organize/settings"
+    },
+    {
+      "source": "/zh/settings",
+      "destination": "/zh/organize/settings"
+    },
+    {
       "source": "/api-playground/mdx/:slug*",
       "destination": "/api-playground/mdx-setup"
+    },
+    {
+      "source": "/es/api-playground/mdx/:slug*",
+      "destination": "/es/api-playground/mdx-setup"
+    },
+    {
+      "source": "/fr/api-playground/mdx/:slug*",
+      "destination": "/fr/api-playground/mdx-setup"
+    },
+    {
+      "source": "/zh/api-playground/mdx/:slug*",
+      "destination": "/zh/api-playground/mdx-setup"
     },
     {
       "source": "/api-playground/asyncapi/setup",
       "destination": "/api-playground/asyncapi-setup"
     },
     {
+      "source": "/es/api-playground/asyncapi/setup",
+      "destination": "/es/api-playground/asyncapi-setup"
+    },
+    {
+      "source": "/fr/api-playground/asyncapi/setup",
+      "destination": "/fr/api-playground/asyncapi-setup"
+    },
+    {
+      "source": "/zh/api-playground/asyncapi/setup",
+      "destination": "/zh/api-playground/asyncapi-setup"
+    },
+    {
       "source": "/create/broken-links",
       "destination": "/create/redirects"
+    },
+    {
+      "source": "/es/create/broken-links",
+      "destination": "/es/create/redirects"
+    },
+    {
+      "source": "/fr/create/broken-links",
+      "destination": "/fr/create/redirects"
+    },
+    {
+      "source": "/zh/create/broken-links",
+      "destination": "/zh/create/redirects"
     },
     {
       "source": "/ai/autopilot",
       "destination": "/automations/index"
     },
     {
+      "source": "/es/ai/autopilot",
+      "destination": "/es/automations/index"
+    },
+    {
+      "source": "/fr/ai/autopilot",
+      "destination": "/fr/automations/index"
+    },
+    {
+      "source": "/zh/ai/autopilot",
+      "destination": "/zh/automations/index"
+    },
+    {
       "source": "/ai/slack-app",
       "destination": "/ai/slack-bot"
+    },
+    {
+      "source": "/es/ai/slack-app",
+      "destination": "/es/ai/slack-bot"
+    },
+    {
+      "source": "/fr/ai/slack-app",
+      "destination": "/fr/ai/slack-bot"
+    },
+    {
+      "source": "/zh/ai/slack-app",
+      "destination": "/zh/ai/slack-bot"
     },
     {
       "source": "/changelog/overview",
@@ -408,20 +1136,80 @@
       "destination": "/agent/index"
     },
     {
+      "source": "/es/ai/agent",
+      "destination": "/es/agent/index"
+    },
+    {
+      "source": "/fr/ai/agent",
+      "destination": "/fr/agent/index"
+    },
+    {
+      "source": "/zh/ai/agent",
+      "destination": "/zh/agent/index"
+    },
+    {
       "source": "/ai/suggestions",
       "destination": "/automations/index"
+    },
+    {
+      "source": "/es/ai/suggestions",
+      "destination": "/es/automations/index"
+    },
+    {
+      "source": "/fr/ai/suggestions",
+      "destination": "/fr/automations/index"
+    },
+    {
+      "source": "/zh/ai/suggestions",
+      "destination": "/zh/automations/index"
     },
     {
       "source": "/insights/overview",
       "destination": "/analytics"
     },
     {
+      "source": "/es/insights/overview",
+      "destination": "/es/analytics"
+    },
+    {
+      "source": "/fr/insights/overview",
+      "destination": "/fr/analytics"
+    },
+    {
+      "source": "/zh/insights/overview",
+      "destination": "/zh/analytics"
+    },
+    {
       "source": "/insights/feedback",
       "destination": "/optimize/feedback"
     },
     {
+      "source": "/es/insights/feedback",
+      "destination": "/es/optimize/feedback"
+    },
+    {
+      "source": "/fr/insights/feedback",
+      "destination": "/fr/optimize/feedback"
+    },
+    {
+      "source": "/zh/insights/feedback",
+      "destination": "/zh/optimize/feedback"
+    },
+    {
       "source": "/migration-services/custom",
       "destination": "/migration-services/enterprise"
+    },
+    {
+      "source": "/es/migration-services/custom",
+      "destination": "/es/migration-services/enterprise"
+    },
+    {
+      "source": "/fr/migration-services/custom",
+      "destination": "/fr/migration-services/enterprise"
+    },
+    {
+      "source": "/zh/migration-services/custom",
+      "destination": "/zh/migration-services/enterprise"
     },
     {
       "source": "/migration-services/pro",
@@ -444,6 +1232,18 @@
       "destination": "/automations/index"
     },
     {
+      "source": "/es/agent/suggestions",
+      "destination": "/es/automations/index"
+    },
+    {
+      "source": "/fr/agent/suggestions",
+      "destination": "/fr/automations/index"
+    },
+    {
+      "source": "/zh/agent/suggestions",
+      "destination": "/zh/automations/index"
+    },
+    {
       "source": "/agent/workflows",
       "destination": "/automations/index"
     },
@@ -456,8 +1256,32 @@
       "destination": "/agent/index"
     },
     {
+      "source": "/es/agent/quickstart",
+      "destination": "/es/agent/index"
+    },
+    {
+      "source": "/fr/agent/quickstart",
+      "destination": "/fr/agent/index"
+    },
+    {
+      "source": "/zh/agent/quickstart",
+      "destination": "/zh/agent/index"
+    },
+    {
       "source": "/installation",
       "destination": "/cli/install"
+    },
+    {
+      "source": "/es/installation",
+      "destination": "/es/cli/install"
+    },
+    {
+      "source": "/fr/installation",
+      "destination": "/fr/cli/install"
+    },
+    {
+      "source": "/zh/installation",
+      "destination": "/zh/cli/install"
     },
     {
       "source": "/settings/global",
@@ -476,23 +1300,71 @@
       "destination": "/automations/manage"
     },
     {
+      "source": "/es/workflows/enable",
+      "destination": "/es/automations/manage"
+    },
+    {
+      "source": "/fr/workflows/enable",
+      "destination": "/fr/automations/manage"
+    },
+    {
       "source": "/workflows/index",
       "destination": "/automations/index"
+    },
+    {
+      "source": "/es/workflows/index",
+      "destination": "/es/automations/index"
+    },
+    {
+      "source": "/fr/workflows/index",
+      "destination": "/fr/automations/index"
     },
     {
       "source": "/workflows/reference",
       "destination": "/automations/reference"
     },
     {
+      "source": "/es/workflows/reference",
+      "destination": "/es/automations/reference"
+    },
+    {
+      "source": "/fr/workflows/reference",
+      "destination": "/fr/automations/reference"
+    },
+    {
       "source": "/workflows/manage",
       "destination": "/automations/manage"
+    },
+    {
+      "source": "/es/workflows/manage",
+      "destination": "/es/automations/manage"
+    },
+    {
+      "source": "/fr/workflows/manage",
+      "destination": "/fr/automations/manage"
     },
     {
       "source": "/workflows/create",
       "destination": "/automations/create"
     },
     {
+      "source": "/es/workflows/create",
+      "destination": "/es/automations/create"
+    },
+    {
+      "source": "/fr/workflows/create",
+      "destination": "/fr/automations/create"
+    },
+    {
       "source": "/guides/use-workflows",
       "destination": "/guides/use-automations"
+    },
+    {
+      "source": "/es/guides/use-workflows",
+      "destination": "/es/guides/use-automations"
+    },
+    {
+      "source": "/fr/guides/use-workflows",
+      "destination": "/fr/guides/use-automations"
     }
-  ]
+]


### PR DESCRIPTION
## Summary

- follow up on the Bugbot finding from #6947 by redirecting the deleted Spanish, French, and Chinese analytics URLs
- audit redirect history and add every missing locale redirect where the translated source previously existed, the source is now gone, and the translated destination exists
- group each English redirect with its Spanish, French, and Chinese variants while preserving the existing English redirect order and wildcard precedence

This adds 218 locale mappings: 75 Spanish, 75 French, and 68 Chinese. All 124 pre-existing redirects remain unchanged.

## Validation

- mint broken-links
- redirects.json parses as valid JSON
- zero duplicate redirect sources
- zero redirect cycles
- zero historically verified missing locale redirects remain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only redirect additions with no application logic changes; main risk is a wrong source/destination pair causing 404s or bad hops for localized traffic.
> 
> **Overview**
> Adds **218 locale-specific redirect rules** in `redirects.json` so Spanish (`/es`), French (`/fr`), and Chinese (`/zh`) URLs follow the same path moves as English when old translated pages are gone but the new destinations exist.
> 
> Each affected English rule is now grouped with its locale variants (same source/destination pattern under the locale prefix), including wildcards such as `authentication-personalization/*` and `api-reference/*`. Existing English sources and order are unchanged aside from regrouping; the French `api-reference/*` entry is only reordered next to the other locale API redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec70afc9e96fbffef93ed798e54cec7d310e649d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->