### PR TITLE
Document audio embeds

### DIFF
--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Images and embeds"
-description: "Add images, embed YouTube videos, and include iframes in your MDX pages to enhance documentation with visual and interactive media content."
-keywords: ["images", "videos", "iframes", "media", "svg"]
+description: "Add images, audio, videos, and iframes to your MDX pages to enhance documentation with visual and interactive media content."
+keywords: ["images", "audio", "videos", "iframes", "media", "svg"]
 ---
 
-Add images, embed videos, and include interactive content with iframes to your documentation.
+Add images, audio, videos, and interactive iframe content to your documentation.
 
 <Frame>
 <img
@@ -154,6 +154,19 @@ To display different images for light and dark themes, use Tailwind CSS classes:
 SVG files that use `foreignObject` elements render differently in production than in local development. Mintlify's image CDN strips `foreignObject` from SVGs as a security measure, which can truncate or hide text and other embedded HTML content.
 
 This commonly affects SVGs exported from tools like [draw.io](https://www.drawio.com) that have HTML text formatting or word wrap turned on. To fix this, disable **Formatted Text** and **Word Wrap** on all labels in your diagram before exporting to SVG. See the [draw.io documentation](https://www.drawio.com/doc/faq/svg-export-text-problems) for more information on SVG exports.
+
+## Audio
+
+Use the HTML `<audio>` element to embed an audio player. Mintlify supports `.mp3` and `.wav` files in your documentation repository. See [Files](/create/files) for file size and hosting requirements.
+
+```html
+<audio controls preload="metadata" className="w-full">
+  <source src="/audio/getting-started.mp3" type="audio/mpeg" />
+  <a href="/audio/getting-started.mp3">Download the audio file</a>.
+</audio>
+```
+
+Include fallback content, such as a download link, for browsers that don't support the audio element. Use a root-relative path for audio files stored in your repository.
 
 ## Videos
 


### PR DESCRIPTION
## Documentation changes

Adds an Audio section to the media guide with:

- A native HTML audio player example for MP3 and WAV files.
- A fallback download link for browsers without audio element support.
- Links to the existing static-file requirements and root-relative path guidance.

Closes #457

## Validation

- mint validate --telemetry=false
- mint broken-links --files create/image-embeds.mdx --telemetry=false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to `create/image-embeds.mdx` with no runtime or security impact.
> 
> **Overview**
> Documents how authors can embed **audio** in MDX alongside existing image and video guidance.
> 
> The page intro, `description`, and `keywords` now mention audio. A new **Audio** section explains using the HTML `<audio>` element for repository-hosted `.mp3` and `.wav` files, with a full-width player example, fallback download link, root-relative paths, and a pointer to [Files](/create/files) for hosting limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879d3fcf33d70fa972f2d9c50f8cd9113260d003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->