### PR TITLE
Add BYOK base URL constraint, add-on visibility, and assistant cross-link

### DIFF
--- a/ai/bring-your-own-model.mdx
+++ b/ai/bring-your-own-model.mdx
@@ -5,7 +5,7 @@ keywords: ["BYOK", "key", "OpenRouter", "Anthropic", "OpenAI", "LLM", "API key",
 ---
 
 <Info>
-  Bring your own model requires an [Enterprise plan](https://mintlify.com/pricing?ref=bring-your-own-model). [Contact sales](https://www.mintlify.com/contact/sales) to inquire about adding it to your contract.
+  Bring your own model requires an [Enterprise plan](https://mintlify.com/pricing?ref=bring-your-own-model). [Contact sales](https://www.mintlify.com/contact/sales) to inquire about adding it to your contract. The **AI model** section appears in your dashboard only when your contract includes it.
 </Info>
 
 By default, Mintlify selects the models that power the assistant and agent. To use a specific model with your own provider account, supply an API key and choose the model. Mintlify then runs inference against your provider.
@@ -31,7 +31,7 @@ Each provider supports a fixed set of models.
 1. Select the deployment you want to configure.
 2. Navigate to the [API keys](https://app.mintlify.com/settings/organization/api-keys) page in your dashboard.
 3. In the **AI model** section, enable **Bring your own model**.
-4. Select a provider. For an OpenAI-compatible provider, enter a provider name and base URL.
+4. Select a provider. For an OpenAI-compatible provider, enter a provider name and base URL. The base URL must use HTTPS and point to a publicly reachable host.
 5. Select a model.
 6. Enter your provider API key.
 7. Click **Save**.

--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -101,6 +101,8 @@ Changes take up to 10 minutes to propagate.
 
 The assistant runs on credits. Each assistant message consumes credits, where a message is any user interaction with the assistant that receives a response. See [Credit pricing](/credits) for more information.
 
+On Enterprise plans, you can [bring your own model](/ai/bring-your-own-model) to run the assistant on your own LLM provider and API key, which meters usage at a reduced credit rate.
+
 ### Change your credit tier
 
 1. Go to the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.


### PR DESCRIPTION
## What changed

- `ai/bring-your-own-model.mdx`: noted that the OpenAI-compatible base URL must use HTTPS and point to a publicly reachable host, and that the **AI model** section only appears in the dashboard when the contract includes the add-on.
- `assistant/configure.mdx`: added a cross-link to `/ai/bring-your-own-model` in **Manage billing**.

## Rationale

Bot PR #7134 predates the dedicated bring your own model page (#7174, #7177) and duplicates it. These are the only two facts in that PR not already covered by the merged page. #7134 is being closed in favor of this.

The assistant configuration page had no link to the bring your own model page at all. The link goes in **Manage billing**, next to the existing `/credits` link, rather than in its own section: the configuration covers the agent and automations too, so a `## Bring your own model` heading on an assistant page would overstate its scope, and someone reading about credit consumption is the reader who wants to know about the reduced rate.

## Alternatives considered

Merging #7134 as-is, or trimming it to a link. Both leave a bot branch that reintroduces duplicate content on the next sync. Closing it and porting the deltas here is cleaner.

## Areas of uncertainty

- The "publicly reachable host" constraint comes from the bot PR's reading of mint#10538, not from reading the validation code. Worth a check against the actual base URL validation before merge.
- English only. Translations follow automatically after merge.

## Checks

`mint broken-links` passes, `mint a11y` passes, `vale` reports 0 errors on both files (2 pre-existing passive-voice suggestions on untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Updates **bring your own model** docs with two configuration clarifications and ties the assistant billing page to that guide.
> 
> On `ai/bring-your-own-model.mdx`, the Enterprise callout now states that the dashboard **AI model** section only shows when the contract includes the add-on. Step 4 for OpenAI-compatible providers now requires the base URL to use **HTTPS** and target a **publicly reachable** host.
> 
> On `assistant/configure.mdx`, **Manage billing** adds a short Enterprise note linking to `/ai/bring-your-own-model` for using your own provider/API key at a reduced credit rate, alongside the existing credits pricing link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f8e0d18c52739e06c09cc3d7ae7ff6338b42c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->