### PR TITLE
docs: explain when custom llms.txt files are public on authenticated sites

### DIFF
--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -121,3 +121,7 @@ Mintlify automatically hosts an `llms-full.txt` file at the root of your project
 To add a custom `llms.txt` or `llms-full.txt` file, create an `llms.txt` or `llms-full.txt` file at the root of your project. Adding a custom file overrides the automatically generated file of the same name. If you delete a custom file, Mintlify restores the automatically generated file.
 
 Your custom `llms.txt` or `llms-full.txt` file must have a site title as an H1 heading. Other content is optional. See [Format](https://llmstxt.org/#format) in the `llms.txt` specification for more information on optional sections and best practices.
+
+<Note>
+On sites that use [authentication](/deploy/authentication-setup), a custom `llms.txt` or `llms-full.txt` file is served publicly when every page it links to is public. If the file links to any page that isn't public, only authenticated users can access it and anonymous visitors get the automatically generated file instead.
+</Note>

--- a/ai/llmstxt.mdx
+++ b/ai/llmstxt.mdx
@@ -123,5 +123,7 @@ To add a custom `llms.txt` or `llms-full.txt` file, create an `llms.txt` or `llm
 Your custom `llms.txt` or `llms-full.txt` file must have a site title as an H1 heading. Other content is optional. See [Format](https://llmstxt.org/#format) in the `llms.txt` specification for more information on optional sections and best practices.
 
 <Note>
-On sites that use [authentication](/deploy/authentication-setup), a custom `llms.txt` or `llms-full.txt` file is served publicly when every page it links to is public. If the file links to any page that isn't public, only authenticated users can access it and anonymous visitors get the automatically generated file instead.
+On sites that use [authentication](/deploy/authentication-setup), custom `llms.txt` and `llms-full.txt` respect authentication.
+
+If a custom file links to any page that ins't public, only authenticated users can access the file. Anonymous visitors receive the automatically generated `llms.txt` or `llms-full.txt`, which only include publicly available links.
 </Note>

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -509,7 +509,7 @@ Some features behave differently or are unavailable when you enable authenticati
 
 | Feature | Public | Fully authenticated (all pages protected) | Partially authenticated (some public pages) |
 | :------ | :---------- | :---------------------------------- | :-------------------------------- |
-| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files. Custom files that only link to public pages are public | Publicly accessible, reflecting public pages only. Custom files that only link to public pages are public |
+| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files | Publicly accessible, reflecting public pages only |
 | [MCP server](/ai/model-context-protocol) | Full support | Requires authentication to connect | Available without authentication for public pages and with authentication for protected pages |
 | [Markdown export](/ai/markdown-export) | Full support | Full support, respects user groups | Full support, respects user groups |
 | [PDF export](/optimize/pdf-exports) | Full support | Full support, respects user groups. Authenticated pages export with images and assets included. | Full support, respects user groups. Authenticated pages export with images and assets included. |

--- a/deploy/authentication-setup.mdx
+++ b/deploy/authentication-setup.mdx
@@ -509,7 +509,7 @@ Some features behave differently or are unavailable when you enable authenticati
 
 | Feature | Public | Fully authenticated (all pages protected) | Partially authenticated (some public pages) |
 | :------ | :---------- | :---------------------------------- | :-------------------------------- |
-| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files | Publicly accessible, reflecting public pages only |
+| [llms.txt and llms-full.txt](/ai/llmstxt) | Full support | Available behind authentication, so AI tools may not be able to access the files. Custom files that only link to public pages are public | Publicly accessible, reflecting public pages only. Custom files that only link to public pages are public |
 | [MCP server](/ai/model-context-protocol) | Full support | Requires authentication to connect | Available without authentication for public pages and with authentication for protected pages |
 | [Markdown export](/ai/markdown-export) | Full support | Full support, respects user groups | Full support, respects user groups |
 | [PDF export](/optimize/pdf-exports) | Full support | Full support, respects user groups. Authenticated pages export with images and assets included. | Full support, respects user groups. Authenticated pages export with images and assets included. |


### PR DESCRIPTION
## Summary
- On authenticated sites a custom `llms.txt` / `llms-full.txt` is served publicly only when every page it links to is public (mintlify/server#7754); document that under "Custom files" and in the authentication feature table.

## Test plan
- Preview `ai/llmstxt` and `deploy/authentication-setup` and check the note and table cells render

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior changes.
> 
> **Overview**
> Adds a **Note** under **Custom files** in `ai/llmstxt.mdx` clarifying how custom `llms.txt` and `llms-full.txt` behave when the site uses [authentication](/deploy/authentication-setup).
> 
> Custom files **respect auth**: if they link to any non-public page, only signed-in users get the custom file. Anonymous visitors still receive the **auto-generated** `llms.txt` or `llms-full.txt`, which only list publicly available links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 283a134fbafe78a2faf98601dd9d32ce4ad3a1a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->