### PR TITLE
Document className and Tailwind arbitrary value support

### DIFF
--- a/.vale/styles/Mintlify/Headings.yml
+++ b/.vale/styles/Mintlify/Headings.yml
@@ -10,6 +10,7 @@ exceptions:
   - Claude Code
   - CLAUDE.md
   - CLI
+  - className
   - Color.Row
   - Content-Signal
   - CSM

--- a/.vale/styles/config/vocabularies/Mintlify/accept.txt
+++ b/.vale/styles/config/vocabularies/Mintlify/accept.txt
@@ -85,6 +85,7 @@ Clearbit
 CLI
 CloudConvert
 Cloudflare
+className
 Cloudflare's
 CloudFront
 Cloudinary
@@ -240,6 +241,7 @@ JSON-LD
 JSX
 JWTs?
 KaTeX
+keyframes?
 Keycloak
 Kotlin
 kubeconfig
@@ -486,6 +488,7 @@ uncached
 (?i)uncheck(s|ed|ing)?
 undoable
 ungroup(s|ed|ing)?
+unstyled
 unhide
 Unicode
 Unix

--- a/components/accordions.mdx
+++ b/components/accordions.mdx
@@ -91,7 +91,7 @@ Group related accordions together using `<AccordionGroup>`. This creates a cohes
 ## Properties
 
 <ResponseField name="title" type="string" required>
-  Title in the Accordion preview.
+  Title in the Accordion preview. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <ResponseField name="description" type="string">
@@ -107,3 +107,7 @@ Group related accordions together using `<AccordionGroup>`. This creates a cohes
 </ResponseField>
 
 <IconsOptional />
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the accordion. Also accepted on `AccordionGroup`.
+</ResponseField>

--- a/components/callouts.mdx
+++ b/components/callouts.mdx
@@ -53,10 +53,14 @@ Use `Note`, `Warning`, `Info`, `Tip`, `Check`, or `Danger` callouts, or create a
 
 ## Custom callout properties
 
-The generic `Callout` component supports custom icons and colors. The typed callouts (`Note`, `Warning`, `Info`, `Tip`, `Check`, `Danger`) use preset icons and colors and only accept `children`.
+The generic `Callout` component supports custom icons and colors. The typed callouts (`Note`, `Warning`, `Info`, `Tip`, `Check`, `Danger`) use preset icons and colors and accept only `children` and `className`.
 
 <IconsOptional />
 
 <ResponseField name="color" type="string">
   Custom color as a hex code (for example, `#FFC107`). Sets the border, background tint, and text color of the callout.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the callout. Accepted by the generic `Callout` and by the typed callouts.
 </ResponseField>

--- a/components/cards.mdx
+++ b/components/cards.mdx
@@ -133,7 +133,7 @@ Use the [Columns component](/components/columns) to organize multiple cards side
 ## Properties
 
 <ResponseField name="title" type="string">
-  The title displayed on the card.
+  The title displayed on the card. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <IconsOptional />
@@ -164,4 +164,8 @@ Use the [Columns component](/components/columns) to organize multiple cards side
 
 <ResponseField name="type" type="string">
   Apply a callout-style theme to the card. One of `info`, `warning`, `note`, `tip`, `check`, or `danger`. Sets the card's background, border, and default icon to match the selected type.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the card.
 </ResponseField>

--- a/components/code-groups.mdx
+++ b/components/code-groups.mdx
@@ -100,3 +100,9 @@ class HelloWorld {
 ```
 </CodeGroup>
 ````
+
+## Properties
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the code group container.
+</ResponseField>

--- a/components/color.mdx
+++ b/components/color.mdx
@@ -109,10 +109,14 @@ Define different colors for light and dark modes using an object with `light` an
   Color items or rows to display.
 </ResponseField>
 
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the color palette.
+</ResponseField>
+
 ### Color.Row
 
 <ResponseField name="title" type="string">
-  Label for the row of colors.
+  Label for the row of colors. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <ResponseField name="children" type="Color.Item" required>

--- a/components/columns.mdx
+++ b/components/columns.mdx
@@ -82,3 +82,7 @@ Use the `Column` component to wrap text or code in individual columns. This is u
 <ResponseField name="cols" type="number" default={2}>
   The number of columns per row. Accepts values from 1 to 4.
 </ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the columns container.
+</ResponseField>

--- a/components/expandables.mdx
+++ b/components/expandables.mdx
@@ -44,3 +44,7 @@ Use expandables to show and hide nested content within response fields. They are
 <ResponseField name="defaultOpen" type="boolean" default="false">
   Set to `true` for the expandable to open when the page loads
 </ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the expandable.
+</ResponseField>

--- a/components/fields.mdx
+++ b/components/fields.mdx
@@ -57,6 +57,10 @@ Define arrays using the `[]` suffix. For example `string[]`.
   Description of the parameter (Markdown-enabled).
 </ParamField>
 
+<ParamField body="className" type="string">
+  Additional CSS classes to apply to the field.
+</ParamField>
+
 ## Response field
 
 The `<ResponseField>` component defines the return values of an API.
@@ -99,4 +103,8 @@ The `<ResponseField>` component defines the return values of an API.
 
 <ResponseField name="post" type="string[]">
   Labels that appear after the name of the field.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the field.
 </ResponseField>

--- a/components/frames.mdx
+++ b/components/frames.mdx
@@ -61,6 +61,10 @@ Videos without `autoPlay` do not have any additional attributes added by default
   Text that precedes the frame.
 </ResponseField>
 
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the frame.
+</ResponseField>
+
 <CodeGroup>
 
 ```mdx Frame

--- a/components/icons.mdx
+++ b/components/icons.mdx
@@ -46,5 +46,5 @@ Icons appear inline when used within a sentence, paragraph, or heading. <Icon ic
 </ResponseField>
 
 <ResponseField name="className" type="string">
-  Custom CSS class name to apply to the icon.
+  Additional CSS classes to apply to the icon.
 </ResponseField>

--- a/components/index.mdx
+++ b/components/index.mdx
@@ -137,3 +137,15 @@ Mintlify provides built-in MDX components for your documentation pages. Use thes
 <Card title="GitHub" icon="github" href="/components/github">
   Embed a GitHub repository card with live stars and forks.
 </Card>
+
+## Style components
+
+All built-in components accept a `className` prop. Mintlify merges your classes with the component's own styles, so you can restyle a single instance without wrapping it in extra markup or writing a CSS override.
+
+```mdx className example
+<Note className="mt-0">This callout has no top margin.</Note>
+```
+
+Use [Tailwind CSS](/customize/custom-scripts#style-with-tailwind-css) classes, including [arbitrary values](/customize/custom-scripts#arbitrary-values-and-variants) such as `w-[350px]`, or class names that you define in a [custom CSS file](/customize/custom-scripts#add-custom-css).
+
+[Banner](/components/banner), [MDX](/components/mdx), and [Visibility](/components/visibility) do not accept `className`. You configure the banner in `docs.json`, and the other two render their children without a wrapper element.

--- a/components/mermaid-diagrams.mdx
+++ b/components/mermaid-diagrams.mdx
@@ -87,6 +87,10 @@ The controls are especially useful for large or complex diagrams that don't fit 
   Position of the interactive controls. Options: `top-left`, `top-right`, `bottom-left`, `bottom-right`.
 </ResponseField>
 
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the diagram container.
+</ResponseField>
+
 ### Examples
 
 Hide controls on a diagram:

--- a/components/panel.mdx
+++ b/components/panel.mdx
@@ -20,3 +20,9 @@ The components in a `<Panel>` replace a page's table of contents. Page modes tha
 <Panel>
   <Info>Pin info to the side panel. Or add any other component.</Info>
 </Panel>
+
+## Properties
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the panel container.
+</ResponseField>

--- a/components/prompt.mdx
+++ b/components/prompt.mdx
@@ -63,3 +63,7 @@ You are a **technical writing assistant**. Write documentation that is clear, ac
 </ResponseField>
 
 <IconsOptional />
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the prompt card.
+</ResponseField>

--- a/components/steps.mdx
+++ b/components/steps.mdx
@@ -45,10 +45,14 @@ Use steps to display a series of sequential actions or events. You can add as ma
   The size of the step titles. One of `p`, `h2`, `h3`, and `h4`.
 </ResponseField>
 
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the steps container.
+</ResponseField>
+
 ## Individual step properties
 
 <ResponseField name="title" type="string" required>
-  The title is the primary text for the step and shows up next to the indicator.
+  The title is the primary text for the step and shows up next to the indicator. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <ResponseField name="children" type="string | ReactNode">
@@ -71,4 +75,8 @@ Use steps to display a series of sequential actions or events. You can add as ma
 
 <ResponseField name="noAnchor" type="boolean" default="false">
   Whether to hide the anchor link for the step.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the step.
 </ResponseField>

--- a/components/tabs.mdx
+++ b/components/tabs.mdx
@@ -86,12 +86,16 @@ Set these properties on the `<Tabs>` wrapper component.
   Adds a bottom border and padding to the tabs container. Useful to visually separate tabbed content from the rest of the page, especially when tabs contain content of varying lengths.
 </ResponseField>
 
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the tabs container.
+</ResponseField>
+
 ## Tab properties
 
 Set these properties on each individual `<Tab>` component.
 
 <ResponseField name="title" type="string" required>
-  The title of the tab. Short titles are easier to navigate. Tabs with matching titles synchronize their selections.
+  The title of the tab. Short titles are easier to navigate. Tabs with matching titles synchronize their selections. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <ResponseField name="id" type="string">
@@ -104,4 +108,8 @@ Set these properties on each individual `<Tab>` component.
 
 <ResponseField name="iconType" type="string">
   For Font Awesome icons only: One of `regular`, `solid`, `light`, `thin`, `sharp-solid`, `duotone`, `brands`.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the tab's content panel. Classes apply to the panel that holds the tab's content, not to the tab's label in the tab bar.
 </ResponseField>

--- a/components/tiles.mdx
+++ b/components/tiles.mdx
@@ -72,7 +72,7 @@ Combine tiles with the [columns component](/components/columns) to create a resp
 </ResponseField>
 
 <ResponseField name="title" type="string">
-  The title displayed below the tile preview.
+  The title displayed below the tile preview. Supports inline Markdown formatting, such as `**bold**`, `_italic_`, and `` `code` ``.
 </ResponseField>
 
 <ResponseField name="description" type="string">
@@ -81,4 +81,8 @@ Combine tiles with the [columns component](/components/columns) to create a resp
 
 <ResponseField name="children" type="React.ReactNode" required>
   Content displayed inside the tile preview area, typically images or SVGs.
+</ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the tile.
 </ResponseField>

--- a/components/tooltips.mdx
+++ b/components/tooltips.mdx
@@ -30,3 +30,7 @@ Use tooltips to provide additional context or definitions when a user hovers ove
 <ResponseField name="href" type="string">
   URL for the call-to-action link. Required when using `cta`.
 </ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the tooltip trigger.
+</ResponseField>

--- a/components/tree.mdx
+++ b/components/tree.mdx
@@ -172,6 +172,12 @@ The tree component supports keyboard navigation.
 
 ## Properties
 
+### Tree
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the tree container.
+</ResponseField>
+
 ### Tree.Folder
 
 <ResponseField name="name" type="string" required>

--- a/components/view.mdx
+++ b/components/view.mdx
@@ -66,3 +66,7 @@ If you have different heading structures in each view, users only see the headin
 <ResponseField name="iconType" type="string">
   For Font Awesome icons only: One of `regular`, `solid`, `light`, `thin`, `sharp-solid`, `duotone`, `brands`.
 </ResponseField>
+
+<ResponseField name="className" type="string">
+  Additional CSS classes to apply to the view container.
+</ResponseField>

--- a/create/image-embeds.mdx
+++ b/create/image-embeds.mdx
@@ -39,25 +39,26 @@ Image files must be less than 20 MB. For larger files, host them on a CDN servic
 For more control over image display, use HTML `<img>` tags:
 
 ```jsx
-<img 
-  src="/images/dashboard.png" 
+<img
+  src="/images/dashboard.png"
   alt="Main dashboard interface"
-  style={{height: "300px", width: "400px"}}
-  className="rounded-lg"
+  className="w-[400px] h-[300px] rounded-lg"
 />
 ```
 
-#### Resize images with inline styles
+#### Resize images
 
-Use JSX inline styles with the `style` attribute to resize images:
+Use [Tailwind CSS](/customize/custom-scripts#style-with-tailwind-css) classes to resize images. When no utility class covers the size that you need, use an arbitrary value such as `w-[450px]`:
 
 ```jsx
 <img
   src="/images/architecture.png"
-  style={{width: "450px", height: "auto"}}
   alt="Diagram showing the architecture of the system"
+  className="w-[450px] h-auto"
 />
 ```
+
+Avoid the `style` prop for sizing. It can cause a layout shift on page load.
 
 #### Disable image zoom
 

--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -8,7 +8,7 @@ Use CSS to style HTML elements or add custom CSS and JavaScript to fully customi
 
 ## Style with Tailwind CSS
 
-Use Tailwind CSS v3 to style HTML elements. You can control layout, spacing, colors, and other visual properties. Some common classes are:
+Use Tailwind CSS v3 to style HTML elements and components. You can control layout, spacing, colors, and other visual properties. Some common classes are:
 
 - `w-full` - Full width
 - `aspect-video` - 16:9 aspect ratio
@@ -16,14 +16,54 @@ Use Tailwind CSS v3 to style HTML elements. You can control layout, spacing, col
 - `block`, `hidden` - Display control
 - `dark:hidden`, `dark:block` - Dark mode visibility
 
-Tailwind CSS arbitrary values are not supported. For custom values, use the `style` prop instead.
+### Style components with className
 
-```html
-<img style={{ width: '350px', margin: '12px auto' }} src="/path/image.jpg" />
+All built-in components accept a `className` prop. Mintlify merges your classes with the component's own styles, so you can restyle a single instance without wrapping it in extra markup or writing a CSS override.
+
+```mdx className example
+<Note className="mt-0">This callout has no top margin.</Note>
+
+<Card title="Quickstart" href="/quickstart" className="border-2 border-blue-500">
+  Deploy your first documentation site.
+</Card>
 ```
 
+Three components do not accept `className`: [Banner](/components/banner), which you configure in `docs.json`, and [MDX](/components/mdx) and [Visibility](/components/visibility), which render their children without a wrapper element.
+
+<Tip>
+  On [Tabs](/components/tabs), a `Tab` component's `className` applies to the tab's content panel, not to its label in the tab bar.
+</Tip>
+
+### Arbitrary values and variants
+
+Use arbitrary values when no utility class covers the value that you need:
+
+```mdx Arbitrary value examples
+<img src="/images/diagram.png" alt="System architecture diagram" className="w-[450px]" />
+
+<Frame className="lg:w-[calc(100%-2rem)] bg-[#0f172a]">
+  <img src="/images/hero.png" alt="Product hero image" />
+</Frame>
+```
+
+Variants work as they do in any Tailwind project, including responsive prefixes (`sm:`, `md:`, `lg:`), state variants (`hover:`, `focus:`), `dark:`, data attribute variants (`data-[state=open]:`), opacity modifiers (`bg-black/50`), and the `!` important modifier.
+
+Mintlify generates CSS for the Tailwind classes that it finds in your page source, so write class names out in full:
+
+```mdx Write class names in full
+{/* Generates CSS: the full class name appears in the page source. */}
+<div className="bg-blue-500" />
+
+{/* Generates no CSS: the class name is assembled at runtime. */}
+<div className={`bg-${color}-500`} />
+```
+
+<Note>
+  The web editor's live preview does not generate CSS for page-specific Tailwind classes, so a styled page can look unstyled while you edit it. See [Tailwind classes not applying in the editor's live preview](/help-center/tailwind-classes-not-applying-in-editor-preview).
+</Note>
+
 <Warning>
-  Using the `style` prop can cause a layout shift on page load, especially on custom mode pages. Use Tailwind CSS classes or custom CSS files instead to avoid shifts or flickering.
+  Avoid the `style` prop. It can cause a layout shift on page load, especially on custom mode pages. Use Tailwind CSS classes or custom CSS files instead.
 </Warning>
 
 ## Add custom CSS

--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -16,9 +16,9 @@ Use Tailwind CSS v3 to style HTML elements and components. You can control layou
 - `block`, `hidden` - Display control
 - `dark:hidden`, `dark:block` - Dark mode visibility
 
-### Style components with className
+### Style components with `className`
 
-All built-in components accept a `className` prop. Mintlify merges your classes with the component's own styles, so you can restyle a single instance without wrapping it in extra markup or writing a CSS override.
+Components accept a `className` prop. Mintlify merges your classes with the component's own styles, so you can restyle a single instance without wrapping it in extra markup or writing a CSS override.
 
 ```mdx className example
 <Note className="mt-0">This callout has no top margin.</Note>

--- a/customize/custom-scripts.mdx
+++ b/customize/custom-scripts.mdx
@@ -28,15 +28,11 @@ Components accept a `className` prop. Mintlify merges your classes with the comp
 </Card>
 ```
 
-Three components do not accept `className`: [Banner](/components/banner), which you configure in `docs.json`, and [MDX](/components/mdx) and [Visibility](/components/visibility), which render their children without a wrapper element.
-
-<Tip>
-  On [Tabs](/components/tabs), a `Tab` component's `className` applies to the tab's content panel, not to its label in the tab bar.
-</Tip>
+Three components do not accept `className`: [Banner](/components/banner), [MDX](/components/mdx), and [Visibility](/components/visibility).
 
 ### Arbitrary values and variants
 
-Use arbitrary values when no utility class covers the value that you need:
+Use arbitrary values when no utility class covers the value that you need.
 
 ```mdx Arbitrary value examples
 <img src="/images/diagram.png" alt="System architecture diagram" className="w-[450px]" />
@@ -48,7 +44,7 @@ Use arbitrary values when no utility class covers the value that you need:
 
 Variants work as they do in any Tailwind project, including responsive prefixes (`sm:`, `md:`, `lg:`), state variants (`hover:`, `focus:`), `dark:`, data attribute variants (`data-[state=open]:`), opacity modifiers (`bg-black/50`), and the `!` important modifier.
 
-Mintlify generates CSS for the Tailwind classes that it finds in your page source, so write class names out in full:
+Mintlify generates CSS for the Tailwind classes that it finds in your page source, so write class names out in full.
 
 ```mdx Write class names in full
 {/* Generates CSS: the full class name appears in the page source. */}

--- a/docs.json
+++ b/docs.json
@@ -483,6 +483,7 @@
                   "help-center/branch-missing-from-editor-branch-list",
                   "help-center/style-card-icons-with-custom-css",
                   "help-center/can-i-rename-my-deployment-or-organization",
+                  "help-center/tailwind-classes-not-applying-in-editor-preview",
                   "help-center/agent-blocked-by-git-provider-ip-allow-list"
                 ]
               }

--- a/guides/custom-layouts.mdx
+++ b/guides/custom-layouts.mdx
@@ -23,6 +23,8 @@ Set the `mode` field in your page's frontmatter to control which UI elements app
 
 For landing pages, `custom` mode gives you the most control. It removes all UI elements except the top navbar, giving you a blank canvas to build on.
 
+Custom mode pages have no default typography. Native HTML elements such as `<h2>` and `<p>` render with browser default styles, so style them explicitly with Tailwind CSS classes.
+
 ```yaml Example page frontmatter
 ---
 title: "Welcome"
@@ -139,13 +141,15 @@ export const FeatureCard = ({ title, description, href }) => (
   Avoid using the `style` prop on HTML elements. It can cause a layout shift on page load. Use Tailwind CSS classes or a [custom CSS file](/customize/custom-scripts) instead.
 </Warning>
 
+<Note>
+  The web editor's live preview does not generate CSS for page-specific Tailwind classes, so custom layouts can look unstyled while you edit them. Check your styling with `mint dev`, a preview deployment, or a production deployment. See [Tailwind classes not applying in the editor's live preview](/help-center/tailwind-classes-not-applying-in-editor-preview).
+</Note>
+
 ## Add custom CSS
 
 For styles that Tailwind doesn't cover, add a CSS file to your repository. Mintlify applies CSS files site-wide, making their class names available in all MDX files.
 
-<Note>
-  Mintlify does not support Tailwind CSS arbitrary values (for example, `w-[350px]`). Use a custom CSS file for values that Tailwind's utility classes don't cover.
-</Note>
+Reach for a custom CSS file when you need keyframe animations, complex selectors, or styles that apply across many pages. For one-off values, use a Tailwind [arbitrary value](/customize/custom-scripts#arbitrary-values-and-variants) such as `w-[350px]` instead.
 
 ```css Example custom CSS file
 .landing-hero {
@@ -232,3 +236,4 @@ export const HeroCard = ({ title, description, href, icon }) => (
 - **Keep it responsive.** Use Tailwind's responsive prefixes (`sm:`, `md:`, `lg:`) so your layout works on all screen sizes.
 - **Combine modes.** Use `custom` mode for your docs home page and `default` mode for everything else. You set the mode per page, so different pages can use different layouts.
 - **Check for layout shifts.** If elements jump on page load, replace inline `style` props with Tailwind classes or custom CSS.
+- **Style components directly.** Components accept a `className` prop, so you can adjust one instance without a wrapper element or a CSS override. See [Style components with className](/customize/custom-scripts#style-components-with-classname).

--- a/guides/custom-layouts.mdx
+++ b/guides/custom-layouts.mdx
@@ -149,7 +149,7 @@ export const FeatureCard = ({ title, description, href }) => (
 
 For styles that Tailwind doesn't cover, add a CSS file to your repository. Mintlify applies CSS files site-wide, making their class names available in all MDX files.
 
-Reach for a custom CSS file when you need keyframe animations, complex selectors, or styles that apply across many pages. For one-off values, use a Tailwind [arbitrary value](/customize/custom-scripts#arbitrary-values-and-variants) such as `w-[350px]` instead.
+Use a custom CSS file when you need keyframe animations, complex selectors, or styles that apply across many pages. For one-off values, use a Tailwind [arbitrary value](/customize/custom-scripts#arbitrary-values-and-variants) such as `w-[350px]` instead.
 
 ```css Example custom CSS file
 .landing-hero {

--- a/help-center/tailwind-classes-not-applying-in-editor-preview.mdx
+++ b/help-center/tailwind-classes-not-applying-in-editor-preview.mdx
@@ -1,0 +1,35 @@
+---
+title: "Tailwind classes not applying in the editor's live preview"
+description: "Diagnose why a page styled with Tailwind CSS classes, such as a custom mode landing page, looks unstyled in the web editor's live preview but renders correctly on deployments and with mint dev."
+keywords: ["tailwind not working", "tailwind classes not applying", "custom page looks broken", "editor preview unstyled", "live preview missing styles", "custom mode no styles"]
+---
+
+If a page styled with Tailwind CSS classes, such as a [custom mode](/organize/pages#custom) landing page, looks unstyled in the web editor's [live preview](/editor/review#live-preview), your markup is probably correct. The live preview renders your content without a build step, and it does not generate the CSS for page-specific Tailwind classes.
+
+## Why the live preview looks unstyled
+
+Mintlify scans each page for Tailwind classes and generates the matching CSS during a site build. Builds run for production deployments, [preview deployments](/deploy/preview-deployments), and local previews with [`mint dev`](/cli/commands#mint-dev). The live preview skips the build step so that it can render instantly, so the CSS for your Tailwind classes is never generated there.
+
+If you inspect an element in the live preview, the Tailwind classes appear in the HTML with a `mint-` prefix, but no CSS rules match them.
+
+## See your styles rendered accurately
+
+To check how a Tailwind-styled page renders, use a preview that includes a build:
+
+- Run [`mint dev`](/cli/commands#mint-dev) in your local repository.
+- Save your changes to a branch and open a pull request. Mintlify builds a [preview deployment](/deploy/preview-deployments) with a shareable URL.
+- Publish your changes and check your live site.
+
+If the page still looks wrong in one of these previews, the problem is in the page itself. See [Build custom page layouts](/guides/custom-layouts) for working patterns.
+
+## Custom mode pages have no default typography
+
+Separately from the live preview behavior, custom mode is a blank canvas. Mintlify does not apply its default typography to custom mode pages, so native HTML elements such as `<h2>` and `<p>` render with browser default styles on every preview and deployment. Style them explicitly:
+
+```mdx Example styled heading
+<h2 className="text-2xl font-semibold text-gray-900 dark:text-zinc-50">
+  Features
+</h2>
+```
+
+This is expected behavior, not a rendering bug. See [Build custom page layouts](/guides/custom-layouts) for complete examples.

--- a/skill.md
+++ b/skill.md
@@ -147,10 +147,11 @@ The `navigation` property in `docs.json` controls site structure. Choose one pri
 
 **What to customize where:**
 - **Brand colors, fonts, logo** → `docs.json`. See [global settings](https://mintlify.com/docs/settings/global)
-- **Component styling, layout tweaks** → `custom.css` at project root
+- **One-off component or layout tweaks** → `className` with Tailwind CSS classes on the component. See [style components](https://mintlify.com/docs/customize/custom-scripts#style-components-with-classname)
+- **Site-wide styling** → `custom.css` at project root
 - **Dark mode** → Enabled by default. Only disable with `"appearance": "light"` in `docs.json` if brand requires it
 
-Start with `docs.json`. Only add `custom.css` when you need styling that config doesn't support.
+Start with `docs.json`. Use `className` for individual elements, and add `custom.css` only for site-wide styling that config and utility classes don't cover.
 
 ## Write content
 


### PR DESCRIPTION
## Summary

`className` now works on all built-in components ([mint#10540](https://github.com/mintlify/mint/pull/10540)) and dynamic Tailwind utilities work inside it ([mint#6737](https://github.com/mintlify/mint/pull/6737)). Two of our pages stated the opposite: both told users that Tailwind arbitrary values are unsupported and to use the `style` prop instead.

Resolves DOC-316 and DOC-317. DOC-317 was blocked by ENG-7289, which shipped as mint#10540.

## Changes

**Corrections**
- `customize/custom-scripts` and `guides/custom-layouts` no longer claim arbitrary values are unsupported.
- `create/image-embeds` teaches Tailwind classes for resizing instead of inline `style`.
- `components/callouts` said typed callouts accept only `children`.

**New guidance**
- A `className` and arbitrary value section in `custom-scripts`, covering variants, the runtime-class limitation, and the `Tab` content-panel caveat.
- A "Style components" section on the components overview.
- `className` property rows on every component reference page that supports it, plus the three components that don't: `Banner`, `MDX`, `Visibility`.
- Inline Markdown support in component `title` props.
- A help center article for Tailwind classes not applying in the editor's live preview, carried over from #7257.

## Verification

Every behavioral claim was checked against a real `mint dev` build rather than taken from PR descriptions, since [#4938](https://github.com/mintlify/docs/pull/4938) had to be [reverted](https://github.com/mintlify/docs/pull/4957) for documenting `className` support that didn't exist yet.

A test page with `<Note className="w-[453px] lg:w-[calc(100%-2rem)] bg-[#0f172a] !mt-0 data-[state=open]:bg-black/50">` produced:

```css
.\!mint-mt-0 { margin-top: 0px !important }
.mint-w-\[453px\] { width: 453px }
.mint-bg-\[\#0f172a\] { --tw-bg-opacity: 1; background-color: rgb(15 23 42 / var(--tw-bg-opacity, 1)) }
.data-\[state\=open\]\:mint-bg-black\/50[data-state="open"] { background-color: rgb(0 0 0 / 0.5) }
```

Component coverage was confirmed by reading each component's source in `mintlify/mint`, not from the PR description. The live preview limitation was confirmed too: `getDynamicTailwindCss` is only called from the client's static-props paths, never from the dashboard live-preview compile route.

`mint broken-links`, `mint a11y`, and `vale` are clean. All changed pages return 200 in `mint dev`.

## Supersedes

- #7165 — same goal, but it left the contradictory arbitrary-values sentence in place, and its branch still carries a stray `<Accordion title="robert">` test block in `quickstart.mdx` plus unrelated `ai-native.mdx` edits.
- #7180 — closed Aug 31. Its prop-table rows, callouts fix, and `title` Markdown finding are included here.
- #7257 — its English content is included here. Close it if this merges, or tell me and I'll rebase it instead.

## Areas for review

- **Translations.** English only, per our convention that translations run automatically after merge. Both bot PRs hand-edited es/fr/zh; I did not.
- **`RequestExample` / `ResponseExample`.** I left `components/examples` alone. Those get extracted at compile time into the panel and I couldn't confirm `className` reaches the rendered element.
- **Snippets.** Tailwind selectors are generated from the page's own source (`getMdx.ts`), so a class that appears only inside a snippet file may never get the `mint-` prefix. I did not document this because I haven't tested it, but it's worth confirming with Brandon — it may be a bug rather than intended behavior.
- **Vale.** Added `className`, `keyframes?`, and `unstyled` to the vocabulary and `className` to the `Headings` exceptions, rather than reword correct prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or product code; risk is limited to possible inaccuracies in behavioral claims.
> 
> **Overview**
> Updates Mintlify docs to match shipped **`className`** on built-in components and **Tailwind arbitrary values**, replacing guidance that told authors to use inline `style` or claimed arbitrary utilities were unsupported.
> 
> **`customize/custom-scripts`** and **`guides/custom-layouts`** now cover styling components via `className`, arbitrary values and variants, writing class names literally (not assembled at runtime), and avoiding the `style` prop. **`create/image-embeds`** resizes images with Tailwind instead of JSX `style`. Component reference pages add **`className`** where supported, note **inline Markdown on `title`** props, and call out exceptions (**Banner**, **MDX**, **Visibility**). **`components/index`** adds a **Style components** section.
> 
> A new **help center** article explains why Tailwind can look unstyled in the **web editor live preview** (no per-page CSS generation without a build); **`docs.json`** links it. **`skill.md`** and Vale vocab/heading exceptions are updated for the new terminology.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167885af917f48a91aa205650a89835116efa657. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->