### PR TITLE
docs: add content upload step to go-live checklist

### DIFF
--- a/migration-services/go-live-checklist.mdx
+++ b/migration-services/go-live-checklist.mdx
@@ -8,6 +8,7 @@ Use this checklist to set up configurations and validate settings before going l
 
 ## Core setup
 
+- **Add content to your repo.** If using Mintlify's migration services, upload the zip of the content to your repository.
 - **Connect your docs repo to Mintlify.** Install the [GitHub App](/deploy/github), connect your [GitLab repository](/deploy/gitlab), or connect your [Bitbucket Cloud repository](/deploy/bitbucket).
   - If you store your documentation in more than one repository, configure a [multi-repository structure](/deploy/multi-repo) to build your site from multiple repos. If all of your content is in a single repository, skip this step.
 - **Invite team members.** Invite anyone who needs access from the [Members](https://app.mintlify.com/settings/organization/members) page in your dashboard. See [Roles](/dashboard/roles) for more information.


### PR DESCRIPTION
Adds a first step to the go-live checklist's Core setup section telling migration services customers to upload the content zip to their repository before connecting it to Mintlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a migration checklist with no runtime or security impact.
> 
> **Overview**
> Adds a **first Core setup step** on the migration services go-live checklist: customers using **Mintlify migration services** should **upload their content zip to the repository** before connecting the repo to Mintlify.
> 
> No other checklist sections or ordering changes beyond inserting this bullet ahead of “Connect your docs repo to Mintlify.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 828547b07db043880e7834ea908107b928339dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->