### PR TITLE
Document lastUpdatedDate frontmatter for the last modified timestamp

### DIFF
--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -247,16 +247,16 @@ Show a "Last modified on [date]" timestamp on all pages by enabling `metadata.ti
 
 The displayed date is determined in the following order:
 
-1. The `lastUpdatedDate` frontmatter field, if set on the page.
+1. The `lastUpdated` frontmatter field, if set on the page.
 2. For deployments backed by GitHub or GitLab, the date of the last Git commit that modified the page's source file.
 3. The most recent deployment timestamp.
 
-To display a specific date instead of the Git commit date, set the `lastUpdatedDate` frontmatter field. Use this field when your Git history doesn't reflect when the content changed, such as content imported or synced from another system.
+To display a specific date instead of the Git commit date, set the `lastUpdated` frontmatter field. Use this field when your Git history doesn't reflect when the content changed, such as content imported or synced from another system.
 
 ```yaml
 ---
 title: "Page title"
-lastUpdatedDate: "2026-08-13"
+lastUpdated: "2026-08-13"
 ---
 ```
 

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -247,16 +247,16 @@ Show a "Last modified on [date]" timestamp on all pages by enabling `metadata.ti
 
 The displayed date is determined in the following order:
 
-1. The `lastUpdated` frontmatter field, if set on the page.
+1. The `lastUpdatedDate` frontmatter field, if set on the page.
 2. For deployments backed by GitHub or GitLab, the date of the last Git commit that modified the page's source file.
 3. The most recent deployment timestamp.
 
-To display a specific date instead of the Git commit date, set the `lastUpdated` frontmatter field. Use this field when your Git history doesn't reflect when the content changed, such as content imported or synced from another system.
+To display a specific date instead of the Git commit date, set the `lastUpdatedDate` frontmatter field. Use this field when your Git history doesn't reflect when the content changed, such as content imported or synced from another system.
 
 ```yaml
 ---
 title: "Page title"
-lastUpdated: "2026-08-13"
+lastUpdatedDate: "2026-08-13"
 ---
 ```
 

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -245,7 +245,20 @@ Show a "Last modified on [date]" timestamp on all pages by enabling `metadata.ti
 }
 ```
 
-For deployments backed by GitHub or GitLab, the displayed date is the date of the last Git commit that modified the page's source file. If a Git commit date isn't available, the date falls back to the most recent deployment timestamp.
+The displayed date is determined in the following order:
+
+1. The `lastUpdatedDate` frontmatter field, if set on the page.
+2. For deployments backed by GitHub or GitLab, the date of the last Git commit that modified the page's source file.
+3. The most recent deployment timestamp.
+
+To display a specific date instead of the Git commit date, set the `lastUpdatedDate` frontmatter field. Use this field when your Git history doesn't reflect when the content changed, such as content imported or synced from another system.
+
+```yaml
+---
+title: "Page title"
+lastUpdatedDate: "2026-08-13"
+---
+```
 
 To override the global timestamp setting for an individual page, use the `timestamp` frontmatter field. Use this field to show or hide timestamps on specific pages.
 


### PR DESCRIPTION
Documents the date precedence for the "Last modified on" timestamp, added in mintlify/mint#10133: the `lastUpdatedDate` frontmatter field takes priority over the Git commit date, with the deployment timestamp as the final fallback.

Adds a frontmatter example for overriding the displayed date, for content imported or synced from another system where Git history doesn't reflect real update dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the pages guide; no product code or runtime behavior is modified in this repo.
> 
> **Overview**
> Updates the **Last modified timestamp** section in `organize/pages.mdx` to spell out how the displayed date is chosen: **`lastUpdatedDate` frontmatter** first, then Git commit date for GitHub/GitLab-backed deployments, then the latest deployment timestamp.
> 
> Adds guidance and a YAML example for setting **`lastUpdatedDate`** when Git history does not match real content updates (e.g. imported or synced content).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b06251af5881bd6539c51ea49540720d64ca65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->