### PR TITLE
Clarify automatic OpenAPI page generation

### DIFF
--- a/api-playground/openapi-setup.mdx
+++ b/api-playground/openapi-setup.mdx
@@ -45,6 +45,19 @@ Reference any number of OpenAPI specifications in the navigation element of your
   Mintlify supports `$ref` for **internal references only** within a single OpenAPI document. Mintlify does not support external references.
 </Note>
 
+### Generate endpoint pages
+
+Mintlify generates endpoint pages from the specification when it builds your documentation. You do not need to generate MDX files or run a separate scraping command.
+
+After you reference the specification in `docs.json`, validate the configuration and start a local preview:
+
+```bash
+mint validate
+mint dev
+```
+
+The former `npx @mintlify/scraping openapi-file` command is no longer supported. The `@mintlify/scraping` package is for importing existing documentation websites, not for generating pages from an OpenAPI document.
+
 ### Describe your API
 
 Use the following resources to learn about and construct your OpenAPI specification.


### PR DESCRIPTION
## Documentation changes

Updates the OpenAPI setup guide to make the current workflow explicit:

- Endpoint pages generate automatically during a Mintlify build.
- Users should run mint validate and mint dev after referencing the specification.
- The former @mintlify/scraping openapi-file command is no longer supported and scraping is for importing existing documentation websites.

Closes #316

## Validation

- mint validate --telemetry=false
- mint broken-links --files api-playground/openapi-setup.mdx --telemetry=false
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `openapi-setup.mdx` with no product or runtime impact.
> 
> **Overview**
> Adds a **Generate endpoint pages** section early in the OpenAPI setup guide so the default workflow is explicit: endpoint pages are created when Mintlify builds docs after you wire the spec into `docs.json`, with no separate MDX generation step.
> 
> The new text tells readers to run **`mint validate`** and **`mint dev`** after adding the spec reference, and states that **`npx @mintlify/scraping openapi-file`** is no longer supported for this flow—`@mintlify/scraping` is only for importing existing documentation sites, not OpenAPI-driven page generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58e26106781ea84ba3d673f3028b9324165b90e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->