### PR TITLE
Clarify image paths for nested assets

### DIFF
--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -28,6 +28,19 @@ Use [Markdown syntax](https://www.markdownguide.org/basic-syntax/#images) to add
 
 Image paths are root-relative from your docs repository. For example, if your image is at `images/screenshot.png` in your repository, the path is `/images/screenshot.png`. Relative paths (for example, `./screenshot.png`) are not supported.
 
+You can store images in any directory, including an `assets` folder beside related pages. The path in MDX must still start at the repository root:
+
+```text
+/your-project
+  |- docs.json
+  |- guides/
+    |- setup.mdx
+    |- assets/
+      |- setup-dialog.png
+```
+
+Reference the image from any page with `/guides/assets/setup-dialog.png`. You do not need a global image-directory setting.
+
 <Tip>
   Always include descriptive alt text to improve accessibility and SEO. The alt text should clearly describe what the image shows.
 </Tip>


### PR DESCRIPTION
## Documentation changes

Clarifies how to keep images beside related pages while using Mintlify root-relative paths:

- Shows a nested guides/assets directory example.
- Provides the exact path to use from MDX.
- States that no global image-directory setting is required.

Closes #175

## Validation

- mint validate --telemetry=false
- mint broken-links --files create/image-embeds.mdx --telemetry=false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification in `create/image-embeds.mdx`; no product or runtime behavior changes.
> 
> **Overview**
> **Expands the “Basic image syntax” section** in `create/image-embeds.mdx` so authors can colocate images (e.g. `guides/assets/` next to `setup.mdx`) without guessing how paths work.
> 
> The new copy adds a sample repo tree, shows the MDX path `/guides/assets/setup-dialog.png` from any page, and states that **no global image-directory setting** is required—still using repository root-relative paths only (not `./` relative paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd1f974cbf135d736be5fc531e0718e617b525fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->