### PR TITLE
Fix hidden, noindex, llms.txt accuracy

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -24,10 +24,17 @@ View your `llms.txt` by appending `/llms.txt` to your documentation site's URL. 
 
 <PreviewButton href="https://mintlify.com/docs/llms.txt">Open the llms.txt for this site.</PreviewButton>
 
-Mintlify adds HTTP headers to every page response so AI tools can discover your `llms.txt` files without prior knowledge of their location:
+Mintlify adds HTTP headers to every page response so AI tools can discover your `llms.txt` files and other agent resources without prior knowledge of their location:
 
-- `Link: </llms.txt>; rel="llms-txt", </llms-full.txt>; rel="llms-full-txt"`: Follows the standard HTTP `Link` header format for resource discovery.
-- `X-Llms-Txt: /llms.txt`: A convenience header for tools that check for `llms.txt` support.
+- `Link`: Follows the standard HTTP `Link` header format for resource discovery. Advertises `llms.txt`, `llms-full.txt`, your API catalog, [MCP server card](/ai/model-context-protocol#discovery-endpoint), [agent card](/ai/skillmd#agent-card), and [agent skills index](/ai/skillmd#skills-discovery-endpoints).
+- `X-Llms-Txt`: A convenience header for tools that check for `llms.txt` support.
+
+```http Response headers
+Link: </llms.txt>; rel="llms-txt", </llms-full.txt>; rel="llms-full-txt", </.well-known/api-catalog>; rel="api-catalog", </.well-known/mcp/server-card.json>; rel="mcp-server-card", </.well-known/agent-card.json>; rel="agent-card", </.well-known/agent-skills/index.json>; rel="agent-skills"
+X-Llms-Txt: /llms.txt
+```
+
+Sites that use authentication also advertise their OAuth protected resource metadata with `rel="oauth-protected-resource"`. If you serve your documentation under a base path, every advertised path includes that prefix.
 
 ## Structure of the llms.txt file
 
@@ -38,15 +45,18 @@ An `llms.txt` file is a plain Markdown file that contains:
 - **Custom agent instructions** as an `Agent Instructions` block after the description, if you set [`markdown.instructions`](/ai/markdown-export#custom-agent-instructions) in your `docs.json`.
 - **Structured content sections** with links and a description of each page in your documentation.
 - **API specification links** to your OpenAPI and AsyncAPI specs, if your documentation includes them.
+- **External links** in an `Optional` section, for any absolute URLs in your navigation.
 
-The `llms.txt` file lists your pages alphabetically in the order they appear in your repository, starting from the root directory. Page links in the `llms.txt` file include a `.md` extension so AI tools can fetch the Markdown version of each page directly.
+The `llms.txt` file lists your pages in the order they appear in your `docs.json` navigation. Pages that aren't in your navigation but are indexed because you set `seo.indexing: "all"` appear last, in alphabetical order. Page links in the `llms.txt` file include a `.md` extension so AI tools can fetch the Markdown version of each page directly.
 
-Each page's description comes from the `description` field in its frontmatter. Mintlify truncates descriptions at 300 characters and at the first line break. For API reference pages, the description also includes the specification information from the `openapi` or `api` frontmatter field. Pages without a `description` field appear in the `llms.txt` file without a description.
+Each page's description comes from the `description` field in its frontmatter. Mintlify uses the first paragraph of the description and truncates it at 300 characters. Pages without a `description` field appear in the `llms.txt` file without a description.
+
+Both `llms.txt` and `llms-full.txt` list pages from your default language and default version. They exclude [hidden pages](/organize/hidden-pages) and pages with `noindex: true` in their frontmatter unless you set `seo.indexing: "all"` in your `docs.json`.
 
 This structured approach allows LLMs to efficiently process your documentation at a high level and locate relevant content for user queries, improving the accuracy and speed of AI-assisted documentation searches.
 
 <Note>
-  Automatically generated `llms.txt` files cannot exceed 100,000 characters. If your documentation exceeds this limit, Mintlify truncates the file and appends a note listing the number of omitted pages. To list every page without truncation, add a [custom `llms.txt` file](#custom-files) at the root of your project.
+  Automatically generated `llms.txt` files cannot exceed 100,000 characters. As a file approaches this limit, Mintlify shortens page descriptions first, then drops entries and appends a note listing what it omitted. This limit does not apply to `llms-full.txt`. To list every page without truncation, add a [custom `llms.txt` file](#custom-files) at the root of your project.
 </Note>
 
 ```mdx Example llms.txt
@@ -67,11 +77,15 @@ This structured approach allows LLMs to efficiently process your documentation a
 ## AsyncAPI Specs
 
 - [asyncapi](https://example.com/docs/asyncapi.yaml)
+
+## Optional
+
+- [Community](https://example.com/community)
 ```
 
 ## llms-full.txt
 
-The `llms-full.txt` file combines your entire documentation site into a single file as context for AI tools and LLM indexing.
+The `llms-full.txt` file combines your entire documentation site into a single file as context for AI tools and LLM indexing. Each page appears as its title, source URL, description, and full Markdown content.
 
 Mintlify automatically hosts an `llms-full.txt` file at the root of your project. View your `llms-full.txt` by appending `/llms-full.txt` to your documentation site's URL. Mintlify also hosts the file at `/.well-known/llms-full.txt` for compatibility with tools that follow the `.well-known` convention.
 

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -347,7 +347,7 @@ You can preview how your meta tags appear on different platforms using [metatags
 
 Mintlify automatically generates a `sitemap.xml` file and a `robots.txt` file. You can view your sitemap by appending `/sitemap.xml` to your documentation site's URL.
 
-By default, Mintlify indexes only the pages you include in your `docs.json` navigation. It excludes [hidden pages](/organize/hidden-pages) that exist in your repository but are not listed in your navigation from the following locations:
+By default, Mintlify indexes only the pages you include in your `docs.json` navigation. It excludes [hidden pages](/organize/hidden-pages)—pages that are missing from your navigation, pages under a hidden tab or group, and pages with `hidden: true` in their frontmatter—from the following locations:
 
 - Search engine sitemaps
 - Internal documentation search

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -436,10 +436,12 @@ When enabled, your site:
 - Renders every page with `noindex, nofollow` robots meta tags.
 - Returns an empty `sitemap.xml`.
 - Returns `404` for `llms.txt` and `llms-full.txt`.
-- Clears your search index so pages no longer appear in internal search, the [assistant](/assistant/index), or your [search MCP server](/ai/model-context-protocol).
+- Removes your pages from [Mintlify Index](/search-index), so coding agents can no longer retrieve your content there.
 - Serves a site-wide disallow `robots.txt`:
 
   
+
+Your in-product search, [assistant](/assistant/index), and [MCP server](/ai/model-context-protocol) keep working. To remove pages from those, use `noindex: true` or `searchable: false` on individual pages.
 
 Disable indexing when you need to keep a deployment online for internal review, staging, or limited sharing. This prevents the site from appearing in public search results or being used by AI tools as training or retrieval data.
 

--- a/organize/hidden-pages.mdx
+++ b/organize/hidden-pages.mdx
@@ -35,7 +35,7 @@ hidden: true
 ---
 ```
 
-To make a page visible again, remove the `hidden` field entirely. Do not set `hidden: false` as it results in undefined behavior.
+To make a page visible again, remove the `hidden` field entirely. Setting `hidden: false` has the same effect on the navigation, but avoid it on pages inside a hidden group or tab: those pages stay out of the navigation because their parent isn't rendered, while `hidden: false` puts them back into search, sitemaps, and AI context.
 
 <Note>
   By default, `hidden: true` excludes a page from search engine indexing, sitemaps, and AI context.
@@ -98,13 +98,18 @@ By default, hidden pages don't appear in indexing for search engines, documentat
 
 The following table summarizes how each property affects page visibility and indexing:
 
-| Property | Sidebar navigation | Site search | Sitemap | Search engine indexing | AI assistant context |
-|---|---|---|---|---|---|
-| `hidden: true` | Hidden | Excluded | Excluded | Excluded | Excluded |
-| `noindex: true` | Visible | Excluded | Excluded | Excluded | Excluded |
-| `searchable: false` (page frontmatter) | Visible | Excluded | Included | Included | Excluded |
-| `searchable: true` (on hidden tab/group) | Hidden | Included | Included | Included | Included |
-| `seo.indexing: "all"` (in `docs.json`) | Hidden | Included | Included | Included | Included |
+| Property | Sidebar navigation | Site search | Sitemap | Search engine indexing | AI assistant context | `llms.txt` |
+|---|---|---|---|---|---|---|
+| `hidden: true` (page frontmatter) | Hidden | Excluded | Excluded | Excluded | Excluded | Excluded |
+| Page not listed in `docs.json` | Hidden | Excluded | Excluded | Excluded from sitemap only | Excluded | Excluded |
+| `noindex: true` (page frontmatter) | Visible | Excluded | Excluded | Excluded | Excluded | Excluded |
+| `searchable: false` (page frontmatter) | Visible | Excluded | Included | Included | Excluded | Included |
+| `searchable: true` (on hidden tab or group) | Hidden | Included | Included | Included | Included | Included |
+| `seo.indexing: "all"` (in `docs.json`) | Hidden | Included | Included | Included | Included | Included |
+
+The two ways to hide a page differ for search engines. `hidden: true` adds a `noindex` meta tag to the page, which tells crawlers not to index it. Leaving a page out of your `docs.json` navigation only keeps it out of your `sitemap.xml`, so a crawler that finds the URL somewhere else can still index the page. Add `hidden: true` or `noindex: true` to the page's frontmatter when you need the meta tag.
+
+The `llms.txt` column also applies to `llms-full.txt`. See [llms.txt](/ai/llmstxt) for details on both files.
 
 ### Include all hidden pages
 
@@ -150,7 +155,7 @@ A page's own `hidden: true` frontmatter always takes precedence. To re-exclude a
 
 ### Page-level `searchable`
 
-At the page frontmatter level, `searchable` only accepts `false`. Use it to keep a page indexable by external search engines while excluding it from in-product search and AI assistant context. See [Exclude a page from search](/optimize/search#exclude-a-page-from-search) for an example.
+At the page frontmatter level, only `searchable: false` has an effect. Use it to keep a page indexable by external search engines while excluding it from in-product search and AI assistant context. Pages with `searchable: false` still appear in your `llms.txt` and `llms-full.txt` files. See [Exclude a page from search](/optimize/search#exclude-a-page-from-search) for an example.
 
 Page-level `searchable` does not override `hidden: true` on the same page. To make a hidden page discoverable, leave `searchable` unset and either move it under a hidden tab or group with `searchable: true`, or set `seo.indexing: "all"` in `docs.json`.
 
@@ -158,7 +163,7 @@ Page-level `searchable` does not override `hidden: true` on the same page. To ma
 
 The relationship between `hidden` and `noindex` is one-directional:
 
-- **`hidden: true` → automatically applies `noindex`**: Hidden pages are automatically excluded from search engines, sitemaps, and AI context.
+- **`hidden: true` → automatically applies `noindex`**: Pages with `hidden: true` in their frontmatter are automatically excluded from search engines, sitemaps, and AI context.
 - **`noindex: true` → does NOT apply `hidden`**: Pages with `noindex: true` remain visible in navigation. They don't appear in site search, sitemaps, search engine indexing, or AI assistant context.
 
 To exclude a specific page from search and indexing while keeping it visible in navigation, add `noindex: true` to its frontmatter. To hide a page from navigation as well, use `hidden: true`. To exclude a page only from your in-product search and AI assistant context while keeping it indexable by external search engines, use [`searchable: false`](/optimize/search#exclude-a-page-from-search) instead.


### PR DESCRIPTION
## Documentation changes

Fixes inaccuracies about the behavior of hidden pages and where they appear.

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to MDX documentation with no application code or configuration defaults modified.
> 
> **Overview**
> Updates **llms.txt** docs to match current product behavior: page order follows **`docs.json` navigation** (with `seo.indexing: "all"` extras last), descriptions use the **first paragraph** (300-char cap), and **hidden / `noindex`** pages are omitted unless indexing is set to `"all"`. Adds **Optional** nav URLs, richer **`Link`** header discovery (API catalog, MCP/agent cards, skills index, OAuth metadata), and clearer **100k-character** truncation rules.
> 
> **Hidden pages** and **SEO** docs are aligned: hidden pages are defined as missing from nav, under hidden tabs/groups, or `hidden: true`; the visibility table adds an **`llms.txt`** column and a row for pages **not listed in navigation** (sitemap-only exclusion vs `noindex` from `hidden: true`). **`searchable: false`** is documented as still included in `llms.txt` / `llms-full.txt`, and **`hidden: false`** inside hidden parents is warned as re-enabling indexing while nav stays hidden.
> 
> **Project-level “Don’t index”** now states removal from **Mintlify Index** for coding agents, and clarifies that in-product search, assistant, and MCP keep working unless pages use **`noindex`** or **`searchable: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a64686a891aea7f03930532b28b21ed2b460496b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->