### PR TITLE
Rename noCopy to nocopy in code block docs

### DIFF
--- a/create/code.mdx
+++ b/create/code.mdx
@@ -448,22 +448,22 @@ sayHello();
 
 ### Hide copy button
 
-Use the `noCopy` flag to hide the copy to clipboard button on a code block. This can be useful for content where copying is not meaningful, like ASCII diagrams or terminal output.
+Use the `nocopy` flag to hide the copy to clipboard button on a code block. This can be useful for content where copying is not meaningful, like ASCII diagrams or terminal output.
 
-Pass `noCopy="false"` to explicitly show the copy button.
+Pass `nocopy="false"` to explicitly show the copy button. For a code block with no language, use ` ```nocopy ` on its own to render the block as plain text without a copy button.
 
 Inside a `<CodeGroup>`, you can define the visibility of the copy button for each tab.
 
 <CodeGroup>
 
-```text title="No copy example" noCopy
+```text title="No copy example" nocopy
 User ──▶ CDN ──▶ Origin
               │
               └──▶ Cache
 ```
 
 ````mdx Format
-```text title="No copy example" noCopy
+```text title="No copy example" nocopy
 User ──▶ CDN ──▶ Origin
               │
               └──▶ Cache
@@ -560,7 +560,7 @@ Use the `<CodeBlock>` component in custom React components to programmatically r
   Whether to wrap the code block.
 </ResponseField>
 
-<ResponseField name="noCopy" type="boolean">
+<ResponseField name="nocopy" type="boolean">
   Whether to hide the copy-to-clipboard button.
 </ResponseField>
 

--- a/es/create/code.mdx
+++ b/es/create/code.mdx
@@ -457,29 +457,27 @@ Activa el ajuste de texto para líneas largas con `wrap`. Esto evita el desplaza
   ### Ocultar el botón de copiar
 </div>
 
-Oculta el botón para copiar al portapapeles en un bloque de código con `noCopy`. Úsalo para contenido en el que copiar no aporta valor, como diagramas ASCII o salida de terminal.
+Oculta el botón para copiar al portapapeles en un bloque de código con `nocopy`. Úsalo para contenido en el que copiar no aporta valor, como diagramas ASCII o salida de terminal.
 
-El indicador `noCopy` también acepta `no-copy` y `nocopy` como alias, con cualquier combinación de mayúsculas y minúsculas. Pasa `noCopy="false"` para mostrar el botón de copiar de forma explícita.
+Pasa `nocopy="false"` para mostrar el botón de copiar de forma explícita. Para un bloque de código sin lenguaje, usa ` ```nocopy ` por sí solo para renderizar el bloque como texto plano sin botón de copiar.
 
-Para un bloque de código sin lenguaje, usa `no-copy` por sí solo para renderizar el bloque como texto plano sin botón de copiar.
+Dentro de un `<CodeGroup>`, puedes definir la visibilidad del botón de copiar para cada pestaña.
 
 <CodeGroup>
-  ```text No copy example no-copy
+  ```text title="Ejemplo sin copiar" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
 
   ````mdx Format
-  ```text No copy example no-copy
+  ```text title="Ejemplo sin copiar" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
   ````
 </CodeGroup>
-
-Dentro de un `<CodeGroup>`, el botón de copiar compartido se oculta cuando la pestaña seleccionada define `noCopy` y vuelve a aparecer al cambiar a una pestaña que no lo define.
 
 <div id="diff">
   ### Diff
@@ -573,7 +571,7 @@ Usa el componente `<CodeBlock>` en componentes personalizados de React para rend
   Si ajustar el bloque de código.
 </ResponseField>
 
-<ResponseField name="noCopy" type="boolean">
+<ResponseField name="nocopy" type="boolean">
   Si ocultar el botón para copiar al portapapeles.
 </ResponseField>
 

--- a/fr/create/code.mdx
+++ b/fr/create/code.mdx
@@ -457,29 +457,27 @@ Activez le retour à la ligne pour les longues lignes à l’aide de `wrap`. Cel
   ### Masquer le bouton de copie
 </div>
 
-Masquez le bouton de copie dans le presse-papiers d’un bloc de code à l’aide de `noCopy`. Utilisez cette option pour du contenu où la copie n’a pas de sens, comme des diagrammes ASCII ou la sortie d’un terminal.
+Masquez le bouton de copie dans le presse-papiers d’un bloc de code à l’aide de `nocopy`. Utilisez cette option pour du contenu où la copie n’a pas de sens, comme des diagrammes ASCII ou la sortie d’un terminal.
 
-L’indicateur `noCopy` accepte aussi `no-copy` et `nocopy` comme alias, quelle que soit la casse. Passez `noCopy="false"` pour afficher explicitement le bouton de copie.
+Passez `nocopy="false"` pour afficher explicitement le bouton de copie. Pour un bloc de code sans langage, utilisez ` ```nocopy ` seul pour afficher le bloc en texte brut sans bouton de copie.
 
-Pour un bloc de code sans langage, utilisez `no-copy` seul pour afficher le bloc en texte brut sans bouton de copie.
+À l’intérieur d’un `<CodeGroup>`, vous pouvez définir la visibilité du bouton de copie pour chaque onglet.
 
 <CodeGroup>
-  ```text No copy example no-copy
+  ```text title="Exemple sans copie" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
 
   ````mdx Format
-  ```text No copy example no-copy
+  ```text title="Exemple sans copie" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
   ````
 </CodeGroup>
-
-À l’intérieur d’un `<CodeGroup>`, le bouton de copie partagé est masqué lorsque l’onglet sélectionné définit `noCopy` et réapparaît lorsque vous passez à un onglet qui ne le définit pas.
 
 <div id="diff">
   ### Diff
@@ -573,7 +571,7 @@ Utilisez le composant `<CodeBlock>` dans des composants React personnalisés pou
   Indique s’il faut effectuer un retour à la ligne dans le bloc de code.
 </ResponseField>
 
-<ResponseField name="noCopy" type="boolean">
+<ResponseField name="nocopy" type="boolean">
   Indique s’il faut masquer le bouton de copie dans le presse-papiers.
 </ResponseField>
 

--- a/zh/create/code.mdx
+++ b/zh/create/code.mdx
@@ -457,29 +457,27 @@ Mintlify 使用 [Shiki](https://shiki.style/) 实现语法高亮，支持所有�
   ### 隐藏复制按钮
 </div>
 
-使用 `noCopy` 隐藏代码块上的复制到剪贴板按钮。适用于复制没有意义的内容，例如 ASCII 图或终端输出。
+使用 `nocopy` 隐藏代码块上的复制到剪贴板按钮。适用于复制没有意义的内容，例如 ASCII 图或终端输出。
 
-`noCopy` 标志也接受 `no-copy` 和 `nocopy` 作为别名，且不区分大小写。传入 `noCopy="false"` 可显式显示复制按钮。
+传入 `nocopy="false"` 可显式显示复制按钮。对于未指定语言的代码块，可以单独使用 ` ```nocopy `，将代码块以纯文本渲染，且不显示复制按钮。
 
-对于未指定语言的代码块，可以单独使用 `no-copy`，将代码块以纯文本渲染，且不显示复制按钮。
+在 `<CodeGroup>` 内，可以为每个选项卡分别设置复制按钮的可见性。
 
 <CodeGroup>
-  ```text No copy example no-copy
+  ```text title="无复制按钮示例" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
 
   ````mdx Format
-  ```text No copy example no-copy
+  ```text title="无复制按钮示例" nocopy
   User ──▶ CDN ──▶ Origin
                 │
                 └──▶ Cache
   ```
   ````
 </CodeGroup>
-
-在 `<CodeGroup>` 内，当所选选项卡设置了 `noCopy` 时，共享的复制按钮会被隐藏；切换到未设置该选项的选项卡时，按钮会重新显示。
 
 <div id="diff">
   ### 差异
@@ -572,7 +570,7 @@ Mintlify 使用 [Shiki](https://shiki.style/) 实现语法高亮，支持所有�
   是否对代码块进行换行显示。
 </ResponseField>
 
-<ResponseField name="noCopy" type="boolean">
+<ResponseField name="nocopy" type="boolean">
   是否隐藏复制到剪贴板的按钮。
 </ResponseField>
 


### PR DESCRIPTION
## What

mintlify/mint#10203 merged with the flag named `nocopy` (one name, no `noCopy`/`no-copy` aliases, no case-insensitivity). The auto-generated docs in #7017 documented `noCopy` and the alias behavior from an earlier revision of that PR.

## Changes

- `create/code.mdx` + es/fr/zh: `noCopy` → `nocopy` in prose, examples, and the `<CodeBlock>` ResponseField
- Drop the "also accepts `no-copy` / `nocopy`, any casing" sentence (not true)
- Keep the bare ` ```nocopy ` fence form (still supported)
- Fix the malformed `text No copy example no-copy` fences in the translations (now `title="…" nocopy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to MDX; no runtime or API behavior in this repo.
> 
> **Overview**
> Updates the **Format code** docs (English plus es/fr/zh) so the hide-copy behavior matches the shipped Mint flag **`nocopy`**, not the outdated **`noCopy`** / alias wording from an earlier revision.
> 
> Prose, fenced examples, and the `<CodeBlock>` **`nocopy`** `ResponseField` are renamed consistently. Docs no longer claim **`no-copy`** / **`nocopy`** aliases or case-insensitive matching. Translations fix malformed fences (proper **`title="…" nocopy`**) and drop the extra **CodeGroup** tab-switching note that referred to **`noCopy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48c732e1e26e6ebec80dc577aaa8ea9d4b5fcf37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->