### PR TITLE
Update docs for fixed credit pricing

### DIFF
--- a/assistant/configure.mdx
+++ b/assistant/configure.mdx
@@ -99,7 +99,7 @@ Changes take up to 10 minutes to propagate.
 
 ## Manage billing
 
-The assistant runs on credits. Each assistant message consumes credits, where a message is any user interaction with the assistant that receives a response. See [Credit pricing](/credits) for more information.
+The assistant runs on credits. Each question the assistant answers costs 25 credits. If the assistant can't find an answer in your docs and says so, the message costs nothing. See [Credit pricing](/credits) for more information.
 
 On Enterprise plans, you can [bring your own model](/ai/bring-your-own-model) to run the assistant on your own LLM provider and API key, which meters usage at a reduced credit rate.
 

--- a/automations/index.mdx
+++ b/automations/index.mdx
@@ -50,7 +50,7 @@ When an automation opens or updates a pull request, Mintlify adds context direct
 
 ## Usage limits
 
-Automation runs count toward your credit usage. The credits a single run consumes depend on the size of the task: how much content the agent reads, how many files it changes, and how long the run takes. Larger context repositories and broader prompts use more credits than narrowly scoped ones.
+Automation runs count toward your credit usage. Each run that updates your docs costs 250 credits, regardless of how much content the agent reads or how many files it changes. Runs that find nothing to update cost nothing. See [Credit pricing](/credits) for more information.
 
 See your credit usage, set overages, and manage your credit package on the [Usage](https://app.mintlify.com/settings/organization/usage) page of your dashboard.
 

--- a/automations/manage.mdx
+++ b/automations/manage.mdx
@@ -124,7 +124,7 @@ You can trigger an automation on demand without waiting for its next scheduled o
 3. Click the run button (**Test run** or **Run now**, depending on the automation).
 4. Select the run scope.
     - **Since a date**: Reviews changes from the selected date through the current time. The date defaults to the automation's last run, or seven days ago if it has never run.
-    - **Everything**: Reviews the entire site or repository history. This scope usually takes longer and uses significantly more credits than a targeted run.
+    - **Everything**: Reviews the entire site or repository history. This scope usually takes longer than a targeted run.
     - **Specific pull request**: Limits the run to one pull request in a selected repository.
 5. Click **Run now**.
 

--- a/credits.mdx
+++ b/credits.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Credit pricing"
-description: "Understand how your organization's credit balance works, what consumes credits, and how Mintlify bills credit add-ons, overages, and rollovers."
+description: "Learn the fixed credit price of each AI action, how your organization's shared credit balance works, and how Mintlify bills credit add-ons, overages, and rollovers."
 keywords: ["credits", "billing", "pricing", "organization", "assistant", "agent", "automations", "add-ons", "overages", "rollovers", "usage", "export", "CSV", "activity log"]
 ---
 
-Mintlify's AI features run on credits. Your organization has one monthly credit balance, shared by every deployment and everyone on your team. Manage it on the [Usage](https://app.mintlify.com/settings/organization/usage) page in your dashboard.
+Mintlify's AI features run on credits. Every action has a fixed credit price, and you pay only when an action produces a result. Your organization has one monthly credit balance, shared by every deployment and everyone on your team. Manage it on the [Usage](https://app.mintlify.com/settings/organization/usage) page in your dashboard.
 
 ## Your shared balance
 
@@ -24,15 +24,36 @@ Individual deployments have their own overage settings, so you can configure dif
 
 ## What uses credits
 
-Your credit balance powers the assistant, agent, and automations.
+Every AI action has a fixed credit price. Actions that produce nothing cost nothing.
 
-The assistant uses credits for each interaction with a user.
+| Action | Credits |
+|:-------|:--------|
+| Assistant answers a question | 25 |
+| Assistant can't answer a question | 0 |
+| Automation updates your docs | 250 |
+| Automation finds nothing to update | 0 |
 
-The agent uses credits for each run you invoke.
+The price is the same regardless of how much content the agent reads, how many passes it takes, or how long the action runs.
 
-Automations use credits each time they run, whether you run them on a schedule, on a trigger, or manually.
+### Assistant answers
 
-Runs use different amounts of credits depending on the task size and context used. The cost depends on how much content the agent reads, how many files it changes, and how long the run takes.
+An answer is a response that addresses the user's question. Each answer costs 25 credits, whether the question comes from your docs site, the [widget](/assistant/widget), or the [assistant API](/api/assistant/create-assistant-message-v2).
+
+If the assistant can't find an answer in your docs and says so, the message costs nothing.
+
+### Automation updates
+
+An update is a run that changes your docs, either by opening or updating a pull request or by committing directly to your repository, depending on the automation's [update mode](/guides/use-automations#update-mode). Each update costs 250 credits, whether the run starts on a schedule, on a trigger, manually, or through the API. A run that changes several pages is still one update.
+
+A run that reviews your repository and finds nothing to update costs nothing. Runs that fail also cost nothing.
+
+### Editor agent and Slack agent
+
+Pro and Enterprise plans include the [editor agent](/editor/agent) and the [agent in Slack](/agent/slack). Using them doesn't consume credits.
+
+<Note>
+  Before September 4, 2026, credit costs varied with the tokens each run used. Fixed prices apply automatically to every action from that date. Your plan, its included credits, and the price per credit stay the same.
+</Note>
 
 ## Plan availability
 
@@ -82,9 +103,14 @@ Up to 50% of unused credits carry forward to the next month, so the most your or
 
 ## Estimate your usage
 
-Credit costs vary by task. View the [Usage](https://app.mintlify.com/settings/organization/usage) page in your dashboard to see how your deployment uses credits.
+Because every action has a fixed price, you can project usage from volume alone:
 
-The **Activity log** section lists the credits consumed by each event. Multiply the cost of a typical event by your expected monthly volume to project what your organization needs.
+- Multiply the number of questions you expect the assistant to answer each month by 25.
+- Multiply the number of automation runs you expect to update your docs each month by 250.
+
+For example, an organization whose assistant answers 200 questions and whose automations make 12 updates in a month uses 8,000 credits, which fits within a single Pro plan's 10,000 monthly credits.
+
+The **Activity log** section of the [Usage](https://app.mintlify.com/settings/organization/usage) page lists each action and the credits it consumed, so you can check your projection against real usage.
 
 ## Export usage activity
 
@@ -101,7 +127,7 @@ The exported CSV includes the date, product, and credits consumed for each event
 
 ### Run automations on a schedule
 
-SEO audits, writing style checks, and broken link detection don't need to run on every code change. A daily or weekly schedule lowers credit consumption because the agent batches work across multiple changes in a single run. The tradeoff is a delay between when content changes and when the automation acts on it.
+SEO audits, writing style checks, and broken link detection don't need to run on every code change. A daily or weekly schedule batches multiple changes into a single update, so you pay 250 credits once instead of once per change. Runs that find nothing to update are free, so a schedule that runs more often than your content changes doesn't cost extra. The tradeoff is a delay between when content changes and when the automation acts on it.
 
 ### Bring your own model
 
@@ -109,4 +135,4 @@ On Enterprise plans, you can supply your own LLM provider API key and choose the
 
 ### Find what's consuming your credits
 
-The [Usage](https://app.mintlify.com/settings/organization/usage) page breaks usage down by feature category. If one automation costs more than you expect, review its trigger frequency and any custom instructions that widen its scope.
+The [Usage](https://app.mintlify.com/settings/organization/usage) page breaks usage down by feature category. If one automation makes more updates than you expect, review its trigger frequency and any custom instructions that widen its scope.

--- a/editor/collaborate.mdx
+++ b/editor/collaborate.mdx
@@ -55,7 +55,7 @@ Mention `@mintlify` in a comment, suggestion, or reply to ask the [editor agent]
 
 The agent runs read-only when replying to comments. It can search your docs, read pages, fetch web content, and load skills, but it cannot edit content, create suggestions, or publish. To make changes, open the [editor agent](/editor/agent) directly.
 
-Mentions work on private pages for members who already have access. Each reply counts toward your editor agent usage.
+Mentions work on private pages for members who already have access.
 
 ## Real-time editing
 

--- a/guides/use-automations.mdx
+++ b/guides/use-automations.mdx
@@ -94,9 +94,9 @@ Decide how much review you want before changes go live.
 
 ## Control credit usage
 
-Every automation run consumes credits. Costs vary with how much content the agent reads, how many files it changes, and how long the run takes. Complex runs that update many pages cost more. To see how many credits your automations use, check the activity log on the [Usage](https://app.mintlify.com/settings/organization/usage) page.
+Every automation run that updates your docs costs 250 credits, no matter how much content the agent reads or how many pages it changes. Runs that find nothing to update cost nothing. To see how many credits your automations use, check the activity log on the [Usage](https://app.mintlify.com/settings/organization/usage) page.
 
-Scheduling cron jobs to run at specific times gives you more precise control over credit usage. For example, run an automation once a day or once a week to know exactly how many pull requests it creates per month. Push-triggered automations can vary more from month to month because they depend on how often content or code changes.
+Scheduling cron jobs to run at specific times gives you more precise control over credit usage. For example, run an automation once a day or once a week to cap how many updates it can make per month, and batch several source changes into one update instead of paying for each separately. Push-triggered automations can vary more from month to month because they depend on how often content or code changes.
 
 ## Review and improve automation results
 


### PR DESCRIPTION
## Summary

Replace token-based credit cost descriptions with the new flat per-action prices (25 credits per assistant answer, 250 per automation update, 0 when nothing is produced) and note that the editor and Slack agents are included with Pro and Enterprise.

## Test Plan

- Run `mint dev` and review `/credits` for the pricing table and answer/update definitions.
- Run `mint broken-links` and confirm no failures.
- Spot-check `/assistant/configure`, `/automations`, and `/guides/use-automations` for the updated pricing language.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes to billing and product copy; no application code, auth, or data paths are modified.
> 
> **Overview**
> Documentation now describes **fixed credit prices** instead of variable, token-based usage. The **`/credits`** page is the hub: a pricing table (**25** for assistant answers, **250** for automation doc updates, **0** when there’s no answer or no update), definitions of “answer” and “update,” and a note that **editor agent** and **Slack agent** use on Pro/Enterprise **don’t consume credits**. A **September 4, 2026** note explains the switch from token-based metering.
> 
> Related pages are aligned: **assistant configure**, **automations overview/manage**, and **use automations** repeat the flat rates and free no-op runs. **Usage estimation** is rewritten as simple volume math (questions × 25, updates × 250). **Cost-control** guidance for scheduled automations emphasizes batching into one paid update per run rather than size-dependent cost. **`editor/collaborate`** drops the line that `@mintlify` replies count toward editor agent usage; **`automations/manage`** no longer warns that an “Everything” manual run uses “significantly more credits.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367776812362226ed33e9de8e00ef133d3ba836f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->