### PR TITLE
Document nav logo CSS specificity

### DIFF
--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -190,7 +190,14 @@ Multiple instances of these elements can appear on a page. Use these as `value` 
     - `breadcrumb-item`: Individual breadcrumb item.
   </Accordion>
   <Accordion title="Topbar navigation">
-    - `nav-logo`: Logo in the navigation bar.
+    - `nav-logo`: Logo image in the navigation bar. To override its default size utilities, target `img.nav-logo` and use `!important`.
+
+      ```css
+      img.nav-logo {
+        height: 3.75rem !important;
+        width: auto !important;
+      }
+      ```
     - `navbar-link`: Link element within the navigation bar.
     - `nav-anchors`: Container for anchor links in the topbar.
     - `nav-anchor`: Individual anchor link in the topbar.


### PR DESCRIPTION
## Documentation changes

Clarifies that custom logo sizing should target `img.nav-logo` and includes a CSS example that overrides the default Tailwind height utility while preserving the logo aspect ratio.

Closes #6242

---

## For Reviewers

- [x] The selector matches Mintlify template usage.
- [x] The example addresses the documented specificity conflict.
- [x] The change is limited to the affected navigation hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to custom CSS guidance; no runtime or product code affected.
> 
> **Overview**
> Updates the **Topbar navigation** element-selector docs for `nav-logo` so custom sizing guidance matches how the logo is rendered in the template.
> 
> The `nav-logo` entry now states it applies to the **logo image**, explains that default size utilities need **`img.nav-logo` with `!important`**, and adds a short **CSS example** (`height: 3.75rem`, `width: auto`) for overriding Tailwind height while keeping aspect ratio. Closes #6242.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de42626a7d90c8edd46518b71f0d3e92c6b88a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->