### PR TITLE
Restricting preview deployment auth gating

### DIFF
--- a/api/preview/trigger.mdx
+++ b/api/preview/trigger.mdx
@@ -18,6 +18,10 @@ The `branch` must exist in the repository connected to your Mintlify project and
 - **Scheduled previews**: Build previews from long-running feature branches on a schedule.
 - **Custom tooling**: Integrate preview creation into internal workflows or Slack bots.
 
+## Access to previews
+
+Previews created with this endpoint are publicly accessible unless organization authentication is enabled for your previews, which applies to every preview in your deployment. You cannot password-protect an individual preview through this endpoint. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments).
+
 ## Rate limits
 
 This endpoint allows up to 5 requests per minute per organization.

--- a/api/preview/trigger.mdx
+++ b/api/preview/trigger.mdx
@@ -20,7 +20,7 @@ The `branch` must exist in the repository connected to your Mintlify project and
 
 ## Access to previews
 
-Previews created with this endpoint are publicly accessible unless organization authentication is enabled for your previews, which applies to every preview in your deployment. You cannot password-protect an individual preview through this endpoint. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments).
+Previews created with this endpoint are publicly accessible unless you enable authentication for your previews, which applies to every preview in your deployment. You cannot password-protect an individual preview through this endpoint. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments).
 
 ## Rate limits
 

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -49,8 +49,6 @@ You can manually create a preview for any branch.
 
 You can also create preview deployments programmatically using the [Trigger preview deployment](/api/preview/trigger) API endpoint. This is useful for integrating preview creation into continuous integration and continuous delivery (CI/CD) pipelines or custom tooling.
 
-The endpoint does not accept a password, so previews created this way cannot be password-protected individually. If organization authentication is enabled for previews, it applies to these previews too. See [Restrict access to preview deployments](#restrict-access-to-preview-deployments).
-
 ## Redeploy a preview
 
 Redeploy a preview to refresh content or retry after a failed deployment.
@@ -81,13 +79,13 @@ The widget only appears on preview deployments, not on your live site or local p
 
 ## Restrict access to preview deployments
 
-By default, preview deployments are publicly accessible to anyone with the URL. You can restrict access by requiring organization authentication for all previews or by password-protecting individual previews.
-
 <Info>
-  Both options require preview deployment authentication, which is available on the [Enterprise plan](https://mintlify.com/pricing?ref=preview-deployments). Access to preview deployments is a separate requirement, available on Pro and Enterprise plans. To restrict preview access on another plan, contact your account team about upgrading.
+  Restricting access to preview deployments requires an [Enterprise plan](https://mintlify.com/pricing?ref=preview-deployments).
 </Info>
 
-If your site requires [authentication](/deploy/authentication-setup), preview authentication is enabled automatically and cannot be turned off. The **Preview authentication** toggle is locked on, and the **Make private** option is not available when you create a preview.
+By default, preview deployments are publicly accessible to anyone with the URL. You can restrict access by requiring organization authentication for all previews or by password-protecting individual previews.
+
+If your site requires [authentication](/deploy/authentication-setup) to access, preview authentication is automatically enabled and cannot be disabled.
 
 ### Require organization authentication
 
@@ -102,7 +100,7 @@ Restrict preview access to authenticated members of your Mintlify organization.
 
 ### Password-protect an individual preview
 
-Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard. The **Make private** toggle does not appear if your deployment lacks preview deployment authentication or if organization authentication is already enabled.
+Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard.
 
 1. Go to your [dashboard](https://app.mintlify.com/).
 2. Click **Previews**.

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -49,6 +49,8 @@ You can manually create a preview for any branch.
 
 You can also create preview deployments programmatically using the [Trigger preview deployment](/api/preview/trigger) API endpoint. This is useful for integrating preview creation into continuous integration and continuous delivery (CI/CD) pipelines or custom tooling.
 
+The endpoint does not accept a password, so previews created this way cannot be password-protected individually. If organization authentication is enabled for previews, it applies to these previews too. See [Restrict access to preview deployments](#restrict-access-to-preview-deployments).
+
 ## Redeploy a preview
 
 Redeploy a preview to refresh content or retry after a failed deployment.
@@ -81,11 +83,17 @@ The widget only appears on preview deployments, not on your live site or local p
 
 By default, preview deployments are publicly accessible to anyone with the URL. You can restrict access by requiring organization authentication for all previews or by password-protecting individual previews.
 
+<Info>
+  Both options require preview deployment authentication, which is available on the [Enterprise plan](https://mintlify.com/pricing?ref=preview-deployments). Access to preview deployments is a separate requirement, available on Pro and Enterprise plans. To restrict preview access on another plan, contact your account team about upgrading.
+</Info>
+
+If your site requires [authentication](/deploy/authentication-setup), preview authentication is enabled automatically and cannot be turned off. The **Preview authentication** toggle is locked on, and the **Make private** option is not available when you create a preview.
+
 ### Require organization authentication
 
 Restrict preview access to authenticated members of your Mintlify organization.
 
-1. Navigate to the **Previews** section in the [Add-ons](https://app.mintlify.com/products/addons) page of your dashboard.
+1. Navigate to the **Previews** section of the [Add-ons](https://app.mintlify.com/settings/deployment/addons) page in your dashboard.
 2. Click the **Preview authentication** toggle to enable or disable preview authentication.
   <Frame>
     <img src="/images/previews/preview-auth-light.png" alt="The preview authentication toggle in the Add-ons page" className="block dark:hidden" />
@@ -94,7 +102,7 @@ Restrict preview access to authenticated members of your Mintlify organization.
 
 ### Password-protect an individual preview
 
-Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when creating a manual preview and is not shown when organization authentication is already enabled for your deployment.
+Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard. The **Make private** toggle does not appear if your deployment lacks preview deployment authentication or if organization authentication is already enabled.
 
 1. Go to your [dashboard](https://app.mintlify.com/).
 2. Click **Previews**.

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -87,7 +87,7 @@ The widget only appears on preview deployments, not on your live site or local p
 
 By default, preview deployments are publicly accessible to anyone with the URL. You can restrict access by requiring organization authentication for all previews or by password-protecting individual previews.
 
-If your site requires [authentication](/deploy/authentication-setup) to access, preview authentication is automatically enabled and cannot be disabled.
+If your site requires [authentication](/deploy/authentication-setup) to access, preview authentication is automatically enabled and cannot be disabled. Reviewers sign in to previews with the same authentication method your site uses.
 
 ### Require organization authentication
 
@@ -102,7 +102,7 @@ Restrict preview access to authenticated members of your Mintlify organization.
 
 ### Password-protect an individual preview
 
-Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard.
+Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard. The **Make private** toggle does not appear if your plan does not include preview authentication or if your site requires authentication.
 
 1. Go to the [Activity](https://app.mintlify.com/activity) page in your dashboard.
 2. Click the **Previews** tab.

--- a/deploy/preview-deployments.mdx
+++ b/deploy/preview-deployments.mdx
@@ -39,8 +39,8 @@ A maintainer with write access to the main repository can preview changes from a
 
 You can manually create a preview for any branch.
 
-1. Go to your [dashboard](https://app.mintlify.com/).
-2. Click **Previews**.
+1. Go to the [Activity](https://app.mintlify.com/activity) page in your dashboard.
+2. Click the **Previews** tab.
 3. Click **Create custom preview**.
 4. Enter the name of the branch you want to preview.
 5. Click **Create preview**.
@@ -53,8 +53,10 @@ You can also create preview deployments programmatically using the [Trigger prev
 
 Redeploy a preview to refresh content or retry after a failed deployment.
 
-1. Click the preview from your [dashboard](https://app.mintlify.com/).
-2. Click **Redeploy**.
+1. Go to the [Activity](https://app.mintlify.com/activity) page in your dashboard.
+2. Click the **Previews** tab.
+3. Click the preview you want to redeploy.
+4. Click **Redeploy**.
 
 <Frame>
   <img src="/images/previews/redeploy-preview-light.png" alt="The Previews menu with the deploy button emphasized by an orange rectangle." className="block dark:hidden" />
@@ -102,8 +104,8 @@ Restrict preview access to authenticated members of your Mintlify organization.
 
 Password-protect a specific preview to share it with external reviewers without adding them to your Mintlify organization. This option is available when you create a manual preview from your dashboard.
 
-1. Go to your [dashboard](https://app.mintlify.com/).
-2. Click **Previews**.
+1. Go to the [Activity](https://app.mintlify.com/activity) page in your dashboard.
+2. Click the **Previews** tab.
 3. Click **Create custom preview**.
 4. Enter the name of the branch you want to preview.
 5. Toggle **Make private** on and enter a password. Passwords must be at least 8 characters.
@@ -119,7 +121,7 @@ Preview deployments stay live as long as their source branch exists in your repo
 
 - **Automatic previews**: The preview for a pull request remains available while the pull request is open and after it's merged or closed, as long as the source branch still exists. When you delete the branch, the next dashboard sync removes the preview.
 - **Manual previews**: Manual previews stay live until you delete them. Redeploying a manual preview refreshes its content against the latest commit on the specified branch.
-- **Delete a preview**: In your [dashboard](https://app.mintlify.com/), go to **Previews**, open the preview, and click **Delete** to remove it immediately.
+- **Delete a preview**: On the [Activity](https://app.mintlify.com/activity) page of your dashboard, click the **Previews** tab, open the preview, and click **Delete** to remove it immediately.
 
 Preview URLs are unique per branch. If you delete a preview and later recreate one for the same branch, Mintlify may issue a new URL.
 
@@ -129,7 +131,7 @@ Mintlify generates preview URLs automatically. The subdomain and domain are not 
 
 If your preview deployment fails, try these troubleshooting steps.
 
-- **View the build logs**: In your [dashboard](https://app.mintlify.com/), go to **Previews** and click the failed preview. The deployment logs show errors that caused failures.
+- **View the build logs**: On the [Activity](https://app.mintlify.com/activity) page of your dashboard, click the **Previews** tab and click the failed preview. The deployment logs show errors that caused failures.
 - **Check your configuration**:
    - Missing `docs.json` at the configured content root. If your `docs.json` is in a subdirectory, confirm the **docs.json is in a subdirectory** setting points to the correct path.
    - Invalid `docs.json` syntax (for example, an empty file or a stray trailing comma that breaks JSON parsing).

--- a/editor/review.mdx
+++ b/editor/review.mdx
@@ -23,7 +23,7 @@ To open the [agent](/editor/agent) beside the preview, click **Ask agent** in th
 
 When you open a pull request from a feature branch, Mintlify builds a preview deployment: a temporary URL where your changes render exactly as they look when published. The preview rebuilds each time you save new changes to the branch. The URL format is `organization-branch-name.mintlify.site`.
 
-Preview URLs are publicly accessible by default. To restrict access to members of your Mintlify organization, enable preview authentication on the [Add-ons](https://app.mintlify.com/products/addons) page of your dashboard.
+Preview URLs are publicly accessible by default. To restrict access to members of your Mintlify organization, enable preview authentication in the **Previews** section of the [Add-ons](https://app.mintlify.com/settings/deployment/addons) page in your dashboard. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments) for plan requirements.
 
 ## Which preview to use
 

--- a/editor/review.mdx
+++ b/editor/review.mdx
@@ -23,7 +23,7 @@ To open the [agent](/editor/agent) beside the preview, click **Ask agent** in th
 
 When you open a pull request from a feature branch, Mintlify builds a preview deployment: a temporary URL where your changes render exactly as they look when published. The preview rebuilds each time you save new changes to the branch. The URL format is `organization-branch-name.mintlify.site`.
 
-Preview URLs are publicly accessible by default. To restrict access to members of your Mintlify organization, enable preview authentication in the **Previews** section of the [Add-ons](https://app.mintlify.com/settings/deployment/addons) page in your dashboard. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments) for plan requirements.
+Preview URLs are publicly accessible by default. To restrict access to members of your Mintlify organization, enable preview authentication in the **Previews** section of the [Add-ons](https://app.mintlify.com/settings/deployment/addons) page in your dashboard. See [Restrict access to preview deployments](/deploy/preview-deployments#restrict-access-to-preview-deployments) for more information.
 
 ## Which preview to use
 


### PR DESCRIPTION
## Documentation changes

adds info on ent gate

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to preview auth, plan requirements, and dashboard URLs with no application code changes.
> 
> **Overview**
> Updates preview deployment docs to match **Enterprise-gated** access controls and current dashboard flows.
> 
> **Restrict access to preview deployments** now calls out that restricting previews requires an **Enterprise plan**, and adds that sites with production [authentication](/deploy/authentication-setup) automatically enforce the same auth on previews (and cannot turn that off). Password-protecting a single preview is clarified: **Make private** only shows for manual dashboard previews when the plan includes preview authentication and the site is not already auth-protected.
> 
> Dashboard instructions across manual create, redeploy, delete, and troubleshooting now route through the **[Activity](https://app.mintlify.com/activity)** page and the **Previews** tab instead of a top-level **Previews** entry. Add-ons links for preview authentication point to `/settings/deployment/addons`.
> 
> The **Trigger preview deployment** API page gains an **Access to previews** section: API-triggered previews are public unless org-wide preview auth is on, and per-preview passwords are not available via the API.
> 
> **Editor review** doc aligns with the new Add-ons path and links to the restrict-access guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afcf57729cab579338255be0a6dbf555ba36f4b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->