### PR TITLE
Add search MCP card to quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -199,6 +199,10 @@ Find your exact URL on the **Overview** page of your [dashboard](https://app.min
   Edit documentation in your browser and preview how your pages look when published.
 </Card>
 
+<Card title="Connect the ssearch MCP" icon="search" horizontal href="/ai/model-context-protocol">
+  Connect AI tools like Claude, Cursor, and ChatGPT to your search MCP server so they can efficiently search and retrieve content from your site.
+</Card>
+
 <Card title="Explore CLI commands" icon="terminal" horizontal href="/cli/index">
   Find broken links, check accessibility, validate OpenAPI specs, and more.
 </Card>


### PR DESCRIPTION
## Documentation changes

Brief description of what's being updated

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only navigation change with no runtime or security impact; verify the card title typo before merge.
> 
> **Overview**
> Adds a **Next steps** card on the quickstart page that points readers to `/ai/model-context-protocol` for wiring Claude, Cursor, ChatGPT, and similar tools to the hosted **search MCP** server.
> 
> The new card sits between the web editor and CLI next-step cards and reuses the same horizontal `Card` pattern as the other links.
> 
> **Note:** The card title in the diff reads **"Connect the ssearch MCP"**, which looks like a typo versus the docs’ **Search MCP** naming on the destination page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbd76994b0ed2f1aee5f24168a522618a5d7368c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->