### PR TITLE
[fix] show "on this page" TOC on widget page

### DIFF
--- a/assistant/widget.mdx
+++ b/assistant/widget.mdx
@@ -3,7 +3,6 @@ title: "Widget"
 sidebarTitle: "Widget"
 description: "Install and configure the Mintlify widget to embed an AI assistant trained on your content into any website, web app, or dashboard."
 keywords: ["assistant", "chat", "embed"]
-mode: "wide"
 tag: "New"
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only frontmatter change that only affects page layout; no product or security impact.
> 
> **Overview**
> Removes `mode: "wide"` from the `assistant/widget.mdx` frontmatter so the **"on this page"** table of contents shows again.
> 
> Wide mode was hiding the TOC for extra horizontal space; the page now uses the default layout with sidebar TOC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bbfefbee816bdd2a33b1dfbd06afc89b94776cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->