### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -2,6 +2,9 @@ name: Check links
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     name: Check links


### PR DESCRIPTION
## Documentation changes

Add an explicit `permissions` block to `.github/workflows/check-links.yml` so the workflow does not inherit potentially broad default token rights.

Best fix (minimal and least-privilege): add at the workflow root (after `on:` and before `jobs:`):

- `permissions:`
- `contents: read`

This is sufficient for `actions/checkout` and for running the link checker, and keeps behavior unchanged while ensuring the token is restricted. No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only hardening that restricts the workflow token; no application or runtime behavior changes.
> 
> **Overview**
> Resolves the code scanning alert **“Workflow does not contain permissions”** by declaring an explicit least-privilege token scope on the **Check links** pull-request workflow.
> 
> Adds a root-level `permissions` block with **`contents: read`**, so the job no longer relies on broader default `GITHUB_TOKEN` rights while still allowing `actions/checkout` and the Mintlify broken-link check to run unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46df48e149ebf992ac93eccaa4ed2ba328464346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->