### PR TITLE
Document variable merging in multi-repository deployments

### DIFF
--- a/deploy/multi-repo.mdx
+++ b/deploy/multi-repo.mdx
@@ -32,7 +32,7 @@ Each repository in a multi-repository deployment has its own:
 
 During deployment, Mintlify reads each repository and combines the configured sources into one site. Each source appears under its configured URL path.
 
-One repository acts as the **base source** for the deployment. Its `docs.json` is the root `docs.json` and controls site-level configuration, including theme, colors, logo, site name, top-level navigation, integrations, SEO, and other top-level fields. Every other source contributes only its own navigation and content under its configured URL path. The first repository you configure is the base source by default, and you can [change which source is the base](#change-the-base-source) at any time.
+One repository acts as the **base source** for the deployment. Its `docs.json` is the root `docs.json` and controls site-level configuration, including theme, colors, logo, site name, top-level navigation, integrations, SEO, and other top-level fields. Every other source contributes its own navigation and content under its configured URL path, plus any [variables](#variables-across-sources) that the base source doesn't define. The first repository you configure is the base source by default, and you can [change which source is the base](#change-the-base-source) at any time.
 
 <Note>
   Multi-repository deployments are different from a [monorepo setup](/deploy/monorepo). Use a monorepo setup when you store all content in a subdirectory alongside source code in a single repository. Use multi-repository deployments when you store content across separate repositories.
@@ -173,6 +173,15 @@ Do not use full `https://` URLs for internal cross-source links. Root-relative p
 ### Avoid path conflicts across sources
 
 When one source uses the root URL path, its pages can share the same final URL as pages in another source. If two sources produce the same page path, Mintlify serves the page from the source with the more specific URL path and logs a conflict warning in the deployment update. To avoid conflicts, keep filenames in the root source from overlapping with URL paths configured for other sources.
+
+## Variables across sources
+
+Mintlify merges the [`variables`](/organize/settings-reference#variables) defined in each source repository's `docs.json` into one set for the deployed site. Pages in any source can reference any merged variable with `{{variableName}}` syntax.
+
+When more than one source defines the same variable key:
+
+- The base source's value always wins.
+- If two non-base sources define the same key with different values and the base source doesn't define it, Mintlify uses the value from the source configured first and logs a warning in the deployment update that names the conflicting repositories.
 
 ## Reference navigation from another source
 

--- a/deploy/multi-repo.mdx
+++ b/deploy/multi-repo.mdx
@@ -180,8 +180,8 @@ Mintlify merges the [`variables`](/organize/settings-reference#variables) define
 
 When more than one source defines the same variable key:
 
-- The base source's value always wins.
-- If two non-base sources define the same key with different values and the base source doesn't define it, Mintlify uses the value from the source configured first and logs a warning in the deployment update that names the conflicting repositories.
+- The base source's value always takes precedence.
+- If two non-base sources define the same key with different values and the base source doesn't define it, Mintlify uses the value from the source configured first and logs a warning in the deployment to update the conflicting names in the non-base sources.
 
 ## Reference navigation from another source
 


### PR DESCRIPTION
## Summary
- Document that `variables` from each source repository's `docs.json` are merged into the deployed site in multi-repository deployments, with base source precedence and first-source-wins for non-base conflicts (mintlify/server#7483)

## Test plan
- Read the new "Variables across sources" section on `/deploy/multi-repo` and confirm it matches the merge behavior shipped in mintlify/server#7483

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to deploy/multi-repo.mdx with no runtime or configuration impact.
> 
> **Overview**
> Documents how **`variables`** from each source repo’s `docs.json` are merged on multi-repository deployments, matching behavior from mintlify/server#7483.
> 
> The **base source** paragraph now notes that non-base sources also contribute **variables** the base doesn’t define, with a link to the new section. **Variables across sources** explains site-wide merge, `{{variableName}}` usage across sources, base-source precedence on duplicate keys, and first-configured non-base source wins when the base omits the key (with a deployment warning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f1b5c2c9adada5a7d896c1fe405eca2a5bbc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->