### PR TITLE
feat: Dependabot configuration to update actions in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for GitHub Actions workflows in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Documentation changes

Noticed the actions used in the workflows here are outdated, proposing a Dependabot configuration to update - reference https://docs.github.com/en/actions/security-guides/using-githubs-security-features-to-secure-your-use-of-github-actions#keeping-the-actions-in-your-workflows-secure-and-up-to-date

Resolves warnings on workflow runs e.g. https://github.com/mintlify/docs/actions/runs/33103735151
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v2, actions/setup-node@v3

Suggest enabling https://docs.github.com/en/code-security/dependabot/working-with-dependabot/about-dependabot-on-github-actions-runners#enabling-or-disabling-for-your-repository as well

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change; runtime behavior changes only when Dependabot merge PRs are accepted.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so Dependabot opens weekly PRs to bump **`github-actions`** references across repo workflows (scoped to **`/`**).
> 
> This targets outdated pins called out in workflow warnings (e.g. **`actions/checkout@v2`** and **`actions/setup-node@v3`** in **`index-sitemap.yml`**) without changing workflow logic in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901450d606e3c0087bb4c2509d1c315182e1945f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->