### PR TITLE
Reread Arthur's feedback: cut step 7, restore Getting help

### DIFF
--- a/poc-onboarding.mdx
+++ b/poc-onboarding.mdx
@@ -23,8 +23,7 @@ Complete these steps in order:
 | 4. Publish a change | Verify your writing and review workflow. |
 | 5. Apply branding | Match the site to your product. |
 | 6. Test AI features | Evaluate assistant answers and one AI workflow. |
-| 7. Review IT and security requirements | Confirm authentication and compliance requirements. |
-| 8. Review results | Compare the POC against your success criteria. |
+| 7. Review results | Compare the POC against your success criteria. |
 
 Your repository remains the source of truth. The dashboard lets you edit, configure, and publish the `.mdx` files and `docs.json` configuration in that repository. Your live site displays the published result.
 
@@ -37,7 +36,7 @@ Your repository remains the source of truth. The dashboard lets you edit, config
 | Documentation owner | Runs the POC and completes most steps. | A few hours total |
 | GitHub administrator | Approves the Mintlify GitHub App. | 15 minutes |
 | Designer or brand owner | Provides logos, colors, and fonts. | 30 minutes |
-| Identity or IT administrator | Configures authentication and DNS, if required. | 1 to 2 hours |
+| Identity or IT administrator | Configures DNS for a custom domain, if you test authentication. | 1 to 2 hours |
 
 ### Gather your content and brand assets
 
@@ -103,7 +102,7 @@ Share the goal, baseline, and criteria with your AE or SE.
   </Step>
 </Steps>
 
-Use the `.mintlify.site` URL during the POC unless you need to test authentication. Authentication requires a custom domain or `*.mintlify.app` subdomain.
+Use the `.mintlify.site` URL during the POC unless you need to test authentication. Authentication requires a [custom domain](/customize/custom-domain) or `*.mintlify.app` subdomain, and does not work on a custom basepath such as `yourcompany.com/docs`.
 
 ## Step 2: Invite your team
 
@@ -282,55 +281,7 @@ Choose the workflow most relevant to your evaluation:
   </Accordion>
 </AccordionGroup>
 
-## Step 7: Review IT and security requirements
-
-Bring your IT or security team into the POC before the final review.
-
-<Warning>
-  Site authentication does not work on the default `.mintlify.site` URL or on a custom basepath such as `yourcompany.com/docs`. Use a custom domain or `*.mintlify.app` subdomain.
-</Warning>
-
-### Control dashboard access
-
-Evaluate the controls your team requires:
-
-- [Single sign-on](/dashboard/sso) with SAML or OIDC.
-- [SCIM provisioning](/dashboard/scim).
-- [Network access policies](/dashboard/network-access).
-- [Audit logs](/dashboard/audit-logs) and [session security](/dashboard/session-security).
-
-### Control documentation access
-
-Configure [authentication](/deploy/authentication-setup) for your readers:
-
-- **Password:** Quick access control for a POC.
-- **Mintlify-managed access:** Uses your dashboard organization as the user list.
-- **OAuth 2.0:** Connects to your identity provider.
-- **JWT:** Supports custom programmatic access models.
-
-Use [groups](/deploy/authentication-setup#control-access-with-groups) to restrict specific pages:
-
-```yaml
----
-title: "Production runbook"
-groups: ["engineering"]
----
-```
-
-Test with one account in the group and one account outside it.
-
-<Note>
-  `hidden: true` removes a page from navigation but does not restrict access. Use authentication and groups for access control. See [Hidden pages](/organize/hidden-pages).
-</Note>
-
-### Complete infrastructure and compliance checks
-
-- Add a [custom domain](/customize/custom-domain). Use a test subdomain during the POC.
-- Connect your [analytics platform](/integrations/analytics/overview).
-- Enable [CI checks](/deploy/ci) for links and accessibility.
-- Share [Enterprise contracting](/enterprise-contracting) with security and procurement teams.
-
-## Step 8: Review results
+## Step 7: Review results
 
 Book one hour with your decision maker. Start with the goal and baseline you defined before the POC, then review:
 
@@ -343,7 +294,6 @@ Book one hour with your decision maker. Start with the goal and baseline you def
 | Content gaps are identifiable | Unanswered and downvoted questions in [Assistant analytics](/analytics/assistant). |
 | Readers find useful content | [Traffic](/analytics/traffic), [search](/analytics/search), and [engagement](/analytics/user-engagements) data. |
 | Automated updates are useful | The automation run history and proposed change. |
-| Security requirements are met | Your IT team's review. |
 
 Resolve open questions with your AE or SE before this meeting.
 
@@ -355,7 +305,13 @@ Most POCs take two to three weeks:
 |---|---|
 | Week 1 | Connect the repository, invite your team, define success, and start the content migration. Start domain setup if you need authentication. |
 | Week 2 | Review content, publish a change, apply branding, test the assistant, and evaluate one AI workflow. |
-| Week 3 | Complete the IT and security review, then review the results with your decision maker. |
+| Week 3 | Review the results with your decision maker. |
+
+## Getting help
+
+- Contact your AE or SE for time-sensitive POC questions.
+- Email [support@mintlify.com](mailto:support@mintlify.com) for other questions.
+- See [Advanced support](/advanced-support) for post-POC support options.
 
 ## After the POC
 


### PR DESCRIPTION
Corrects #7085, which merged the wrong reading of Arthur's Slack review.

## Why

Two lines in Arthur's thread sat between a screenshot of **Getting help** and a screenshot of the **step 7** row:

> here it should contact your AE and SE
> usually this is implied, i think we can remove it

#7085 read "we can remove it" as attaching to the screenshot above it, so it cut Getting help and kept step 7. A wider crop of the thread makes the other reading more likely: the line is a lead-in to the step 7 screenshot that follows it. This PR flips both.

## Changes

- **Step 7, Review IT and security requirements** — removed. Review results renumbers from step 8 to step 7.
- **Getting help** — restored, with the first bullet pointing at the AE and SE rather than a shared Slack channel.

Everything else from #7085 stays as merged: the decision maker row is still out of the participants table, the value drivers framing and the engineering-time-saved driver stay, and AE/SE terminology stays throughout.

## Knock-on edits

Removing step 7 orphaned several references:

- The "Security requirements are met" row is out of the results table.
- Week 3 of the timeline no longer mentions an IT and security review.
- The [custom domain](/customize/custom-domain) link moved into step 1, now the only place stating that authentication needs one. Step 1 also picked up the custom-basepath caveat from the deleted step 7 warning.
- The IT administrator's responsibility reads "Configures DNS for a custom domain, if you test authentication" rather than "Configures authentication and DNS".

## What this drops

A lot of surface area, so worth a deliberate look before merging: SSO, SCIM, network access policies, audit logs, session security, the four authentication methods, group-based page access with the `groups` frontmatter example, the "hidden is not private" note, the analytics platform link, CI checks, and the Enterprise contracting pointer.

The authentication domain requirement survives in step 1. Everything else listed above is now absent from the page.

If Arthur only meant the security *review* is implied rather than the whole step, a trimmed step 7 keeping the authentication and groups mechanics would be the middle option. Worth one line to him before this merges.

## Verification

`mint broken-links` and `mint a11y` both clean. Workflow table and section headings match one-for-one across all seven steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only POC onboarding edits with no product or security behavior changes; the page no longer surfaces several enterprise security links that were in the removed step.
> 
> **Overview**
> **Reverses the prior misread of review feedback** by dropping the dedicated **Step 7: Review IT and security requirements** (SSO/SCIM, reader auth, groups, compliance links, etc.) and folding the POC back to **seven steps**, with **Review results** as step 7 instead of step 8.
> 
> **Restores a Getting help** section (AE/SE first, then support email and advanced support). The results table loses the **Security requirements are met** row; **Week 3** of the timeline is only the decision-maker review. **Step 1** now carries the authentication domain note—custom domain or `*.mintlify.app`, not custom basepaths—and the IT admin participant row is scoped to **DNS for a custom domain when testing auth**, not full auth setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eb9a126e952e1829503c3f6810e81d15dff886e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->