### PR TITLE
docs: explain escaping pipes in tables

### DIFF
--- a/create/list-table.mdx
+++ b/create/list-table.mdx
@@ -78,6 +78,20 @@ To add a table, use three or more hyphens (`---`) to create each column's header
 | Joined   | Whether the user joined the community |
 ```
 
+### Escape pipe characters
+
+To include a literal pipe character (`|`) in a table cell, prefix it with a backslash (`\|`). Escape pipe characters even when they appear inside inline code. Otherwise, the pipe is treated as a column separator and can cause parsing errors during preview or validation.
+
+| Value         | Description                       |
+| ------------- | --------------------------------- |
+| `read\|write` | A value containing a literal pipe |
+
+```mdx
+| Value         | Description                       |
+| ------------- | --------------------------------- |
+| `read\|write` | A value containing a literal pipe |
+```
+
 ### Column alignment
 
 Use colons in the separator row to align column content:


### PR DESCRIPTION
## Documentation changes

Adds an **Escape pipe characters** section to the tables guide. It explains that literal pipe characters in table cells must be escaped, including pipes inside inline code, and provides both a rendered example and its MDX source.

Related to #2749. This documentation change does not modify CLI diagnostics; it documents one reproducible cause of parsing errors and the correct workaround.

---

## For Reviewers

### ✅ Technical accuracy
- [x] Code examples work as written
- [x] Commands and configurations are correct
- [x] Links resolve to the right destinations
- [x] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [x] Instructions are clear and easy to follow
- [x] Steps are in logical order
- [x] Nothing important is missing
- [x] Examples help illustrate the concepts

### ✅ User experience
- [x] A new user could follow these docs successfully
- [x] Common gotchas or edge cases are addressed
- [x] Error messages or troubleshooting guidance is helpful

## Validation

- `mint validate --telemetry=false`
- Local Mintlify preview confirmed that `read\|write` in the source renders as `read|write`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to a single MDX page with no runtime or tooling changes.
> 
> **Overview**
> Adds an **Escape pipe characters** subsection to the lists-and-tables guide (`create/list-table.mdx`), placed before column alignment.
> 
> It documents that literal `|` in table cells must be written as `\|`, including inside inline code, because unescaped pipes are parsed as column separators and can break preview or validation. The section includes a live example (`read\|write`) and matching MDX source block.
> 
> This is documentation only (related to #2749); no CLI or parser behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8853dc463b79bf1f632c9be389ef9c2e0058b77c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->