### PR TITLE
Document localhost OpenAPI previews

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -45,6 +45,29 @@ Reference any number of OpenAPI specifications in the navigation element of your
   Mintlify supports `$ref` for **internal references only** within a single OpenAPI document. Mintlify does not support external references.
 </Note>
 
+### Use a localhost specification
+
+During local development, you can generate an OpenAPI document from a service running on your machine and reference its localhost URL:
+
+```json
+"navigation": {
+  "tabs": [
+    {
+      "tab": "API Reference",
+      "openapi": "http://localhost:8000/openapi.json"
+    }
+  ]
+}
+```
+
+Pass `--local-schema` to allow the CLI to fetch the specification over HTTP:
+
+```bash
+mint dev --local-schema
+```
+
+To validate the same configuration without starting a preview, run `mint validate --local-schema`. Production deployments require OpenAPI URLs to use HTTPS.
+
 ### Describe your API
 
 Use the following resources to learn about and construct your OpenAPI specification.


### PR DESCRIPTION
## Documentation changes

Documents the existing local OpenAPI workflow:

- Reference a specification served from localhost in docs.json.
- Run mint dev with --local-schema.
- Use the same flag with mint validate.
- Keep HTTPS as the production requirement.

Closes #617

## Validation

- mint validate --telemetry=false
- mint broken-links --files api-playground/openapi-setup.mdx --telemetry=false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Adds a **Use a localhost specification** section to the OpenAPI setup guide so developers can preview API docs against a spec served from their machine during local work.
> 
> The new content shows pointing `navigation.openapi` at a `http://localhost:…` URL, running **`mint dev --local-schema`** so the CLI can fetch that spec over HTTP, and the same **`--local-schema`** flag with **`mint validate`** when checking config without a dev server. It also states that **production** OpenAPI URLs must use **HTTPS**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bbaeec70e2c24fd9aeb9f28dd0cdc6e1869d72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->