### PR TITLE
docs(analytics): document June 2026 agent traffic measurement change

### DIFF
--- a/analytics/traffic.mdx
+++ b/analytics/traffic.mdx
@@ -36,9 +36,9 @@ Review traffic analytics to:
 Mintlify identifies agent visitors by IP address and user agent. The agent visitor count approximates distinct sources of AI traffic rather than individual agent sessions or conversations. Multiple requests from the same IP address count as one visitor.
 
 <Note>
-  Agent traffic measurement expanded in June 2026. Before then, only a subset of agent traffic was captured. Starting June 8, 2026, Mintlify recognizes a broader set of agent user agents, counts agent HTML page views alongside markdown requests, and serves markdown to more agents. As a result, agent views increased across most sites around that date. This reflects improved measurement and agent access, not a sudden change in real traffic. When comparing agent views across June 8, 2026, account for this shift.
+  Agent traffic measurement expanded in June 2026. Before then, the analytics dashboard only captured a subset of agent traffic. Starting June 8, 2026, Mintlify recognizes a broader set of agent user agents, counts agent HTML page views alongside Markdown requests, and serves Markdown to more agents. As a result, agent views increased across most sites around that date. This reflects improved measurement and agent access, not a sudden change in traffic. When comparing agent views over time, account for this shift.
 
-  The size of the increase varies by site, since it depends on how much agent traffic each site receives. Sites that AI tools reference frequently, such as support or help content, show a larger increase than sites with less agent traffic.
+  The size of the increase varies by site, since it depends on how much agent traffic each site receives. Sites that AI tools reference frequently show a larger increase than sites with less agent traffic.
 </Note>
 
 Use agent views to understand:

--- a/analytics/traffic.mdx
+++ b/analytics/traffic.mdx
@@ -35,6 +35,12 @@ Review traffic analytics to:
 
 Mintlify identifies agent visitors by IP address and user agent. The agent visitor count approximates distinct sources of AI traffic rather than individual agent sessions or conversations. Multiple requests from the same IP address count as one visitor.
 
+<Note>
+  Agent traffic measurement expanded in June 2026. Before then, only a subset of agent traffic was captured. Starting June 8, 2026, Mintlify recognizes a broader set of agent user agents, counts agent HTML page views alongside markdown requests, and serves markdown to more agents. As a result, agent views increased across most sites around that date. This reflects improved measurement and agent access, not a sudden change in real traffic. When comparing agent views across June 8, 2026, account for this shift.
+
+  The size of the increase varies by site, since it depends on how much agent traffic each site receives. Sites that AI tools reference frequently, such as support or help content, show a larger increase than sites with less agent traffic.
+</Note>
+
 Use agent views to understand:
 
 - **AI agent distribution**: See which AI platforms access your docs to learn which tools your users prefer.


### PR DESCRIPTION
## Summary
- Documents the June 8, 2026 agent traffic measurement change on the Traffic analytics page, so customers understand why agent views jumped around that date.
- Explains it reflects expanded agent user-agent recognition, counting agent HTML page views alongside markdown requests, and serving markdown to more agents — improved measurement and access, not a real traffic spike.
- Notes that the size of the increase varies by site depending on how much agent traffic it receives (e.g. support/help content sees a larger jump).

Context: prompted by a customer (Quo) asking why agent visits jumped on their support site but appeared flat on their product docs around June 8. Both had the same measurement change; the difference is volume of agent (mostly ChatGPT) retrieval.

## Test plan
- Preview the docs and open **Analytics > Traffic**, section **Interpret agent views**.
- Confirm the new note renders correctly in light and dark mode and reads clearly for a customer.

https://claude.ai/code/session_01NzT7aqK6SeX7ZX8fb3a7zT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change on the analytics Traffic page; no product, data, or security impact.
> 
> **Overview**
> Adds a note on the Traffic analytics page explaining why **agent views jumped around June 8, 2026**.
> 
> The note clarifies that Mintlify expanded agent user-agent detection, started counting agent HTML views with Markdown requests, and serves Markdown to more agents—so the spike is improved measurement and access, not a real traffic change. It also notes the increase size varies by how much agent traffic a site already gets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c79748b44690a8fca97fa52e2e720c1a9445ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->