### PR TITLE
Remove object form frontmatter example from SDK reference setup

### DIFF
--- a/api-playground/sdk-reference-setup.mdx
+++ b/api-playground/sdk-reference-setup.mdx
@@ -120,11 +120,9 @@ Add the page to your `docs.json` navigation like any other page. Mintlify only b
 
 Once a tab or group with `sdk` contains a page with `sdk` frontmatter, Mintlify stops auto-populating that tab or group and shows only the pages you wrote. Move the page out of the tab or group if you want the rest of the library to auto-populate.
 
-Point `sdk` at a symbol in one of two ways:
+Point `sdk` at a symbol:
 
-<CodeGroup>
-
-```mdx String form
+```mdx
 ---
 title: "Client"
 sdk: "class Client"
@@ -133,21 +131,7 @@ sdk: "class Client"
 Create a `Client` to call the API.
 ```
 
-```mdx Object form
----
-title: "getUser"
-sdk:
-  kind: method
-  name: getUser
-  parent: Client
----
-
-Fetch a user by ID.
-```
-
-</CodeGroup>
-
-The string form follows the pattern `[source] kind name`. If you leave out `source`, the page inherits it from the tab or group `sdk` config. The string form always inherits `format`, so it only works on pages under a tab or group with `sdk`. Use the object form everywhere else. For methods and properties, include the parent name, such as `method Client.getUser`.
+The string form follows the pattern `[source] kind name`. If you leave out `source`, the page inherits it from the tab or group `sdk` config. The string form always inherits `format`, so it only works on pages under a tab or group with `sdk`. Everywhere else, set `sdk` to an object with the fields below. For methods and properties, include the parent name, such as `method Client.getUser`.
 
 If you leave out `title` or `description`, Mintlify uses the title and description generated for the symbol.
 


### PR DESCRIPTION
## Summary

- Removes the object form `sdk` frontmatter example from the "Customize a page for a single symbol" section, leaving the string form as a plain code block instead of a CodeGroup
- Rewords the surrounding prose so the object form fields below still have context

Notably, this PR removes the object frontmatter example but preserves language referring to that option, which is displayed under the code example above the supported fields for that syntax are also mentioned:
> Everywhere else, set `sdk` to an object with the fields below.

**Screenshot ↓** (click to open/expand)

<table>
  <tbody>
    <tr>
      <td><img width="auto" height="1000" alt="" src="https://github.com/user-attachments/assets/91894718-4f9c-4de6-9e3f-08277b8d9768" /></td>
    </tr>
  </tbody>
</table>

## Test plan

- [x] Preview the page and confirm the string form example renders as a standalone code block
- [x] Confirm the `ParamField` list still reads coherently without the object form example