### PR TITLE
docs: document llms.txt scoped proxy routes

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -56,8 +56,10 @@ Both `llms.txt` and `llms-full.txt` list pages from your default language and de
 This structured approach allows LLMs to efficiently process your documentation at a high level and locate relevant content for user queries, improving the accuracy and speed of AI-assisted documentation searches.
 
 <Note>
-  Automatically generated `llms.txt` files cannot exceed 100,000 characters. As a file approaches this limit, Mintlify shortens page descriptions first, then drops entries and appends a note listing what it omitted. This limit does not apply to `llms-full.txt`. To list every page without truncation, add a [custom `llms.txt` file](#custom-files) at the root of your project.
+  Automatically generated `llms.txt` index files cannot exceed 100,000 characters. For large documentation sites, Mintlify splits the index into linked files under `/_llms/` so agents can discover every page without loading one oversized file. This limit does not apply to `llms-full.txt`.
 </Note>
+
+If you use a reverse proxy or maintain a path allowlist, forward `/_llms/*` in addition to `/llms.txt` so agents can follow the generated index links. For documentation hosted at a base path, forward `<base-path>/_llms/*` instead. Mintlify-managed custom domains do not require additional configuration. See [Reverse proxy](/deploy/reverse-proxy#routing-configuration) for routing guidance.
 
 ```mdx Example llms.txt
 # Site title

--- a/deploy/reverse-proxy.mdx
+++ b/deploy/reverse-proxy.mdx
@@ -51,6 +51,8 @@ Your proxy must forward all HTTP methods on documentation paths. Mintlify sends 
 
 Mintlify serves these files under your base path, like `<your-subdomain>.mintlify.site/docs/llms.txt`. They are available on your domain under your subpath, like `your-domain.com/docs/llms.txt`, through your main subpath route.
 
+The `/docs/*` route also covers generated `llms.txt` indexes under `/docs/_llms/*`. If your proxy uses a more granular path allowlist instead of forwarding all `/docs/*` requests, include `/docs/_llms/*` so agents can follow every index linked from `/docs/llms.txt`.
+
 The `/.well-known/skills/*`, `/.well-known/agent-skills/*`, `/skill.md`, `/llms.txt`, and `/llms-full.txt` routes are optional. Include them only if you also want to serve these files at root paths on your domain, like `your-domain.com/llms.txt`. Each root path maps to the file under your base path on your Mintlify subdomain.
 
 ### Required header configuration


### PR DESCRIPTION
## Summary

- explain that large generated `llms.txt` files use scoped indexes under `/_llms/*`
- document the reverse-proxy and granular path-allowlist requirements, including base paths
- clarify that Mintlify-managed custom domains need no additional configuration

## Testing

- `mint broken-links`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **llms.txt** docs to match how large sites are handled today: instead of describing truncation and omitted entries at the 100,000-character cap, it explains that Mintlify **splits** the generated index into linked files under **`/_llms/`** so agents can discover all pages without one huge file.
> 
> Adds operator guidance for **reverse proxies and path allowlists**—forward **`/_llms/*`** alongside **`/llms.txt`**, use **`<base-path>/_llms/*`** when docs sit under a base path, and note that **Mintlify-managed custom domains** need no extra setup—with a cross-link to the reverse-proxy page.
> 
> On **Reverse proxy**, clarifies that **`/docs/*`** already covers **`/docs/_llms/*`**, and that granular allowlists must explicitly include **`/docs/_llms/*`** so index links from **`/docs/llms.txt`** remain reachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4ac4c2ad0ef86684118816a21d945bad539e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->