### PR TITLE
Document pull request-backed editor branches

### DIFF
--- a/editor/branching-and-publishing.mdx
+++ b/editor/branching-and-publishing.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Branching and publishing"
-description: "Understand how branches and protection rules determine what happens when you publish, and how to manage the full review and deployment workflow."
+description: "Create pull request-backed branches, autosave changes to Git, and manage the review and deployment workflow from the editor."
 keywords: ["editor", "branch", "publish", "pull request", "preview", "git", "merge", "deploy"]
 ---
 
-The web editor autosaves everything as you type, but your changes are only live when you choose to publish them.
+The web editor uses pull requests to keep branch work separate from your live site. When you create a branch, the editor automatically opens a draft pull request. As you edit, your changes save to the branch in Git and update the pull request automatically.
 
-What happens when you publish depends on two things: **which branch you're on** and **whether that branch requires pull requests**.
+Your changes only go live when you merge the pull request into your deployment branch.
 
-## Saving versus publishing
+## Save changes
 
-**Saving** happens automatically. Mintlify stores your edits on its servers and persists them across browser tabs, devices, and network interruptions.
+Changes on a branch save automatically to Mintlify and Git. You don't need to click **Publish** to commit them. Each save updates the branch's draft pull request and preview deployment.
 
-**Publishing** commits your changes to your Git repository. Click **Publish** in the toolbar to open the publish menu, save your changes as a Git commit, and create a pull request.
+Changes on your deployment branch also save in the editor, but don't reach Git or your live site until you click **Publish**, unless you enable [main branch autocommits](/editor/settings#main-branch-autocommits).
 
-The editor tracks the following as pending changes:
+Automatic saving includes:
 
 - Content edits in pages
 - New or deleted pages
@@ -22,42 +22,24 @@ The editor tracks the following as pending changes:
 - Media uploads
 - Configuration updates
 
-## What happens when you publish
+## Work on a branch
 
-The actions available when you click the publish button depend on your current branch and whether it has branch protection rules that require pull requests.
-
-| Branch type | Branch protection | Available actions |
-| --- | --- | --- |
-| <Tooltip tip="The branch that publishes to your live site, typically 'main'." headline="Deployment branch">Deployment branch</Tooltip> | None | **Publish** directly to your live site |
-| Deployment branch | Pull requests required | **Create branch** to move changes to a new branch |
-| <Tooltip tip="An isolated branch where you work on updates before merging to your deployment branch." headline="Feature branch">Feature branch</Tooltip> | None | **Save in branch**, **Create pull request** |
-| Feature branch | Pull requests required | **Save in branch**, **Create pull request** |
-
-- **Publish**: Commits and deploys your changes to your live site immediately.
-- **Save in branch**: Commits your changes to the feature branch without merging to your deployment branch.
-- **Create branch**: Moves your pending changes to a new feature branch when you're on a protected deployment branch.
-- **Create pull request**: Opens a pull request targeting your deployment branch.
-
-If there are no pending changes, the editor disables the publish and save actions.
-
-<Note>
-  Your live site updates after Mintlify builds and deploys your changes. This typically takes 30 seconds to a few minutes. Check the deployment status on your [dashboard](https://app.mintlify.com).
-</Note>
-
-## When to use a branch
-
-**Edit directly on your deployment branch** if you do not use a Git-based workflow.
-
-**Create a branch** when you use a branch-based workflow where you make each change to your content on a separate branch.
-
-## Create and switch branches
-
-### Create a branch
+Use a branch when you want to review changes before they reach your live site. Each branch you create in the editor is backed by a draft pull request.
 
 1. Click the branch name in the editor toolbar.
 2. Click **Create new branch**.
 3. If you have pending changes, choose whether to bring them to the new branch or leave them on the current branch.
 4. Enter a name and click **Create branch**.
+
+The editor creates the branch and a draft pull request, then switches you to the new branch. All subsequent changes autosave to Git and appear in the pull request.
+
+<Note>
+  The branch selector shows your deployment branch and branches that have pull requests. Git branches without pull requests don't appear in the visual editor.
+</Note>
+
+<Note>
+  Your live site updates after Mintlify builds and deploys your changes. This typically takes 30 seconds to a few minutes. Check the deployment status on your [dashboard](https://app.mintlify.com).
+</Note>
 
 <Tip>
   Use descriptive branch names so you can identify them and other people understand what each branch is for.
@@ -69,17 +51,13 @@ If there are no pending changes, the editor disables the publish and save action
 2. Search for or scroll to the branch you want.
 3. Click the branch to switch to it.
 
-<Note>
-  Switching branches while you have unpublished changes prompts you to bring those changes to the new branch or leave them behind. Changes left behind remain on your original branch.
-</Note>
-
 <Tip>
   To copy a branch name, hover over the branch in the dropdown and click the copy icon. This is useful when sharing the branch with teammates or referencing it in a pull request.
 </Tip>
 
 ## Preview your changes
 
-Every time you save changes to a feature branch, Mintlify builds a preview deployment, a temporary URL where your changes render exactly as they look when published.
+Every time the editor saves changes to a branch, Mintlify updates its preview deployment, a temporary URL where your changes render exactly as they look when published.
 
 ### Access and share a preview
 
@@ -118,7 +96,7 @@ For example: `https://app.mintlify.com/acme/docs/editor/main/~/guides/quickstart
 
 ## Review and merge pull requests
 
-When a pull request is open for the current branch, the publish menu shows a review panel with:
+Every editor-created branch starts with a draft pull request. When you're ready for feedback, mark the pull request ready for review. The publish menu shows a review panel with:
 
 - The pull request title, description, and whether it is a draft.
 - The source and target branches.
@@ -155,13 +133,9 @@ When an [automation](/automations) opens a pull request, you can jump straight f
 
 Either entry point opens the editor on the automation's branch with the changed pages preselected in the publish menu. You can review the diff and merge or request changes without leaving the editor.
 
-### Simultaneous publishing
-
-Only one publish can happen at a time per branch. If another team member publishes to the same branch, wait for the current publish to complete before trying again.
-
 ### Pull request titles and descriptions
 
-If your organization requires pull requests, you can enter a title and description when you publish. If you leave either blank, the editor uses a default message that lists the files you created, updated, moved, or deleted.
+The editor creates a title and description when it opens the draft pull request. You can edit the pull request title from the branch menu or update both fields in your Git provider.
 
 ## Resolve conflicts
 


### PR DESCRIPTION
## Description

Updates the editor branch guide for the new pull request-backed workflow.
- Explain automatic draft pull request creation and Git autosaves
- Document bringing or leaving pending changes when branching
- Clarify branch visibility, previews, and review flow

## Test Plan

- `npx mint@latest validate`
- Review the branching guide preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single MDX guide with no product or security impact.
> 
> **Overview**
> Rewrites **Branching and publishing** for the editor’s **pull request-backed** workflow instead of the older publish/save matrix tied to branch protection.
> 
> **Autosave and Git:** Feature-branch edits now **autosave to Mintlify and Git** and refresh the draft PR and preview without clicking **Publish**. The deployment branch still needs **Publish** (or [main branch autocommits](/editor/settings#main-branch-autocommits)) to reach Git and production.
> 
> **Branches:** Creating a branch **opens a draft pull request** automatically; the doc adds visibility rules (only deployment branch and PR-backed branches in the selector) and keeps the bring-or-leave pending changes step when branching.
> 
> **Removed or slimmed:** The branch-type vs protection **action table**, separate “when to use a branch” guidance, the note about unpublished changes when switching branches, and **simultaneous publishing** per branch.
> 
> **Review flow:** PR titles/descriptions are **created at draft open** (editable in the branch menu or Git host), not only at publish; previews are tied to **editor saves** on branches rather than manual “save to feature branch.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5852d1c0137eeb30539818876750f2d758d6a5c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->