### PR TITLE
Document environment-specific docs configuration

### DIFF
--- a/guides/branches.mdx
+++ b/guides/branches.mdx
@@ -28,6 +28,22 @@ gitGraph
 
 Always work from branches when updating documentation to keep your live site stable and enable review workflows.
 
+## Use environment-specific configurations
+
+Mintlify reads `docs.json` from the branch that a deployment or preview builds. The configuration does not switch at runtime based on an environment variable.
+
+Use branches and deployments to keep configuration changes separate:
+
+| Environment | Branch | Build |
+| --- | --- | --- |
+| Production | `main` | Your live deployment |
+| Staging | `staging` | A separate deployment connected to the staging branch |
+| Short-lived test | `feature/*` | A [preview deployment](/deploy/preview-deployments) |
+
+For a temporary configuration change, edit `docs.json` on a feature branch and review the preview before merging. For a long-lived staging environment, create a separate deployment connected to the staging branch. Each branch must contain a complete, valid `docs.json` at the configured content root.
+
+If configurations share most settings, use [`$ref` to split your configuration](/organize/settings#split-configuration-with-%24ref) into smaller files. Keep any environment-specific referenced files on the corresponding branch.
+
 ## Branch naming conventions
 
 Use clear, descriptive names that explain the purpose of a branch.
@@ -124,4 +140,4 @@ Use clear, descriptive names that explain the purpose of a branch.
 
 ## Merge branches
 
-Once your changes are ready to publish, create a pull request to merge your branch into the deployment branch. 
+Once your changes are ready to publish, create a pull request to merge your branch into the deployment branch.


### PR DESCRIPTION
## Documentation changes

Adds an environment-specific configuration section to the branch guide:

- Explains that Mintlify reads docs.json from the branch being built.
- Maps production, staging, and short-lived tests to deployments and previews.
- Clarifies that each branch needs a complete valid configuration.
- Links to split configuration with $ref for shared settings.

Closes #1003

## Validation

- mint validate --telemetry=false
- mint broken-links --files guides/branches.mdx --telemetry=false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `guides/branches.mdx` with no product or runtime behavior changes.
> 
> **Overview**
> Adds a **Use environment-specific configurations** section to the branch workflow guide, placed before branch naming conventions.
> 
> It clarifies that Mintlify loads `docs.json` from the branch a deployment or preview builds—not from runtime environment variables—and includes a table tying production (`main`), staging (`staging`), and feature branches to live deployments, staging deployments, and preview deployments. The section also describes when to change config on a feature branch versus maintaining a staging deployment, the requirement for a complete valid `docs.json` on each branch, and points readers to split shared settings with `$ref` while keeping environment-specific referenced files on the right branch.
> 
> A trivial whitespace fix removes trailing space after the merge-branches closing sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b6396d7e66a9aa3541e9c5f35de3be525584bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->