### PR TITLE
docs: document documentTitle frontmatter

### DIFF
--- a/.claude/skills/mintlify/SKILL.md
+++ b/.claude/skills/mintlify/SKILL.md
@@ -85,9 +85,10 @@ keywords: ["relevant", "search", "terms"]
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `title` | string | Yes | Page title in navigation and browser tabs. |
+| `title` | string | Yes | Page title in navigation and as the on-page heading. |
 | `description` | string | No | Brief description for SEO. Displays under the title. |
 | `sidebarTitle` | string | No | Short title for sidebar navigation. |
+| `documentTitle` | string | No | Browser tab title. Falls back to `title`. |
 | `icon` | string | No | Lucide, Font Awesome, or Tabler icon name. Also accepts a URL or file path. |
 | `tag` | string | No | Label next to page title in sidebar (e.g., "NEW"). |
 | `hidden` | boolean | No | Remove from sidebar. Page still accessible by URL. |

--- a/.claude/skills/mintlify/reference/configuration.md
+++ b/.claude/skills/mintlify/reference/configuration.md
@@ -31,9 +31,10 @@ The SKILL.md file lists common frontmatter fields. Here is the complete set:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `title` | string | Yes | Page title in navigation and browser tabs. |
+| `title` | string | Yes | Page title in navigation and as the on-page heading. |
 | `description` | string | No | Brief description for SEO. Displays under the title. |
 | `sidebarTitle` | string | No | Short title for sidebar navigation. |
+| `documentTitle` | string | No | Browser tab title. Falls back to `title`. |
 | `icon` | string | No | Lucide, Font Awesome, or Tabler icon name. Also accepts a URL or file path. |
 | `iconType` | string | No | Font Awesome icon style: `regular`, `solid`, `light`, `thin`, `sharp-solid`, `duotone`, `brands`. |
 | `tag` | string | No | Label next to page title in sidebar (e.g., "NEW"). |

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -28,7 +28,7 @@ Mintlify generates the following meta tags for every page. You can override thes
 
 **Page-specific metadata:**
 
-- `title` - Browser tab title, formatted as "Page Title - Site Name", set `documentTitle` in frontmatter to change the page-title portion without changing the on-page heading
+- `title` - On page H1 title and browser tab title, formatted as "Page Title - Site Name". Set `documentTitle` to change the page-title portion without changing the on-page heading
 - `og:title` - Open Graph title, defaults to page title
 - `twitter:title` - Twitter title, falls back to `og:title`, then page title
 - `description` - Page description

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -28,7 +28,7 @@ Mintlify generates the following meta tags for every page. You can override thes
 
 **Page-specific metadata:**
 
-- `title` - Page title, formatted as "Page Title - Site Name"
+- `title` - Browser tab title, formatted as "Page Title - Site Name". Set `documentTitle` in frontmatter to change the page-title portion without changing the on-page heading.
 - `og:title` - Open Graph title, defaults to page title
 - `twitter:title` - Twitter title, falls back to `og:title`, then page title
 - `description` - Page description
@@ -199,6 +199,7 @@ Page-specific meta tags include:
 - `title` - Page title
 - `description` - Page description appears below the title on the page and in some search engine results
 - `canonical` - Canonical URL for this page, overrides the auto-generated canonical
+- `documentTitle` - Browser tab title. Site name is still appended. Does not change the on-page heading or `og:title`
 - `keywords` - Comma-separated keywords
 - `og:title` - Open Graph title for social sharing
 - `og:description` - Open Graph description, falls back to `description`

--- a/optimize/seo.mdx
+++ b/optimize/seo.mdx
@@ -28,7 +28,7 @@ Mintlify generates the following meta tags for every page. You can override thes
 
 **Page-specific metadata:**
 
-- `title` - Browser tab title, formatted as "Page Title - Site Name". Set `documentTitle` in frontmatter to change the page-title portion without changing the on-page heading.
+- `title` - Browser tab title, formatted as "Page Title - Site Name", set `documentTitle` in frontmatter to change the page-title portion without changing the on-page heading
 - `og:title` - Open Graph title, defaults to page title
 - `twitter:title` - Twitter title, falls back to `og:title`, then page title
 - `description` - Page description
@@ -199,7 +199,7 @@ Page-specific meta tags include:
 - `title` - Page title
 - `description` - Page description appears below the title on the page and in some search engine results
 - `canonical` - Canonical URL for this page, overrides the auto-generated canonical
-- `documentTitle` - Browser tab title. Site name is still appended. Does not change the on-page heading or `og:title`
+- `documentTitle` - Browser tab title, site name is still appended, does not change the on-page heading
 - `keywords` - Comma-separated keywords
 - `og:title` - Open Graph title for social sharing
 - `og:description` - Open Graph description, falls back to `description`

--- a/organize/pages.mdx
+++ b/organize/pages.mdx
@@ -16,13 +16,13 @@ All frontmatter fields are optional. If you omit `title`, Mintlify generates one
 Use frontmatter to control:
 
 - Page titles and descriptions
-- Sidebar titles, icons, and tags
+- Sidebar titles, browser tab titles, icons, and tags
 - Page layouts
 - SEO meta tags
 - Custom metadata
 
 <ResponseField name="title" type="string">
-  The title of your page that appears in navigation and browser tabs.
+  The title of your page. Displays as the H1 heading and is the default for navigation, browser tabs, and social sharing titles.
 
   If omitted, Mintlify generates a title from the path. The last segment of the path becomes the title, with dashes and underscores replaced by spaces and the first letter capitalized. For example, `guides/getting-started.md` becomes **Getting started**.
 </ResponseField>
@@ -33,6 +33,10 @@ Use frontmatter to control:
 
 <ResponseField name="sidebarTitle" type="string">
   A short title that displays in the sidebar navigation.
+</ResponseField>
+
+<ResponseField name="documentTitle" type="string">
+  The title used in the browser tab and HTML `<title>` tag. If omitted, Mintlify uses `title` and appends your site name. The on-page heading is unchanged.
 </ResponseField>
 
 <ResponseField name="icon" type="string">
@@ -105,6 +109,7 @@ Use frontmatter to control:
 title: "About frontmatter"
 description: "Frontmatter is the metadata that controls how your page appears and behaves"
 sidebarTitle: "Frontmatter"
+documentTitle: "About frontmatter | Metadata"
 icon: "book"
 tag: "NEW"
 ---


### PR DESCRIPTION
## Documentation changes

Document the optional `documentTitle` frontmatter field so authors can set the browser tab / HTML `<title>` independently of the on-page heading. `title` remains the H1; site name is still appended to the document title.

Closes 

---

## For Reviewers

When reviewing documentation PRs, please consider:

### ✅ Technical accuracy
- [ ] Code examples work as written
- [ ] Commands and configurations are correct
- [ ] Links resolve to the right destinations
- [ ] Prerequisites and requirements are accurate

### ✅ Clarity and completeness
- [ ] Instructions are clear and easy to follow
- [ ] Steps are in logical order
- [ ] Nothing important is missing
- [ ] Examples help illustrate the concepts

### ✅ User experience
- [ ] A new user could follow these docs successfully
- [ ] Common gotchas or edge cases are addressed
- [ ] Error messages or troubleshooting guidance is helpful


Made with [Cursor](https://cursor.com)