### PR TITLE
Fix infinite redirect loop on the migration overview page

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -937,35 +937,19 @@
     },
     {
       "source": "/guides/migration",
-      "destination": "/migration/index"
+      "destination": "/migration"
     },
     {
       "source": "/es/guides/migration",
-      "destination": "/es/migration/index"
+      "destination": "/es/migration"
     },
     {
       "source": "/fr/guides/migration",
-      "destination": "/fr/migration/index"
+      "destination": "/fr/migration"
     },
     {
       "source": "/zh/guides/migration",
-      "destination": "/zh/migration/index"
-    },
-    {
-      "source": "/migration",
-      "destination": "/migration/index"
-    },
-    {
-      "source": "/es/migration",
-      "destination": "/es/migration/index"
-    },
-    {
-      "source": "/fr/migration",
-      "destination": "/fr/migration/index"
-    },
-    {
-      "source": "/zh/migration",
-      "destination": "/zh/migration/index"
+      "destination": "/zh/migration"
     },
     {
       "source": "/settings/seo",


### PR DESCRIPTION
Four self-referential rules redirected /migration to /migration/index in each language. The redirect matcher strips a trailing /index before matching, so /migration/index matched the /migration rule and redirected to itself, making the migration overview unreachable in all four languages.

Remove those rules -- Mintlify serves migration/index.mdx at /migration natively, the same as /assistant, /editor, and /automations -- and point the /guides/migration redirects at /migration instead of /migration/index.

## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Redirect-only documentation routing fix with no auth, data, or application logic changes.
> 
> **Overview**
> Fixes an **infinite redirect loop** that made the migration overview unreachable in English, Spanish, French, and Chinese.
> 
> **Removes** four self-referential rules that redirected `/migration` (and locale prefixes) to `/migration/index`. Mintlify’s matcher treats `/migration/index` like `/migration`, so those rules looped on themselves. The overview is already served at `/migration` from `migration/index.mdx`, so those entries are unnecessary.
> 
> **Updates** the `/guides/migration` redirects (all locales) to target `/migration` instead of `/migration/index`, matching how other section index pages are routed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7637f8d8b5248544b41cc8adc0e8227fdcb13057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->