### PR TITLE
docs: explain generated llms index routes

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -65,7 +65,7 @@ For example, a large site might link to the following generated index:
 - [API reference](https://docs.example.com/_llms/api-reference.md)
 ```
 
-Agents should follow these index links recursively until they reach documentation page links. The generated files are part of `llms.txt`; they are different from `llms-full.txt` and do not need to exist in your repository.
+Agents should follow these index links recursively until they reach documentation page links. The generated files are part of `llms.txt` and do not need to exist in your repository. They are separate from `llms-full.txt`.
 
 The `/_llms/` route uses the same base path as your documentation:
 

--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -55,11 +55,28 @@ Both `llms.txt` and `llms-full.txt` list pages from your default language and de
 
 This structured approach allows LLMs to efficiently process your documentation at a high level and locate relevant content for user queries, improving the accuracy and speed of AI-assisted documentation searches.
 
-<Note>
-  Automatically generated `llms.txt` index files cannot exceed 100,000 characters. For large documentation sites, Mintlify splits the index into linked files under `/_llms/` so agents can discover every page without loading one oversized file. This limit does not apply to `llms-full.txt`.
-</Note>
+## Split indexes under `/_llms`
 
-If you use a reverse proxy or maintain a path allowlist, forward `/_llms/*` in addition to `/llms.txt` so agents can follow the generated index links. For documentation hosted at a base path, forward `<base-path>/_llms/*` instead. Mintlify-managed custom domains do not require additional configuration. See [Reverse proxy](/deploy/reverse-proxy#routing-configuration) for routing guidance.
+Automatically generated `llms.txt` index files cannot exceed 100,000 characters. When an index is larger than this limit, Mintlify keeps the main `llms.txt` file as a directory and moves groups of page links into generated Markdown files under `/_llms/`. This limit does not apply to `llms-full.txt`.
+
+For example, a large site might link to the following generated index:
+
+```mdx
+- [API reference](https://docs.example.com/_llms/api-reference.md)
+```
+
+Agents should follow these index links recursively until they reach documentation page links. The generated files are part of `llms.txt`; they are different from `llms-full.txt` and do not need to exist in your repository.
+
+The `/_llms/` route uses the same base path as your documentation:
+
+- A root-hosted site serves an index at `https://docs.example.com/_llms/api-reference.md`.
+- A site hosted at `/docs` serves it at `https://example.com/docs/_llms/api-reference.md`.
+
+If you use a reverse proxy or path allowlist, forward the generated route in addition to `llms.txt`. A broad `<base-path>/*` rule already includes `<base-path>/_llms/*`. With granular rules, add `<base-path>/_llms/*` explicitly. See [Reverse proxy](/deploy/reverse-proxy#routing-configuration) for routing guidance.
+
+<Warning>
+  A directory such as `/docs` in your repository does not set your site's public base path. Configure the base path in your Mintlify dashboard and use the same prefix in your reverse proxy. Otherwise, `llms.txt` can be reachable at the public prefix while its generated `/_llms/` links point somewhere else.
+</Warning>
 
 ```mdx Example llms.txt
 # Site title

--- a/deploy/reverse-proxy.mdx
+++ b/deploy/reverse-proxy.mdx
@@ -14,6 +14,8 @@ When you implement a reverse proxy, monitor for potential issues with domain ver
 
 Set your base path on the [Custom domain setup](https://app.mintlify.com/settings/deployment/custom-domain) page in your dashboard. Then configure your reverse proxy to route that path to Mintlify. The default base path is `/docs`, but you can use any base path you choose, like `/help` or `/resources`.
 
+The directory that contains your documentation in your repository does not configure the public base path. For example, storing documentation under a `/docs` directory does not replace setting `/docs` as the base path in your dashboard.
+
 In all configurations, use `mintlify.site` as the proxy target.
 
 ## Host at `/docs` subpath
@@ -40,6 +42,7 @@ Proxy these paths to your Mintlify subdomain:
 | --------------------------------- | ------------------------------------ | -------- |
 | `/docs`                           | `<your-subdomain>.mintlify.site/docs` | No cache |
 | `/docs/*`                         | `<your-subdomain>.mintlify.site/docs/*` | No cache |
+| `/docs/_llms/*`                   | `<your-subdomain>.mintlify.site/docs/_llms/*` | No cache |
 | `/.well-known/vercel/*`           | `<your-subdomain>.mintlify.site/.well-known/vercel/*` | No cache |
 | `/.well-known/skills/*` (optional)        | `<your-subdomain>.mintlify.site/docs/.well-known/skills/*` | No cache |
 | `/.well-known/agent-skills/*` (optional)  | `<your-subdomain>.mintlify.site/docs/.well-known/agent-skills/*` | No cache |
@@ -52,6 +55,8 @@ Your proxy must forward all HTTP methods on documentation paths. Mintlify sends 
 Mintlify serves these files under your base path, like `<your-subdomain>.mintlify.site/docs/llms.txt`. They are available on your domain under your subpath, like `your-domain.com/docs/llms.txt`, through your main subpath route.
 
 The `/docs/*` route also covers generated `llms.txt` indexes under `/docs/_llms/*`. If your proxy uses a more granular path allowlist instead of forwarding all `/docs/*` requests, include `/docs/_llms/*` so agents can follow every index linked from `/docs/llms.txt`.
+
+Do not rewrite only `/docs/llms.txt` to a root-hosted `/llms.txt`. Set `/docs` as the deployment base path and forward the full `/docs/*` route. This keeps page links and generated `/docs/_llms/*` index links on the same public prefix.
 
 The `/.well-known/skills/*`, `/.well-known/agent-skills/*`, `/skill.md`, `/llms.txt`, and `/llms-full.txt` routes are optional. Include them only if you also want to serve these files at root paths on your domain, like `your-domain.com/llms.txt`. Each root path maps to the file under your base path on your Mintlify subdomain.
 
@@ -203,6 +208,18 @@ Configure your reverse proxy using the same [routing configuration](#routing-con
 
 - Remove `Host` header forwarding.
 - Set the `Origin` header to your Mintlify subdomain (`<your-subdomain>.mintlify.site`).
+
+### Generated `/_llms/` links return 404
+
+**Symptoms**: Your `llms.txt` file loads, but links under `/_llms/` return 404 or omit your public subpath.
+
+**Cause**: The public subpath does not match the base path configured in Mintlify, or the proxy only forwards `llms.txt` and not its generated index routes.
+
+**Solution**:
+
+- Set the public subpath as the base path in your Mintlify dashboard. A repository directory with the same name does not configure it.
+- Forward the full `<base-path>/*` route, or add `<base-path>/_llms/*` to a granular allowlist.
+- Redeploy your documentation, then verify both `<base-path>/llms.txt` and one linked `<base-path>/_llms/*.md` URL.
 
 ### Performance issues
 


### PR DESCRIPTION
## Summary

- add a dedicated section for generated `/_llms/*.md` indexes with root and base-path examples
- clarify that repository directories do not configure the public base path
- make the nested proxy route explicit and add troubleshooting for missing prefixes and 404s

## Validation

- `git diff --check`
- `mint broken-links`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to llms.txt and reverse-proxy guides; no application or security logic changes.
> 
> **Overview**
> Expands how Mintlify splits oversized `llms.txt` indexes into generated Markdown under **`/_llms/`**, including recursive discovery for agents, root vs subpath URL examples, and reverse-proxy / allowlist guidance.
> 
> **Reverse proxy** docs now state explicitly that a repo folder (e.g. `/docs`) is not the public base path, add **`/docs/_llms/*`** to the routing table, warn against rewriting only `llms.txt` off the configured prefix, and add troubleshooting when `/_llms/` links 404 or drop the subpath.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfaa37f20223e7333e098704d628307b57f38ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->