### PR TITLE
Mintlify MDX extension

### DIFF
--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -346,7 +346,7 @@ PostgreSQL
 Postman
 PowerShell
 PR
-prefetching
+(?i)prefetch(es|ed|ing)?
 prefill(s|ing|ed)?
 preloaded
 prepend(ed|ing)?

--- a/cli/index.mdx
+++ b/cli/index.mdx
@@ -54,6 +54,6 @@ Run `mint config` to set persistent defaults like your documentation subdomain.
 ## Next steps
 
 - [Install the CLI](/cli/install): Get the CLI installed and ready to use.
-- [VS Code extension](/cli/vs-code-extension): Add autocomplete, inline error checking, and an in-editor preview.
+- [Mintlify MDX extension](/cli/mdx-extension): Add autocomplete, inline error checking, and an in-editor preview.
 - [Preview locally](/cli/preview): Run a local development server with search and assistant support.
 - [Commands](/cli/commands): Complete reference for all commands and flags.

--- a/cli/index.mdx
+++ b/cli/index.mdx
@@ -54,5 +54,6 @@ Run `mint config` to set persistent defaults like your documentation subdomain.
 ## Next steps
 
 - [Install the CLI](/cli/install): Get the CLI installed and ready to use.
+- [VS Code extension](/cli/vs-code-extension): Add autocomplete, inline error checking, and an in-editor preview.
 - [Preview locally](/cli/preview): Run a local development server with search and assistant support.
 - [Commands](/cli/commands): Complete reference for all commands and flags.

--- a/cli/install.mdx
+++ b/cli/install.mdx
@@ -117,7 +117,7 @@ If `mint update` is not available on your version, reinstall the CLI with the la
 
 For syntax highlighting, autocomplete, and error checking in MDX files, use the following extensions:
 
-- **Cursor, Devin Desktop, VS Code**: [Mintlify MDX extension](/cli/vs-code-extension) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for formatting.
+- **Cursor, Devin Desktop, VS Code**: [Mintlify MDX extension](/cli/mdx-extension) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for formatting.
 - **JetBrains**: [MDX IntelliJ IDEA plugin](https://plugins.jetbrains.com/plugin/14944-mdx) and [Prettier](https://prettier.io/docs/webstorm).
 
 You can also format MDX files with [`mint format`](/cli/commands#mint-format).

--- a/cli/install.mdx
+++ b/cli/install.mdx
@@ -113,12 +113,14 @@ If `mint update` is not available on your version, reinstall the CLI with the la
   ```
 </CodeGroup>
 
-## Formatting
+## Editor support
 
-For syntax highlighting and code formatting in MDX files, use the following extensions:
+For syntax highlighting, autocomplete, and error checking in MDX files, use the following extensions:
 
-- **Cursor, Devin Desktop, VS Code**: [MDX VS Code extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- **JetBrains**: [MDX IntelliJ IDEA plugin](https://plugins.jetbrains.com/plugin/14944-mdx) and [Prettier](https://prettier.io/docs/webstorm)
+- **Cursor, Devin Desktop, VS Code**: [Mintlify MDX extension](/cli/vs-code-extension) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for formatting.
+- **JetBrains**: [MDX IntelliJ IDEA plugin](https://plugins.jetbrains.com/plugin/14944-mdx) and [Prettier](https://prettier.io/docs/webstorm).
+
+You can also format MDX files with [`mint format`](/cli/commands#mint-format).
 
 ## Troubleshooting
 

--- a/cli/mdx-extension.mdx
+++ b/cli/mdx-extension.mdx
@@ -1,7 +1,7 @@
 ---
-title: "VS Code extension"
+title: "Mintlify MDX extension"
 description: "Install the Mintlify MDX extension for autocomplete, inline diagnostics, hover documentation, and an in-editor preview while you write MDX locally."
-keywords: ["VS Code", "extension", "Cursor", "MDX", "autocomplete", "diagnostics", "IntelliSense", "preview", "editor"]
+keywords: ["Cursor", "MDX", "autocomplete", "diagnostics", "IntelliSense", "preview", "editor"]
 ---
 
 The Mintlify MDX extension adds language support for Mintlify projects to VS Code. It knows every built-in component and its properties, so you get autocomplete as you type, and it reports unknown components, invalid properties, and unresolved snippet imports directly in your editor instead of when your build fails.

--- a/cli/mdx-extension.mdx
+++ b/cli/mdx-extension.mdx
@@ -4,11 +4,9 @@ description: "Install the Mintlify MDX extension for autocomplete, inline diagno
 keywords: ["Cursor", "MDX", "autocomplete", "diagnostics", "IntelliSense", "preview", "editor"]
 ---
 
-The Mintlify MDX extension adds language support for Mintlify projects to VS Code. It knows every built-in component and its properties, so you get autocomplete as you type, and it reports unknown components, invalid properties, and unresolved snippet imports directly in your editor instead of when your build fails.
+The Mintlify MDX extension adds language support for Mintlify projects to VS Code, Cursor, Devin Desktop, and other editors that support the VS Code extension API. The extension knows every built-in component and property, so you get autocomplete as you type, and it reports unknown components, invalid properties, and unresolved snippet imports.
 
 The extension also runs a live preview inside your editor, so you can write and see rendered output without switching to a browser.
-
-The extension works in VS Code and in editors built on it, including Cursor.
 
 ## Prerequisites
 
@@ -28,21 +26,17 @@ Or install from within your editor:
 
 1. Open the Extensions view.
 2. Search for `@id:mintlify.mintlify-snippets`.
-3. Select **Install**.
+3. Click **Install**.
 
 You can also install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=mintlify.mintlify-snippets).
-
-<Note>
-  The marketplace lists the extension as **Mintlify MDX**, but its identifier is `mintlify.mintlify-snippets` because it started as a snippets-only extension. Searching for "Mintlify" also returns several older extensions for unrelated products, so match the identifier to confirm you have the right one.
-</Note>
 
 The extension activates when you open an `.mdx` file or a workspace containing a `docs.json` file.
 
 ## Autocomplete
 
-Type `<` to see every built-in component. Inside a tag, autocomplete suggests that component's properties, and enumerated values for properties that accept a fixed set of options, like `<Badge color="...">`. Type `</` to close the nearest open tag.
+Type `<` to view every built-in component. Autocomplete suggests components' properties and values inside tags.
 
-Components that you import from [reusable snippets](/create/reusable-snippets) are suggested alongside built-in ones.
+The extension suggests components that you import from [reusable snippets](/create/reusable-snippets) alongside built-in ones.
 
 ## Diagnostics
 
@@ -55,7 +49,7 @@ The extension reports problems in the Problems panel and underlines them in your
 - Unclosed or mismatched tags.
 - Unresolved snippet imports.
 
-These are the same classes of error that cause a build to fail, so fixing them as you write avoids a round trip through a failed deployment.
+These classes of error cause build failures, so fix them as you write to avoid failed deployments.
 
 To turn diagnostics off, set `mintlify.diagnostics.enabled` to `false`.
 
@@ -65,7 +59,7 @@ Hover over a component or property to see what it does and a link to its page in
 
 ## Go to definition
 
-`Cmd/Ctrl+click` navigates to the definition of:
+Hold <kbd>CMD</kbd> (macOS) or <kbd>CTRL</kbd> (Windows) and click to navigate to the definition of:
 
 - Snippet components.
 - Import paths.
@@ -75,13 +69,13 @@ The extension finds your docs root by walking up from the open file until it fin
 
 ## Configuration validation
 
-The extension validates `docs.json` against the [Mintlify schema](https://mintlify.com/docs.json), which gives you autocomplete and inline errors for configuration properties. You do not need to add a `$schema` property to your `docs.json` file for this to work in your editor.
+The extension validates `docs.json` against the [Mintlify schema](https://mintlify.com/docs.json).
 
 ## Preview in your editor
 
-Open an `.mdx` file and select the preview icon in the editor title bar, or right-click the file and select **Preview Mintlify**. A preview panel opens beside your editor and renders the page. As you scroll, the preview follows to the heading nearest the top of your editor.
+Open an `.mdx` file and select the preview icon in the editor title bar, or right-click the file and select **Preview Mintlify**. A preview panel opens beside your editor and renders the page.
 
-The preview runs `mint dev` in the background, so it needs the [Mintlify CLI](/cli/install) installed. Because `mint dev` executes your project's code, you must trust the workspace. The URL of the running server appears in the status bar. Select it to stop the server, or run **Mintlify: Stop preview server**.
+In-editor previews require the [Mintlify CLI](/cli/install). The URL of the running server appears in the status bar. Select it to stop the server, or run **Mintlify: Stop preview server**.
 
 To see the output of the underlying `mint dev` process, open the **Mintlify Preview** output channel.
 
@@ -95,15 +89,13 @@ The extension includes snippets that wrap selected text in a component, rather t
 
 To use them, select the content you want to wrap, then run **Snippets: Surround With** from the command palette and choose a component. Snippets are available for `AccordionGroup`, `CardGroup`, `CodeGroup`, `Expandable`, `Frame`, `RequestExample`, `ResponseExample`, and fenced code blocks.
 
-Because these snippets wrap a selection, typing the component name in your file inserts an empty component instead.
-
 ## Settings
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `mintlify.diagnostics.enabled` | `true` | Report unknown components, unknown properties, missing required properties, and unresolved snippet imports. |
-| `mintlify.warnAboutConflictingExtensions` | `true` | Warn when you have another MDX extension installed alongside this one. |
-| `mintlify.preview.command` | `mint dev --no-open` | Command used to start the preview server, run from your docs root. |
+| `mintlify.warnAboutConflictingExtensions` | `true` | Warn when you have another MDX extension installed alongside the Mintlify MDX extension. |
+| `mintlify.preview.command` | `mint dev --no-open` | Command used to start the preview server, run from your project root. |
 | `mintlify.preview.followScroll` | `true` | Scroll the preview to the heading nearest the top of your editor. |
 
 `mintlify.preview.command` is a user setting, so a workspace cannot override it. This prevents a cloned repository from running an arbitrary command on your machine when you open a preview.
@@ -122,9 +114,9 @@ Run these from the command palette:
 
 ## Conflicting extensions
 
-Other MDX extensions provide their own syntax highlighting and language features for `.mdx` files, which conflict with this extension. If you have one installed in a Mintlify project, the extension prompts you to disable it. Disable other MDX extensions to avoid duplicate suggestions and inconsistent highlighting.
+Other MDX extensions provide their own syntax highlighting and language features for `.mdx` files, which conflict with this extension. Disable other MDX extensions to avoid duplicate suggestions and inconsistent highlighting.
 
-For code formatting, use [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) alongside this extension, or run [`mint format`](/cli/commands#mint-format).
+For code formatting, use [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) alongside this extension or run [`mint format`](/cli/commands#mint-format).
 
 ## Troubleshooting
 

--- a/cli/preview.mdx
+++ b/cli/preview.mdx
@@ -32,7 +32,7 @@ npx mint dev
 ```
 
 <Tip>
-  If you write in VS Code or Cursor, the [Mintlify MDX extension](/cli/vs-code-extension) runs this preview in a panel beside your editor and scrolls it to match the page you are editing.
+  If you write in VS Code or Cursor, the [Mintlify MDX extension](/cli/mdx-extension) runs this preview in a panel beside your editor and scrolls it to match the page you are editing.
 </Tip>
 
 ## Log in for search and assistant

--- a/cli/preview.mdx
+++ b/cli/preview.mdx
@@ -31,6 +31,10 @@ To generate a preview without installing the CLI globally, run:
 npx mint dev
 ```
 
+<Tip>
+  If you write in VS Code or Cursor, the [Mintlify MDX extension](/cli/vs-code-extension) runs this preview in a panel beside your editor and scrolls it to match the page you are editing.
+</Tip>
+
 ## Log in for search and assistant
 
 You must authenticate the CLI with your Mintlify account to enable search and the [assistant](/assistant/index).

--- a/cli/vs-code-extension.mdx
+++ b/cli/vs-code-extension.mdx
@@ -1,0 +1,151 @@
+---
+title: "VS Code extension"
+description: "Install the Mintlify MDX extension for autocomplete, inline diagnostics, hover documentation, and an in-editor preview while you write MDX locally."
+keywords: ["VS Code", "extension", "Cursor", "MDX", "autocomplete", "diagnostics", "IntelliSense", "preview", "editor"]
+---
+
+The Mintlify MDX extension adds language support for Mintlify projects to VS Code. It knows every built-in component and its properties, so you get autocomplete as you type, and it reports unknown components, invalid properties, and unresolved snippet imports directly in your editor instead of when your build fails.
+
+The extension also runs a live preview inside your editor, so you can write and see rendered output without switching to a browser.
+
+The extension works in VS Code and in editors built on it, including Cursor.
+
+## Prerequisites
+
+- VS Code 1.85.0 or newer
+- A documentation directory with a valid `docs.json` file
+- The [Mintlify CLI](/cli/install), for the in-editor preview only
+
+## Install the extension
+
+Install from the command line:
+
+```bash
+code --install-extension mintlify.mintlify-snippets
+```
+
+Or install from within your editor:
+
+1. Open the Extensions view.
+2. Search for `@id:mintlify.mintlify-snippets`.
+3. Select **Install**.
+
+You can also install from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=mintlify.mintlify-snippets).
+
+<Note>
+  The marketplace lists the extension as **Mintlify MDX**, but its identifier is `mintlify.mintlify-snippets` because it started as a snippets-only extension. Searching for "Mintlify" also returns several older extensions for unrelated products, so match the identifier to confirm you have the right one.
+</Note>
+
+The extension activates when you open an `.mdx` file or a workspace containing a `docs.json` file.
+
+## Autocomplete
+
+Type `<` to see every built-in component. Inside a tag, autocomplete suggests that component's properties, and enumerated values for properties that accept a fixed set of options, like `<Badge color="...">`. Type `</` to close the nearest open tag.
+
+Components that you import from [reusable snippets](/create/reusable-snippets) are suggested alongside built-in ones.
+
+## Diagnostics
+
+The extension reports problems in the Problems panel and underlines them in your file as you write:
+
+- Unknown components.
+- Unknown or duplicate properties.
+- Invalid values for enumerated properties.
+- Missing required properties.
+- Unclosed or mismatched tags.
+- Unresolved snippet imports.
+
+These are the same classes of error that cause a build to fail, so fixing them as you write avoids a round trip through a failed deployment.
+
+To turn diagnostics off, set `mintlify.diagnostics.enabled` to `false`.
+
+## Hover documentation
+
+Hover over a component or property to see what it does and a link to its page in the Mintlify documentation. Hovering over a snippet component previews the contents of the snippet file.
+
+## Go to definition
+
+`Cmd/Ctrl+click` navigates to the definition of:
+
+- Snippet components.
+- Import paths.
+- `href` and `src` attributes that point to local pages.
+
+The extension finds your docs root by walking up from the open file until it finds `docs.json`, so absolute imports like `/snippets/example.mdx` resolve correctly. The detected project appears in the status bar. To check which root the extension is using, run **Mintlify: Show detected docs root** from the command palette.
+
+## Configuration validation
+
+The extension validates `docs.json` against the [Mintlify schema](https://mintlify.com/docs.json), which gives you autocomplete and inline errors for configuration properties. You do not need to add a `$schema` property to your `docs.json` file for this to work in your editor.
+
+## Preview in your editor
+
+Open an `.mdx` file and select the preview icon in the editor title bar, or right-click the file and select **Preview Mintlify**. A preview panel opens beside your editor and renders the page. As you scroll, the preview follows to the heading nearest the top of your editor.
+
+The preview runs `mint dev` in the background, so it needs the [Mintlify CLI](/cli/install) installed. Because `mint dev` executes your project's code, you must trust the workspace. The URL of the running server appears in the status bar. Select it to stop the server, or run **Mintlify: Stop preview server**.
+
+To see the output of the underlying `mint dev` process, open the **Mintlify Preview** output channel.
+
+<Tip>
+  Use the in-editor preview while you write individual pages, and [`mint dev`](/cli/preview) in a browser when you want to test navigation, search, or authentication across your whole site.
+</Tip>
+
+## Wrap content in components
+
+The extension includes snippets that wrap selected text in a component, rather than inserting an empty component for you to fill in.
+
+To use them, select the content you want to wrap, then run **Snippets: Surround With** from the command palette and choose a component. Snippets are available for `AccordionGroup`, `CardGroup`, `CodeGroup`, `Expandable`, `Frame`, `RequestExample`, `ResponseExample`, and fenced code blocks.
+
+Because these snippets wrap a selection, typing the component name in your file inserts an empty component instead.
+
+## Settings
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `mintlify.diagnostics.enabled` | `true` | Report unknown components, unknown properties, missing required properties, and unresolved snippet imports. |
+| `mintlify.warnAboutConflictingExtensions` | `true` | Warn when you have another MDX extension installed alongside this one. |
+| `mintlify.preview.command` | `mint dev --no-open` | Command used to start the preview server, run from your docs root. |
+| `mintlify.preview.followScroll` | `true` | Scroll the preview to the heading nearest the top of your editor. |
+
+`mintlify.preview.command` is a user setting, so a workspace cannot override it. This prevents a cloned repository from running an arbitrary command on your machine when you open a preview.
+
+## Commands
+
+Run these from the command palette:
+
+| Command | Description |
+| --- | --- |
+| **Mintlify: Preview Mintlify** | Open the preview panel for the current file. |
+| **Mintlify: Stop preview server** | Stop the running preview server. |
+| **Mintlify: Show detected docs root** | Show which `docs.json` file the extension resolved. |
+| **Mintlify: Open component docs** | Open the documentation for the component at your cursor. |
+| **Mintlify: Restart language server** | Restart the language server. |
+
+## Conflicting extensions
+
+Other MDX extensions provide their own syntax highlighting and language features for `.mdx` files, which conflict with this extension. If you have one installed in a Mintlify project, the extension prompts you to disable it. Disable other MDX extensions to avoid duplicate suggestions and inconsistent highlighting.
+
+For code formatting, use [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) alongside this extension, or run [`mint format`](/cli/commands#mint-format).
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Components are reported as unknown">
+    The extension resolves components relative to your docs root. Run **Mintlify: Show detected docs root** to confirm it found the correct `docs.json` file. If the root is wrong or missing, open the folder containing your `docs.json` file as your workspace.
+
+    If the root is correct, run **Mintlify: Restart language server**.
+  </Accordion>
+  <Accordion title="Autocomplete and highlighting behave inconsistently">
+    Another MDX extension is likely also active. Open the Extensions view, search for `mdx`, and disable any other MDX extensions in this workspace.
+  </Accordion>
+  <Accordion title="The preview fails to start">
+    Open the **Mintlify Preview** output channel to see the error from `mint dev`.
+
+    - `could not run "mint dev --no-open"`: The CLI is not installed. Install it with `npm i -g mint`.
+    - `Trust the workspace first`: Trust the workspace through **Manage Workspace Trust**.
+    - `no docs.json found above this file`: Open the folder containing your `docs.json` file as your workspace.
+    - `Invalid docs.json`: Run [`mint validate`](/cli/commands#mint-validate) to find the configuration error.
+  </Accordion>
+  <Accordion title="Snippet imports are reported as unresolved">
+    Absolute import paths resolve from your docs root, not from your file. Confirm the path matches the location of the snippet file relative to your `docs.json` file, and that the detected root is correct.
+  </Accordion>
+</AccordionGroup>

--- a/docs.json
+++ b/docs.json
@@ -37,6 +37,7 @@
                     "root": "cli/index",
                     "pages": [
                       "cli/install",
+                      "cli/vs-code-extension",
                       "cli/preview",
                       "cli/commands"
                     ]


### PR DESCRIPTION
## Documentation changes

documents new Mintlify MDX extension

Closes https://linear.app/mintlify/issue/DOC-424/document-new-mintlify-mdx-vs-code-extension

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime impact; verify `docs.json` nav slug matches `cli/mdx-extension` so the new page is reachable.
> 
> **Overview**
> Adds a new **Mintlify MDX extension** page (`cli/mdx-extension.mdx`) covering install, autocomplete, diagnostics, hover docs, go-to-definition, `docs.json` validation, in-editor preview via `mint dev`, surround-with snippets, settings/commands, conflicting extensions, and troubleshooting.
> 
> Updates the CLI docs to point authors at that extension instead of the generic MDX VS Code plugin: **Editor support** on install, a **Next steps** link on the CLI index, and a **Tip** on local preview describing the side-by-side editor preview.
> 
> Expands the Vale allowlist so **prefetch** inflections pass spellcheck.
> 
> **Reviewer note:** `docs.json` still registers `cli/vs-code-extension` while the new page slug is `cli/mdx-extension`—confirm nav resolves or align the path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebce22eb2b6308ca1a6c867b359fb550412ecf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->